### PR TITLE
feat: add individual standings pages (fell + road-gp)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ npm run preview  # serve built output
 npm test         # run unit tests
 ```
 
+> **Note:** TypeScript errors in Astro pages only surface via `npm run build` — `npm test` only runs pure-function unit tests and will not catch type errors in `.astro` files.
+
 ## Project Structure
 
 ```
@@ -43,7 +45,8 @@ src/
       clubs.json             # competing clubs for that year (id, name, shortName, logo)
       road-gp/
         races.json           # Road GP schedule
-        config.json          # series config (age categories + teamCategories)
+        config.json          # series config (ageCategories, teamCategories, and optionally individualCategories + maxCountingRaces)
+        individual-standings.json  # season individual standings (optional; computed externally)
         results/
           {race-id}.csv                      # final individual results
           {race-id}-provisional.csv          # provisional individual results
@@ -52,12 +55,13 @@ src/
                                              # (build prefers final over provisional if both exist)
       fell/
         races.json           # Fell Championship schedule
-        config.json          # series config (age categories + teamCategories)
+        config.json          # series config (ageCategories, teamCategories, and optionally individualCategories + maxCountingRaces)
         results/
           {race-id}.csv
           {race-id}-provisional.csv
           {race-id}-teams.json
           {race-id}-teams-provisional.json
+        individual-standings.json  # season individual standings (optional; computed externally)
   lib/
     types.ts                 # domain types (Race, Series, SiteConfig, RaceResult, Club,
                              #   SeriesConfig, TeamCategory, TeamResults, TeamClubResult, etc.)
@@ -75,7 +79,8 @@ src/
     road-gp/                 # Road GP schedule + detail pages
       [year]/
         index.astro          # schedule for that year
-        team-standings.astro # season team standings (only generated when team-standings.json exists)
+        team-standings.astro        # season team standings (only generated when team-standings.json exists)
+        individual-standings.astro  # season individual standings (only generated when individual-standings.json exists)
         [raceId]/
           results.astro      # individual results page
           team-results.astro # team results page (only generated when team JSON exists)
@@ -83,6 +88,7 @@ src/
       [year]/
         index.astro
         team-standings.astro
+        individual-standings.astro
         [raceId]/
           results.astro
           team-results.astro
@@ -183,3 +189,60 @@ Season standings are computed externally and placed at `src/data/{year}/{series}
 - `clubs[].points` — one entry per race; `null` for races not yet run (renders as `—`)
 - `clubs[].tiebreaker` — nullable string shown beneath the total when non-null
 - `races[].shortName` in `races.json` provides the column header abbreviation (e.g. `"BPL"`); falls back to the race id if absent
+
+### Individual standings JSON schema
+
+Season individual standings are computed externally and placed at `src/data/{year}/{series}/individual-standings.json`. File absence means no individual standings page is generated for that year.
+
+```json
+{
+  "provisional": true,
+  "races": ["fell-race-1", "fell-race-2"],
+  "categories": [
+    {
+      "category": "sen-m",
+      "runners": [
+        {
+          "position": 1,
+          "name": "Luke Minns",
+          "club": "blackpool",
+          "sex": "M",
+          "ageCategory": "SEN",
+          "total": 47,
+          "results": {
+            "fell-race-1": { "points": 25, "counting": true },
+            "fell-race-3": { "points": 22, "counting": false }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+- `category` — id matching `individualCategories[].id` in the series `config.json`
+- `runners[].results` — sparse map keyed by race id; only races the runner actually entered are present (no nulls)
+- `results[raceId].counting` — `false` when this race didn't count toward the runner's total (shown dimmed with strikethrough on the page)
+- `runners[].total` — pre-computed and stored explicitly
+- `runners[].sex` / `runners[].ageCategory` — stored separately for client-side filtering; displayed combined as e.g. `MSEN`, `FV40`
+
+### Series config.json schema
+
+```json
+{
+  "ageCategories": ["SEN", "V40", "V50"],
+  "maxCountingRaces": 3,
+  "individualCategories": [
+    { "id": "sen-m", "name": "Senior Men" },
+    { "id": "v40-f", "name": "V40 Women" }
+  ],
+  "teamCategories": [
+    { "id": "open", "name": "Open", "scorerCount": 6 }
+  ]
+}
+```
+
+- `ageCategories` — age bands shown in the results filter bar (note: formerly named `categories` — do not use the old name)
+- `maxCountingRaces` — optional; when set, individual standings page shows "Best N races count" and marks non-counting results
+- `individualCategories` — optional; defines which tabs appear on the individual standings page and in what order; `id` is referenced by `individual-standings.json`
+- `teamCategories` — defines team scoring groups; `id` is referenced by team results JSON files

--- a/docs/superpowers/plans/2026-04-28-individual-standings.md
+++ b/docs/superpowers/plans/2026-04-28-individual-standings.md
@@ -1,0 +1,1395 @@
+# Individual Standings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add individual standings pages (fell + road-gp) showing per-runner race scores, with non-counting results visually marked, category tabs, and mobile-friendly filtering.
+
+**Architecture:** Pre-computed `individual-standings.json` files are loaded at build time via `import.meta.glob` and rendered into static pages — identical pattern to existing `team-standings.json`. Pages are only generated when the JSON file is present. Filtering (by sex and age category) is client-side JS operating on data attributes already rendered into the HTML.
+
+**Tech Stack:** Astro v6, TypeScript (strict), Tailwind CSS v4, DaisyUI v5, Vitest
+
+---
+
+## File Map
+
+| Action | File | Change |
+|--------|------|--------|
+| Modify | `src/lib/types.ts` | Rename `categories→ageCategories` in `SeriesConfig`; add 5 new interfaces |
+| Modify | `src/data/2026/fell/config.json` | Rename key `categories → ageCategories` |
+| Modify | `src/data/2026/road-gp/config.json` | Rename key `categories → ageCategories` |
+| Modify | `src/lib/results.ts` | Fix fallback, add glob imports, add 4 new exports |
+| Modify | `tests/lib/results.test.ts` | Add `parseIndividualStandingsPath` test suite |
+| Modify | `src/pages/fell/[year]/[raceId]/results.astro` | `config.categories` → `config.ageCategories` |
+| Modify | `src/pages/road-gp/[year]/[raceId]/results.astro` | `config.categories` → `config.ageCategories` |
+| Modify | `src/components/RaceList.astro` | Add `individualStandingsUrl?` prop |
+| Modify | `src/pages/fell/[year]/index.astro` | Pass `individualStandingsUrl` to `RaceList` |
+| Modify | `src/pages/road-gp/[year]/index.astro` | Pass `individualStandingsUrl` to `RaceList` |
+| Create | `src/pages/fell/[year]/individual-standings.astro` | New page |
+| Create | `src/pages/road-gp/[year]/individual-standings.astro` | New page |
+
+---
+
+## Task 1: Update `types.ts`
+
+**Files:**
+- Modify: `src/lib/types.ts`
+
+- [ ] **Step 1: Replace the full contents of `src/lib/types.ts`**
+
+```typescript
+export type Series = 'road-gp' | 'fell';
+
+export interface SiteConfig {
+  currentYear: number;
+}
+
+export interface Race {
+  id: string;
+  name: string;
+  date: string;       // ISO date string: "2026-06-07"
+  time?: string;      // "HH:MM", e.g. "10:30"
+  location?: string;
+  distance?: string;
+  detailsUrl?: string;
+  image?: string;     // filename relative to /public/images/
+  shortName?: string;
+}
+
+export interface RaceResult {
+  position: number | null;
+  icPosition: number | null;
+  firstName: string;
+  lastName: string;
+  club: string;        // club id (e.g. 'blackpool') or 'Guest'
+  category: string;   // e.g. 'SEN', 'V35', 'U17'
+  sex: string;        // 'M' or 'F'
+  time: string;       // 'MM:SS', may be empty
+}
+
+export interface Club {
+  id: string;
+  name: string;
+  shortName: string;
+  logo: string;        // filename in /public/images/clubs/, may not exist yet
+}
+
+export interface IndividualCategory {
+  id: string;
+  name: string;
+}
+
+export interface SeriesConfig {
+  ageCategories: string[];           // renamed from categories
+  maxCountingRaces?: number;         // optional; when set, the page shows "Best N races count"
+  individualCategories?: IndividualCategory[];
+  teamCategories?: TeamCategory[];
+}
+
+export interface TeamCategory {
+  id: string;
+  name: string;
+  scorerCount: number;
+}
+
+export interface TeamScorer {
+  name: string;
+  position: number;   // rank within the sex/age group used for team scoring
+}
+
+export interface TeamClubResult {
+  position: number;   // finishing position in this team category
+  points: number;     // season points earned (stored explicitly)
+  club: string;       // id → Club lookup via clubs.json
+  total: number;      // sum of scorer positions
+  scorers: TeamScorer[];
+}
+
+export interface TeamCategoryResult {
+  category: string;   // id → TeamCategory lookup via config.teamCategories
+  clubs: TeamClubResult[];
+}
+
+export interface TeamResults {
+  categories: TeamCategoryResult[];
+}
+
+export interface TeamStandingsClub {
+  position: number;
+  club: string;
+  points: (number | null)[];
+  total: number;
+  tiebreaker: string | null;
+}
+
+export interface TeamStandingsCategory {
+  category: string;
+  clubs: TeamStandingsClub[];
+}
+
+export interface TeamStandings {
+  provisional: boolean;
+  races: string[];
+  categories: TeamStandingsCategory[];
+}
+
+export interface IndividualRaceResult {
+  points: number;
+  counting: boolean;
+}
+
+export interface IndividualStandingsRunner {
+  position: number;
+  name: string;
+  club: string;
+  sex: string;          // 'M' or 'F'
+  ageCategory: string;  // e.g. 'SEN', 'V40'
+  total: number;
+  results: Record<string, IndividualRaceResult>;  // keyed by race id; only races the runner entered
+}
+
+export interface IndividualStandingsCategory {
+  category: string;   // id → IndividualCategory lookup via config.individualCategories
+  runners: IndividualStandingsRunner[];
+}
+
+export interface IndividualStandings {
+  provisional: boolean;
+  races: string[];    // ordered list of race ids; defines column order
+  categories: IndividualStandingsCategory[];
+}
+```
+
+- [ ] **Step 2: Run tests to confirm nothing broken yet**
+
+```bash
+npm test
+```
+
+Expected: all tests pass (no code has changed that tests exercise yet).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/types.ts
+git commit -m "refactor: rename SeriesConfig.categories to ageCategories; add individual standings types"
+```
+
+---
+
+## Task 2: Update config JSON files
+
+**Files:**
+- Modify: `src/data/2026/fell/config.json`
+- Modify: `src/data/2026/road-gp/config.json`
+
+- [ ] **Step 1: Update `src/data/2026/fell/config.json`**
+
+```json
+{
+  "ageCategories": ["SEN", "V40", "V50", "V60", "V70"],
+  "teamCategories": [
+    { "id": "open",   "name": "Open",   "scorerCount": 6 },
+    { "id": "ladies", "name": "Ladies", "scorerCount": 3 },
+    { "id": "vets",   "name": "Vets",   "scorerCount": 4 }
+  ]
+}
+```
+
+- [ ] **Step 2: Update `src/data/2026/road-gp/config.json`**
+
+```json
+{
+  "ageCategories": ["U17", "U20", "U23", "SEN", "V35", "V40", "V45", "V50", "V55", "V60", "V65", "V70", "V75", "V80"],
+  "teamCategories": [
+    { "id": "open",   "name": "Open",    "scorerCount": 10 },
+    { "id": "ladies", "name": "Ladies",  "scorerCount": 5  },
+    { "id": "fv40",   "name": "FV40",    "scorerCount": 5  },
+    { "id": "vets",   "name": "Vets",    "scorerCount": 6  },
+    { "id": "vet50s", "name": "Vet 50s", "scorerCount": 4  },
+    { "id": "vet60s", "name": "Vet 60s", "scorerCount": 3  }
+  ]
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/data/2026/fell/config.json src/data/2026/road-gp/config.json
+git commit -m "chore: rename categories key to ageCategories in series configs"
+```
+
+---
+
+## Task 3: Fix `results.ts` — fallback + individual standings helpers
+
+**Files:**
+- Modify: `src/lib/results.ts`
+
+- [ ] **Step 1: Update the import line at the top of `src/lib/results.ts`**
+
+Replace:
+```typescript
+import type { Club, RaceResult, Series, SeriesConfig, TeamResults, TeamStandings } from './types';
+```
+With:
+```typescript
+import type { Club, IndividualStandings, RaceResult, Series, SeriesConfig, TeamResults, TeamStandings } from './types';
+```
+
+- [ ] **Step 2: Add individual standings glob imports**
+
+After line 57 (after the `fellStandingsFiles` declaration), add:
+
+```typescript
+const roadIndividualStandingsFiles = import.meta.glob<{ default: IndividualStandings }>(
+  '../data/*/road-gp/individual-standings.json', { eager: true }
+);
+const fellIndividualStandingsFiles = import.meta.glob<{ default: IndividualStandings }>(
+  '../data/*/fell/individual-standings.json', { eager: true }
+);
+
+function individualStandingsFilesForSeries(series: Series) {
+  return series === 'road-gp' ? roadIndividualStandingsFiles : fellIndividualStandingsFiles;
+}
+```
+
+- [ ] **Step 3: Fix the `getSeriesConfig` fallback on the last line of the file**
+
+Replace:
+```typescript
+  return files[`../data/${year}/${series}/config.json`]?.default ?? { categories: [] };
+```
+With:
+```typescript
+  return files[`../data/${year}/${series}/config.json`]?.default ?? { ageCategories: [] };
+```
+
+- [ ] **Step 4: Add the four new exports at the end of `src/lib/results.ts`**
+
+```typescript
+export function parseIndividualStandingsPath(path: string): { year: number } | null {
+  const match = path.match(/\/data\/(\d+)\/[^/]+\/individual-standings\.json$/);
+  if (!match) return null;
+  return { year: parseInt(match[1], 10) };
+}
+
+export function hasIndividualStandings(year: number, series: Series): boolean {
+  const files = individualStandingsFilesForSeries(series);
+  return `../data/${year}/${series}/individual-standings.json` in files;
+}
+
+export function getIndividualStandingsStaticPaths(series: Series) {
+  const files = individualStandingsFilesForSeries(series);
+  return Object.keys(files).flatMap(path => {
+    const parsed = parseIndividualStandingsPath(path);
+    if (!parsed) return [];
+    const { year } = parsed;
+    const standings = files[path].default;
+    const clubs = getClubs(year);
+    const config = getSeriesConfig(year, series);
+    const linkedRaceIds = standings.races.filter(raceId =>
+      hasResults(year, series, raceId)
+    );
+    return [{
+      params: { year: String(year) },
+      props: { year, standings, clubs, config, linkedRaceIds },
+    }];
+  });
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+npm test
+```
+
+Expected: all existing tests pass (the fallback change and new functions don't break anything).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/results.ts
+git commit -m "feat: add individual standings helpers to results.ts"
+```
+
+---
+
+## Task 4: Add tests for `parseIndividualStandingsPath`
+
+**Files:**
+- Modify: `tests/lib/results.test.ts`
+
+- [ ] **Step 1: Add the test suite**
+
+Append to the end of `tests/lib/results.test.ts`:
+
+```typescript
+describe('parseIndividualStandingsPath', () => {
+  it('parses a road-gp individual standings path', () => {
+    expect(parseIndividualStandingsPath('../data/2026/road-gp/individual-standings.json'))
+      .toEqual({ year: 2026 });
+  });
+
+  it('parses a fell individual standings path', () => {
+    expect(parseIndividualStandingsPath('../data/2026/fell/individual-standings.json'))
+      .toEqual({ year: 2026 });
+  });
+
+  it('returns null for a team-standings path', () => {
+    expect(parseIndividualStandingsPath('../data/2026/fell/team-standings.json'))
+      .toBeNull();
+  });
+
+  it('returns null for a config path', () => {
+    expect(parseIndividualStandingsPath('../data/2026/fell/config.json'))
+      .toBeNull();
+  });
+
+  it('returns null for an individual results path', () => {
+    expect(parseIndividualStandingsPath('../data/2026/fell/results/race-1.csv'))
+      .toBeNull();
+  });
+});
+```
+
+Also update the import line at the top of `tests/lib/results.test.ts`:
+
+Replace:
+```typescript
+import { describe, it, expect } from 'vitest';
+import { parseResultsCsv, parseTeamResultsPath, parseTeamStandingsPath } from '../../src/lib/results';
+```
+With:
+```typescript
+import { describe, it, expect } from 'vitest';
+import { parseResultsCsv, parseTeamResultsPath, parseTeamStandingsPath, parseIndividualStandingsPath } from '../../src/lib/results';
+```
+
+- [ ] **Step 2: Run tests to verify they fail before the function existed (they should pass now since Task 3 already added the function)**
+
+```bash
+npm test
+```
+
+Expected: all tests pass, including the 5 new `parseIndividualStandingsPath` cases.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/lib/results.test.ts
+git commit -m "test: add parseIndividualStandingsPath tests"
+```
+
+---
+
+## Task 5: Fix `config.categories` references in results pages
+
+**Files:**
+- Modify: `src/pages/fell/[year]/[raceId]/results.astro` (line 57)
+- Modify: `src/pages/road-gp/[year]/[raceId]/results.astro` (line 57)
+
+- [ ] **Step 1: Update `src/pages/fell/[year]/[raceId]/results.astro`**
+
+Replace (line 57):
+```astro
+      {config.categories.map(cat => <option value={cat}>{cat}</option>)}
+```
+With:
+```astro
+      {(config.ageCategories ?? []).map(cat => <option value={cat}>{cat}</option>)}
+```
+
+- [ ] **Step 2: Update `src/pages/road-gp/[year]/[raceId]/results.astro`**
+
+Replace (line 57):
+```astro
+      {config.categories.map(cat => <option value={cat}>{cat}</option>)}
+```
+With:
+```astro
+      {(config.ageCategories ?? []).map(cat => <option value={cat}>{cat}</option>)}
+```
+
+- [ ] **Step 3: Run build to confirm no TypeScript errors**
+
+```bash
+npm run build
+```
+
+Expected: build completes with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/fell/[year]/[raceId]/results.astro src/pages/road-gp/[year]/[raceId]/results.astro
+git commit -m "fix: update results pages to use config.ageCategories"
+```
+
+---
+
+## Task 6: Update `RaceList` component and year index pages
+
+**Files:**
+- Modify: `src/components/RaceList.astro`
+- Modify: `src/pages/fell/[year]/index.astro`
+- Modify: `src/pages/road-gp/[year]/index.astro`
+
+- [ ] **Step 1: Replace the full contents of `src/components/RaceList.astro`**
+
+```astro
+---
+// src/components/RaceList.astro
+import type { Race, Series } from '../lib/types';
+import RaceCard from './RaceCard.astro';
+import YearFilter from './YearFilter.astro';
+
+interface Props {
+  races: Race[];
+  year: number;
+  series: Series;
+  availableYears: number[];
+  currentYear: number;
+  seriesBasePath: string;
+  seriesLabel: string;
+  standingsUrl?: string;
+  individualStandingsUrl?: string;
+}
+
+const { races, year, series, availableYears, currentYear, seriesBasePath, seriesLabel, standingsUrl, individualStandingsUrl } = Astro.props;
+---
+
+<div>
+  <div class="flex items-center justify-between mb-6 flex-wrap gap-3">
+    <h1 class="text-2xl font-bold">{seriesLabel} — {year}</h1>
+    {availableYears.length > 1 && (
+      <YearFilter
+        years={availableYears}
+        activeYear={year}
+        seriesBasePath={seriesBasePath}
+        currentYear={currentYear}
+      />
+    )}
+  </div>
+
+  {(standingsUrl || individualStandingsUrl) && (
+    <div class="mb-4 flex gap-2 flex-wrap">
+      {standingsUrl && (
+        <a href={standingsUrl} class="btn btn-sm btn-outline gap-1">
+          Team Standings →
+        </a>
+      )}
+      {individualStandingsUrl && (
+        <a href={individualStandingsUrl} class="btn btn-sm btn-outline gap-1">
+          Individual Standings →
+        </a>
+      )}
+    </div>
+  )}
+
+  {races.length === 0 ? (
+    <p class="text-base-content/60">No races found for {year}.</p>
+  ) : (
+    <div class="flex flex-col gap-4">
+      {races.map(race => (
+        <RaceCard race={race} year={year} series={series} />
+      ))}
+    </div>
+  )}
+</div>
+```
+
+- [ ] **Step 2: Replace the full contents of `src/pages/fell/[year]/index.astro`**
+
+```astro
+---
+// src/pages/fell/[year]/index.astro
+import Layout from '../../../components/Layout.astro';
+import RaceList from '../../../components/RaceList.astro';
+import { getCurrentYear, getAvailableYears, getRaces } from '../../../lib/data';
+import { hasTeamStandings, hasIndividualStandings } from '../../../lib/results';
+
+export async function getStaticPaths() {
+  const current = getCurrentYear();
+  const years = getAvailableYears('fell').filter(y => y !== current);
+  return years.map(year => ({ params: { year: String(year) } }));
+}
+
+const { year: yearParam } = Astro.params;
+const year = parseInt(yearParam);
+const currentYear = getCurrentYear();
+const availableYears = getAvailableYears('fell');
+const races = getRaces(year, 'fell');
+const standingsUrl = hasTeamStandings(year, 'fell')
+  ? `/fell/${year}/team-standings`
+  : undefined;
+const individualStandingsUrl = hasIndividualStandings(year, 'fell')
+  ? `/fell/${year}/individual-standings`
+  : undefined;
+---
+
+<Layout title={`Fell Championship ${year}`}>
+  <RaceList
+    races={races}
+    year={year}
+    series="fell"
+    availableYears={availableYears}
+    currentYear={currentYear}
+    seriesBasePath="/fell"
+    seriesLabel="Fell Championship"
+    standingsUrl={standingsUrl}
+    individualStandingsUrl={individualStandingsUrl}
+  />
+</Layout>
+```
+
+- [ ] **Step 3: Replace the full contents of `src/pages/road-gp/[year]/index.astro`**
+
+```astro
+---
+// src/pages/road-gp/[year]/index.astro
+import Layout from '../../../components/Layout.astro';
+import RaceList from '../../../components/RaceList.astro';
+import { getCurrentYear, getAvailableYears, getRaces } from '../../../lib/data';
+import { hasTeamStandings, hasIndividualStandings } from '../../../lib/results';
+
+export async function getStaticPaths() {
+  const current = getCurrentYear();
+  const years = getAvailableYears('road-gp').filter(y => y !== current);
+  return years.map(year => ({ params: { year: String(year) } }));
+}
+
+const { year: yearParam } = Astro.params;
+const year = parseInt(yearParam);
+const currentYear = getCurrentYear();
+const availableYears = getAvailableYears('road-gp');
+const races = getRaces(year, 'road-gp');
+const standingsUrl = hasTeamStandings(year, 'road-gp')
+  ? `/road-gp/${year}/team-standings`
+  : undefined;
+const individualStandingsUrl = hasIndividualStandings(year, 'road-gp')
+  ? `/road-gp/${year}/individual-standings`
+  : undefined;
+---
+
+<Layout title={`Road Grand Prix ${year}`}>
+  <RaceList
+    races={races}
+    year={year}
+    series="road-gp"
+    availableYears={availableYears}
+    currentYear={currentYear}
+    seriesBasePath="/road-gp"
+    seriesLabel="Road Grand Prix"
+    standingsUrl={standingsUrl}
+    individualStandingsUrl={individualStandingsUrl}
+  />
+</Layout>
+```
+
+- [ ] **Step 4: Run build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/RaceList.astro src/pages/fell/[year]/index.astro src/pages/road-gp/[year]/index.astro
+git commit -m "feat: add individual standings link to series year index pages"
+```
+
+---
+
+## Task 7: Create `fell` individual standings page
+
+**Files:**
+- Create: `src/pages/fell/[year]/individual-standings.astro`
+
+- [ ] **Step 1: Create the file with the full contents below**
+
+```astro
+---
+// src/pages/fell/[year]/individual-standings.astro
+import Layout from '../../../components/Layout.astro';
+import { getRaces } from '../../../lib/data';
+import { getIndividualStandingsStaticPaths } from '../../../lib/results';
+import type { Club, SeriesConfig, IndividualStandings } from '../../../lib/types';
+
+export async function getStaticPaths() {
+  return getIndividualStandingsStaticPaths('fell');
+}
+
+interface Props {
+  year: number;
+  standings: IndividualStandings;
+  clubs: Club[];
+  config: SeriesConfig;
+  linkedRaceIds: string[];
+}
+
+const { year, standings, clubs, config } = Astro.props;
+const linkedRaceIds = new Set(Astro.props.linkedRaceIds);
+const races = getRaces(year, 'fell');
+const raceById = Object.fromEntries(races.map(r => [r.id, r]));
+const categoryById = Object.fromEntries((config.individualCategories ?? []).map(c => [c.id, c]));
+const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
+---
+
+<Layout title={`Fell Championship ${year} — Individual Standings`}>
+  <div class="mb-4">
+    <a href={`/fell/${year}`} class="btn btn-ghost btn-sm gap-1 -ml-3">← Fell Championship {year}</a>
+  </div>
+
+  <div class="mb-6">
+    <div class="flex items-center gap-3 flex-wrap">
+      <h1 class="text-2xl font-bold">Individual Standings</h1>
+      {standings.provisional && (
+        <span class="badge badge-warning badge-lg">Provisional</span>
+      )}
+    </div>
+    <p class="text-sm text-base-content/60 mt-1">{year} Inter Club Fell Championship</p>
+    {config.maxCountingRaces && (
+      <p class="text-sm text-base-content/60 mt-0.5">Best {config.maxCountingRaces} races count</p>
+    )}
+  </div>
+
+  <!-- Category tabs -->
+  <div class="overflow-x-auto -mx-4 px-4 mb-1">
+    <div class="flex border-b border-base-200 min-w-max" role="tablist">
+      {standings.categories.map((cat, i) => {
+        const label = categoryById[cat.category]?.name ?? cat.category;
+        return (
+          <button
+            class:list={[
+              'tab-btn px-4 py-2 text-sm border-b-2 -mb-px whitespace-nowrap transition-colors',
+              i === 0
+                ? 'border-primary font-medium'
+                : 'border-transparent text-base-content/50 hover:text-base-content',
+            ]}
+            data-target={`cat-panel-${i}`}
+            role="tab"
+            aria-selected={i === 0 ? 'true' : 'false'}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  </div>
+
+  <!-- Category panels -->
+  {standings.categories.map((cat, i) => {
+    const distinctAgeCats = [...new Set(cat.runners.map(r => r.ageCategory))].sort();
+    return (
+      <div id={`cat-panel-${i}`} data-panel class:list={['pt-3', i > 0 && 'hidden']} role="tabpanel">
+
+        <!-- Filter controls -->
+        <div class="flex flex-wrap gap-2 mb-3 items-center">
+          <div class="flex gap-1">
+            <button class="filter-sex btn btn-xs btn-active" data-value="">All</button>
+            <button class="filter-sex btn btn-xs btn-ghost" data-value="M">M</button>
+            <button class="filter-sex btn btn-xs btn-ghost" data-value="F">F</button>
+          </div>
+          {distinctAgeCats.length > 1 && (
+            <div class="flex gap-1 flex-wrap">
+              {distinctAgeCats.map(age => (
+                <button class="filter-age btn btn-xs btn-ghost" data-value={age}>{age}</button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <!-- Desktop table -->
+        <div class="hidden sm:block overflow-x-auto">
+          <table class="w-full border-collapse text-sm">
+            <thead>
+              <tr class="border-b border-base-200">
+                <th class="text-left py-2 pr-3 text-base-content/40 font-medium w-8">#</th>
+                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Name</th>
+                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Club</th>
+                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Cat</th>
+                {standings.races.map(raceId => {
+                  const race = raceById[raceId];
+                  const label = race?.shortName ?? raceId;
+                  const href = linkedRaceIds.has(raceId) ? `/fell/${year}/${raceId}/results` : null;
+                  return (
+                    <th class="text-right py-2 px-2 font-medium whitespace-nowrap">
+                      {href
+                        ? <a href={href} class="text-primary hover:underline">{label}</a>
+                        : <span class="text-base-content/20">{label}</span>
+                      }
+                    </th>
+                  );
+                })}
+                <th class="text-right py-2 pl-4 text-base-content/40 font-medium">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {cat.runners.map(runner => {
+                const clubName = clubById[runner.club]?.name ?? runner.club;
+                const catLabel = `${runner.sex}${runner.ageCategory}`;
+                return (
+                  <tr
+                    class="border-b border-base-200/50 last:border-0 hover:bg-base-200/30"
+                    data-sex={runner.sex}
+                    data-age-cat={runner.ageCategory}
+                  >
+                    <td class="py-2.5 pr-3 text-base-content/40 tabular-nums">{runner.position}</td>
+                    <td class="py-2.5 pr-4 font-semibold">{runner.name}</td>
+                    <td class="py-2.5 pr-4">{clubName}</td>
+                    <td class="py-2.5 pr-4 text-base-content/60 text-xs tabular-nums">{catLabel}</td>
+                    {standings.races.map(raceId => {
+                      const result = runner.results[raceId];
+                      if (!result) return <td class="py-2.5 px-2" />;
+                      return (
+                        <td class:list={[
+                          'py-2.5 px-2 text-right tabular-nums',
+                          !result.counting && 'text-base-content/30',
+                        ]}>
+                          <span class:list={[!result.counting && 'line-through']}>
+                            {result.points}
+                          </span>
+                        </td>
+                      );
+                    })}
+                    <td class="py-2.5 pl-4 text-right">
+                      <strong class="text-base-content/80">{runner.total}</strong>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Mobile view -->
+        <div class="sm:hidden">
+          <!-- Race key -->
+          <div class="flex flex-wrap gap-x-3 gap-y-1 py-3 border-b border-base-200 mb-1 text-xs text-base-content/40">
+            {standings.races.map(raceId => {
+              const race = raceById[raceId];
+              const label = race?.shortName ?? raceId;
+              const href = linkedRaceIds.has(raceId) ? `/fell/${year}/${raceId}/results` : null;
+              return (
+                <span>
+                  {href
+                    ? <a href={href} class="text-primary">{label}</a>
+                    : label
+                  }
+                  {' = '}{race?.name ?? raceId}
+                </span>
+              );
+            })}
+          </div>
+
+          {cat.runners.map(runner => {
+            const clubName = clubById[runner.club]?.name ?? runner.club;
+            const catLabel = `${runner.sex}${runner.ageCategory}`;
+            const detailId = `detail-${i}-${runner.position}`;
+            return (
+              <div
+                class="runner-card border-b border-base-200 last:border-0"
+                data-sex={runner.sex}
+                data-age-cat={runner.ageCategory}
+              >
+                <button
+                  class="standings-toggle w-full flex items-center gap-2 py-2.5 text-left"
+                  data-target={detailId}
+                  aria-expanded="false"
+                >
+                  <span class="w-6 shrink-0 text-sm text-base-content/40 tabular-nums">{runner.position}</span>
+                  <span class="flex-1 font-semibold">{runner.name}</span>
+                  <strong class="text-base-content/80">{runner.total}</strong>
+                  <span class="chevron text-base-content/30 text-xs ml-1 transition-transform">▾</span>
+                </button>
+                <div id={detailId} class="hidden pb-3 pl-8">
+                  <p class="text-sm text-base-content/60 mb-1.5">
+                    {clubName} · <span class="font-mono text-xs">{catLabel}</span>
+                  </p>
+                  <div class="flex flex-wrap gap-1.5">
+                    {Object.entries(runner.results).map(([raceId, result]) => {
+                      const race = raceById[raceId];
+                      const label = race?.shortName ?? raceId;
+                      const href = linkedRaceIds.has(raceId) ? `/fell/${year}/${raceId}/results` : null;
+                      return (
+                        <div class:list={[
+                          'rounded px-2.5 py-1 text-center text-sm min-w-[44px]',
+                          result.counting ? 'bg-base-200' : 'bg-base-200/40',
+                        ]}>
+                          {href
+                            ? <a href={href} class:list={['block text-[10px] mb-0.5', result.counting ? 'text-primary' : 'text-base-content/30']}>{label}</a>
+                            : <span class:list={['block text-[10px] mb-0.5', result.counting ? 'text-base-content/40' : 'text-base-content/20']}>{label}</span>
+                          }
+                          <span class:list={[
+                            result.counting ? 'font-semibold' : 'text-base-content/30 line-through',
+                          ]}>{result.points}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+      </div>
+    );
+  })}
+</Layout>
+
+<script>
+  // Tab switching
+  const tabs = document.querySelectorAll<HTMLButtonElement>('.tab-btn');
+  tabs.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const targetId = btn.dataset.target!;
+      tabs.forEach(t => {
+        const active = t === btn;
+        t.classList.toggle('border-primary', active);
+        t.classList.toggle('font-medium', active);
+        t.classList.toggle('border-transparent', !active);
+        t.classList.toggle('text-base-content/50', !active);
+        t.setAttribute('aria-selected', active ? 'true' : 'false');
+      });
+      document.querySelectorAll<HTMLElement>('[id^="cat-panel-"]').forEach(panel => {
+        panel.classList.toggle('hidden', panel.id !== targetId);
+      });
+    });
+  });
+
+  // Mobile accordion
+  document.querySelectorAll<HTMLButtonElement>('.standings-toggle').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const targetId = btn.dataset.target!;
+      const detail = document.getElementById(targetId)!;
+      const isOpen = !detail.classList.contains('hidden');
+      detail.classList.toggle('hidden', isOpen);
+      btn.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+      btn.querySelector('.chevron')?.classList.toggle('rotate-180', !isOpen);
+    });
+  });
+
+  // Filtering
+  function filterPanel(panel: HTMLElement) {
+    const activeSex = panel.querySelector<HTMLElement>('.filter-sex.btn-active')?.dataset.value ?? '';
+    const activeAges = [...panel.querySelectorAll<HTMLElement>('.filter-age.btn-active')]
+      .map(b => b.dataset.value ?? '');
+
+    panel.querySelectorAll<HTMLElement>('tr[data-sex]').forEach(row => {
+      const sexMatch = !activeSex || row.dataset.sex === activeSex;
+      const ageMatch = activeAges.length === 0 || activeAges.includes(row.dataset.ageCat ?? '');
+      row.style.display = sexMatch && ageMatch ? '' : 'none';
+    });
+
+    panel.querySelectorAll<HTMLElement>('.runner-card').forEach(card => {
+      const sexMatch = !activeSex || card.dataset.sex === activeSex;
+      const ageMatch = activeAges.length === 0 || activeAges.includes(card.dataset.ageCat ?? '');
+      card.style.display = sexMatch && ageMatch ? '' : 'none';
+    });
+  }
+
+  document.querySelectorAll<HTMLButtonElement>('.filter-sex').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const panel = btn.closest<HTMLElement>('[data-panel]')!;
+      panel.querySelectorAll<HTMLElement>('.filter-sex').forEach(b => {
+        const active = b === btn;
+        b.classList.toggle('btn-active', active);
+        b.classList.toggle('btn-ghost', !active);
+      });
+      filterPanel(panel);
+    });
+  });
+
+  document.querySelectorAll<HTMLButtonElement>('.filter-age').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const panel = btn.closest<HTMLElement>('[data-panel]')!;
+      btn.classList.toggle('btn-active');
+      btn.classList.toggle('btn-ghost');
+      filterPanel(panel);
+    });
+  });
+</script>
+```
+
+- [ ] **Step 2: Run build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds (the page generates no static paths since no `individual-standings.json` files exist yet, which is correct).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/fell/[year]/individual-standings.astro
+git commit -m "feat: add fell individual standings page"
+```
+
+---
+
+## Task 8: Create `road-gp` individual standings page
+
+**Files:**
+- Create: `src/pages/road-gp/[year]/individual-standings.astro`
+
+- [ ] **Step 1: Create the file**
+
+This is identical to the fell page except for the series label, back-link path, and series string passed to `getIndividualStandingsStaticPaths`. Create `src/pages/road-gp/[year]/individual-standings.astro` with the contents below:
+
+```astro
+---
+// src/pages/road-gp/[year]/individual-standings.astro
+import Layout from '../../../components/Layout.astro';
+import { getRaces } from '../../../lib/data';
+import { getIndividualStandingsStaticPaths } from '../../../lib/results';
+import type { Club, SeriesConfig, IndividualStandings } from '../../../lib/types';
+
+export async function getStaticPaths() {
+  return getIndividualStandingsStaticPaths('road-gp');
+}
+
+interface Props {
+  year: number;
+  standings: IndividualStandings;
+  clubs: Club[];
+  config: SeriesConfig;
+  linkedRaceIds: string[];
+}
+
+const { year, standings, clubs, config } = Astro.props;
+const linkedRaceIds = new Set(Astro.props.linkedRaceIds);
+const races = getRaces(year, 'road-gp');
+const raceById = Object.fromEntries(races.map(r => [r.id, r]));
+const categoryById = Object.fromEntries((config.individualCategories ?? []).map(c => [c.id, c]));
+const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
+---
+
+<Layout title={`Road Grand Prix ${year} — Individual Standings`}>
+  <div class="mb-4">
+    <a href={`/road-gp/${year}`} class="btn btn-ghost btn-sm gap-1 -ml-3">← Road Grand Prix {year}</a>
+  </div>
+
+  <div class="mb-6">
+    <div class="flex items-center gap-3 flex-wrap">
+      <h1 class="text-2xl font-bold">Individual Standings</h1>
+      {standings.provisional && (
+        <span class="badge badge-warning badge-lg">Provisional</span>
+      )}
+    </div>
+    <p class="text-sm text-base-content/60 mt-1">{year} Inter Club Road Grand Prix</p>
+    {config.maxCountingRaces && (
+      <p class="text-sm text-base-content/60 mt-0.5">Best {config.maxCountingRaces} races count</p>
+    )}
+  </div>
+
+  <!-- Category tabs -->
+  <div class="overflow-x-auto -mx-4 px-4 mb-1">
+    <div class="flex border-b border-base-200 min-w-max" role="tablist">
+      {standings.categories.map((cat, i) => {
+        const label = categoryById[cat.category]?.name ?? cat.category;
+        return (
+          <button
+            class:list={[
+              'tab-btn px-4 py-2 text-sm border-b-2 -mb-px whitespace-nowrap transition-colors',
+              i === 0
+                ? 'border-primary font-medium'
+                : 'border-transparent text-base-content/50 hover:text-base-content',
+            ]}
+            data-target={`cat-panel-${i}`}
+            role="tab"
+            aria-selected={i === 0 ? 'true' : 'false'}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  </div>
+
+  <!-- Category panels -->
+  {standings.categories.map((cat, i) => {
+    const distinctAgeCats = [...new Set(cat.runners.map(r => r.ageCategory))].sort();
+    return (
+      <div id={`cat-panel-${i}`} data-panel class:list={['pt-3', i > 0 && 'hidden']} role="tabpanel">
+
+        <!-- Filter controls -->
+        <div class="flex flex-wrap gap-2 mb-3 items-center">
+          <div class="flex gap-1">
+            <button class="filter-sex btn btn-xs btn-active" data-value="">All</button>
+            <button class="filter-sex btn btn-xs btn-ghost" data-value="M">M</button>
+            <button class="filter-sex btn btn-xs btn-ghost" data-value="F">F</button>
+          </div>
+          {distinctAgeCats.length > 1 && (
+            <div class="flex gap-1 flex-wrap">
+              {distinctAgeCats.map(age => (
+                <button class="filter-age btn btn-xs btn-ghost" data-value={age}>{age}</button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <!-- Desktop table -->
+        <div class="hidden sm:block overflow-x-auto">
+          <table class="w-full border-collapse text-sm">
+            <thead>
+              <tr class="border-b border-base-200">
+                <th class="text-left py-2 pr-3 text-base-content/40 font-medium w-8">#</th>
+                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Name</th>
+                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Club</th>
+                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Cat</th>
+                {standings.races.map(raceId => {
+                  const race = raceById[raceId];
+                  const label = race?.shortName ?? raceId;
+                  const href = linkedRaceIds.has(raceId) ? `/road-gp/${year}/${raceId}/results` : null;
+                  return (
+                    <th class="text-right py-2 px-2 font-medium whitespace-nowrap">
+                      {href
+                        ? <a href={href} class="text-primary hover:underline">{label}</a>
+                        : <span class="text-base-content/20">{label}</span>
+                      }
+                    </th>
+                  );
+                })}
+                <th class="text-right py-2 pl-4 text-base-content/40 font-medium">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {cat.runners.map(runner => {
+                const clubName = clubById[runner.club]?.name ?? runner.club;
+                const catLabel = `${runner.sex}${runner.ageCategory}`;
+                return (
+                  <tr
+                    class="border-b border-base-200/50 last:border-0 hover:bg-base-200/30"
+                    data-sex={runner.sex}
+                    data-age-cat={runner.ageCategory}
+                  >
+                    <td class="py-2.5 pr-3 text-base-content/40 tabular-nums">{runner.position}</td>
+                    <td class="py-2.5 pr-4 font-semibold">{runner.name}</td>
+                    <td class="py-2.5 pr-4">{clubName}</td>
+                    <td class="py-2.5 pr-4 text-base-content/60 text-xs tabular-nums">{catLabel}</td>
+                    {standings.races.map(raceId => {
+                      const result = runner.results[raceId];
+                      if (!result) return <td class="py-2.5 px-2" />;
+                      return (
+                        <td class:list={[
+                          'py-2.5 px-2 text-right tabular-nums',
+                          !result.counting && 'text-base-content/30',
+                        ]}>
+                          <span class:list={[!result.counting && 'line-through']}>
+                            {result.points}
+                          </span>
+                        </td>
+                      );
+                    })}
+                    <td class="py-2.5 pl-4 text-right">
+                      <strong class="text-base-content/80">{runner.total}</strong>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Mobile view -->
+        <div class="sm:hidden">
+          <!-- Race key -->
+          <div class="flex flex-wrap gap-x-3 gap-y-1 py-3 border-b border-base-200 mb-1 text-xs text-base-content/40">
+            {standings.races.map(raceId => {
+              const race = raceById[raceId];
+              const label = race?.shortName ?? raceId;
+              const href = linkedRaceIds.has(raceId) ? `/road-gp/${year}/${raceId}/results` : null;
+              return (
+                <span>
+                  {href
+                    ? <a href={href} class="text-primary">{label}</a>
+                    : label
+                  }
+                  {' = '}{race?.name ?? raceId}
+                </span>
+              );
+            })}
+          </div>
+
+          {cat.runners.map(runner => {
+            const clubName = clubById[runner.club]?.name ?? runner.club;
+            const catLabel = `${runner.sex}${runner.ageCategory}`;
+            const detailId = `detail-${i}-${runner.position}`;
+            return (
+              <div
+                class="runner-card border-b border-base-200 last:border-0"
+                data-sex={runner.sex}
+                data-age-cat={runner.ageCategory}
+              >
+                <button
+                  class="standings-toggle w-full flex items-center gap-2 py-2.5 text-left"
+                  data-target={detailId}
+                  aria-expanded="false"
+                >
+                  <span class="w-6 shrink-0 text-sm text-base-content/40 tabular-nums">{runner.position}</span>
+                  <span class="flex-1 font-semibold">{runner.name}</span>
+                  <strong class="text-base-content/80">{runner.total}</strong>
+                  <span class="chevron text-base-content/30 text-xs ml-1 transition-transform">▾</span>
+                </button>
+                <div id={detailId} class="hidden pb-3 pl-8">
+                  <p class="text-sm text-base-content/60 mb-1.5">
+                    {clubName} · <span class="font-mono text-xs">{catLabel}</span>
+                  </p>
+                  <div class="flex flex-wrap gap-1.5">
+                    {Object.entries(runner.results).map(([raceId, result]) => {
+                      const race = raceById[raceId];
+                      const label = race?.shortName ?? raceId;
+                      const href = linkedRaceIds.has(raceId) ? `/road-gp/${year}/${raceId}/results` : null;
+                      return (
+                        <div class:list={[
+                          'rounded px-2.5 py-1 text-center text-sm min-w-[44px]',
+                          result.counting ? 'bg-base-200' : 'bg-base-200/40',
+                        ]}>
+                          {href
+                            ? <a href={href} class:list={['block text-[10px] mb-0.5', result.counting ? 'text-primary' : 'text-base-content/30']}>{label}</a>
+                            : <span class:list={['block text-[10px] mb-0.5', result.counting ? 'text-base-content/40' : 'text-base-content/20']}>{label}</span>
+                          }
+                          <span class:list={[
+                            result.counting ? 'font-semibold' : 'text-base-content/30 line-through',
+                          ]}>{result.points}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+      </div>
+    );
+  })}
+</Layout>
+
+<script>
+  // Tab switching
+  const tabs = document.querySelectorAll<HTMLButtonElement>('.tab-btn');
+  tabs.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const targetId = btn.dataset.target!;
+      tabs.forEach(t => {
+        const active = t === btn;
+        t.classList.toggle('border-primary', active);
+        t.classList.toggle('font-medium', active);
+        t.classList.toggle('border-transparent', !active);
+        t.classList.toggle('text-base-content/50', !active);
+        t.setAttribute('aria-selected', active ? 'true' : 'false');
+      });
+      document.querySelectorAll<HTMLElement>('[id^="cat-panel-"]').forEach(panel => {
+        panel.classList.toggle('hidden', panel.id !== targetId);
+      });
+    });
+  });
+
+  // Mobile accordion
+  document.querySelectorAll<HTMLButtonElement>('.standings-toggle').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const targetId = btn.dataset.target!;
+      const detail = document.getElementById(targetId)!;
+      const isOpen = !detail.classList.contains('hidden');
+      detail.classList.toggle('hidden', isOpen);
+      btn.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+      btn.querySelector('.chevron')?.classList.toggle('rotate-180', !isOpen);
+    });
+  });
+
+  // Filtering
+  function filterPanel(panel: HTMLElement) {
+    const activeSex = panel.querySelector<HTMLElement>('.filter-sex.btn-active')?.dataset.value ?? '';
+    const activeAges = [...panel.querySelectorAll<HTMLElement>('.filter-age.btn-active')]
+      .map(b => b.dataset.value ?? '');
+
+    panel.querySelectorAll<HTMLElement>('tr[data-sex]').forEach(row => {
+      const sexMatch = !activeSex || row.dataset.sex === activeSex;
+      const ageMatch = activeAges.length === 0 || activeAges.includes(row.dataset.ageCat ?? '');
+      row.style.display = sexMatch && ageMatch ? '' : 'none';
+    });
+
+    panel.querySelectorAll<HTMLElement>('.runner-card').forEach(card => {
+      const sexMatch = !activeSex || card.dataset.sex === activeSex;
+      const ageMatch = activeAges.length === 0 || activeAges.includes(card.dataset.ageCat ?? '');
+      card.style.display = sexMatch && ageMatch ? '' : 'none';
+    });
+  }
+
+  document.querySelectorAll<HTMLButtonElement>('.filter-sex').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const panel = btn.closest<HTMLElement>('[data-panel]')!;
+      panel.querySelectorAll<HTMLElement>('.filter-sex').forEach(b => {
+        const active = b === btn;
+        b.classList.toggle('btn-active', active);
+        b.classList.toggle('btn-ghost', !active);
+      });
+      filterPanel(panel);
+    });
+  });
+
+  document.querySelectorAll<HTMLButtonElement>('.filter-age').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const panel = btn.closest<HTMLElement>('[data-panel]')!;
+      btn.classList.toggle('btn-active');
+      btn.classList.toggle('btn-ghost');
+      filterPanel(panel);
+    });
+  });
+</script>
+```
+
+- [ ] **Step 2: Run tests and build**
+
+```bash
+npm test && npm run build
+```
+
+Expected: all tests pass; build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/road-gp/[year]/individual-standings.astro
+git commit -m "feat: add road-gp individual standings page"
+```
+
+---
+
+## Task 9: Smoke test with sample data
+
+**Files:**
+- Create: `src/data/2026/fell/individual-standings.json` (temporary, for smoke testing)
+- Modify: `src/data/2026/fell/config.json` (add `individualCategories` and `maxCountingRaces`)
+
+- [ ] **Step 1: Add `individualCategories` and `maxCountingRaces` to `src/data/2026/fell/config.json`**
+
+```json
+{
+  "ageCategories": ["SEN", "V40", "V50", "V60", "V70"],
+  "maxCountingRaces": 3,
+  "individualCategories": [
+    { "id": "sen-m", "name": "Senior Men"   },
+    { "id": "sen-f", "name": "Senior Women" },
+    { "id": "v40-m", "name": "V40 Men"      },
+    { "id": "v40-f", "name": "V40 Women"    }
+  ],
+  "teamCategories": [
+    { "id": "open",   "name": "Open",   "scorerCount": 6 },
+    { "id": "ladies", "name": "Ladies", "scorerCount": 3 },
+    { "id": "vets",   "name": "Vets",   "scorerCount": 4 }
+  ]
+}
+```
+
+- [ ] **Step 2: Create `src/data/2026/fell/individual-standings.json`**
+
+```json
+{
+  "provisional": true,
+  "races": ["fell-race-1", "fell-race-2", "fell-race-3", "fell-race-4"],
+  "categories": [
+    {
+      "category": "sen-m",
+      "runners": [
+        {
+          "position": 1,
+          "name": "Luke Minns",
+          "club": "blackpool",
+          "sex": "M",
+          "ageCategory": "SEN",
+          "total": 47,
+          "results": {
+            "fell-race-1": { "points": 25, "counting": true },
+            "fell-race-3": { "points": 22, "counting": true }
+          }
+        },
+        {
+          "position": 2,
+          "name": "J. Smith",
+          "club": "wesham",
+          "sex": "M",
+          "ageCategory": "SEN",
+          "total": 38,
+          "results": {
+            "fell-race-1": { "points": 20, "counting": true },
+            "fell-race-2": { "points": 18, "counting": true },
+            "fell-race-3": { "points": 15, "counting": false }
+          }
+        }
+      ]
+    },
+    {
+      "category": "sen-f",
+      "runners": [
+        {
+          "position": 1,
+          "name": "A. Jones",
+          "club": "chorley",
+          "sex": "F",
+          "ageCategory": "SEN",
+          "total": 30,
+          "results": {
+            "fell-race-2": { "points": 30, "counting": true }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+- [ ] **Step 3: Build and preview**
+
+```bash
+npm run build && npm run preview
+```
+
+Expected: build succeeds; navigate to `http://localhost:4321/fell/2026/individual-standings` (adjust port if different) and verify:
+- Provisional badge is shown
+- "Best 3 races count" note appears
+- Two category tabs: "Senior Men" and "Senior Women"
+- Senior Men tab shows two runners; J. Smith's fell-race-3 score (15) is dimmed with strikethrough
+- Senior Women tab shows one runner with one chip
+- M/F filter buttons work
+- On narrow viewport (< 640px width), accordion rows appear instead of the table
+
+- [ ] **Step 4: Commit the smoke-test data (it can be removed later when real data is added)**
+
+```bash
+git add src/data/2026/fell/config.json src/data/2026/fell/individual-standings.json
+git commit -m "chore: add sample individual standings data for 2026 fell (smoke test)"
+```
+
+---
+
+## Spec Coverage Check
+
+| Spec requirement | Covered by |
+|---|---|
+| `categories` renamed to `ageCategories` in config | Tasks 1, 2, 3, 5 |
+| `maxCountingRaces` in config | Task 1 (types), Task 9 (data) |
+| `individualCategories` in config | Task 1 (types), Task 9 (data) |
+| `individual-standings.json` schema | Tasks 1 (types), 3 (loading), 9 (sample) |
+| Page only generated when file exists | Task 3 (`getIndividualStandingsStaticPaths`) |
+| Provisional badge | Tasks 7, 8 |
+| Category tabs | Tasks 7, 8 |
+| Desktop table with race columns | Tasks 7, 8 |
+| Non-counting results dimmed + strikethrough | Tasks 7, 8 |
+| Empty cell for races not run | Tasks 7, 8 |
+| Category column = `sex + ageCategory` (e.g. `MSEN`) | Tasks 7, 8 |
+| Sex filter (M/F/All) | Tasks 7, 8 |
+| Age category filter (multiselect) | Tasks 7, 8 |
+| Mobile accordion | Tasks 7, 8 |
+| Mobile race chips (counting vs non-counting) | Tasks 7, 8 |
+| Navigation link from year index | Tasks 6 |
+| `linkedRaceIds` links race columns to results pages | Tasks 7, 8 |
+| Tests for `parseIndividualStandingsPath` | Task 4 |

--- a/docs/superpowers/specs/2026-04-28-individual-standings-design.md
+++ b/docs/superpowers/specs/2026-04-28-individual-standings-design.md
@@ -1,0 +1,231 @@
+# Individual Standings — Design Spec
+
+**Date:** 2026-04-28  
+**Series:** Fell Championship & Road GP (both series, same pattern)  
+**Status:** Approved
+
+---
+
+## Overview
+
+Add individual standings pages to the InterClub site. Standings are pre-computed externally and dropped as a JSON file alongside the existing `team-standings.json`. The page is only generated at build time when the file exists.
+
+A key difference from team standings: not all races a runner completes count towards their total — only their best N do. The non-counting results must be visually indicated.
+
+---
+
+## 1. Config Changes (`src/data/{year}/{series}/config.json`)
+
+### Rename
+
+`categories` → `ageCategories` (the existing field was misnamed; it holds age category bands used for result filtering, not the full category concept).
+
+This rename must be reflected everywhere the config is consumed:
+- `src/lib/types.ts` (`SeriesConfig.categories` → `SeriesConfig.ageCategories`)
+- `src/lib/results.ts` (any reference to `config.categories`)
+- Any Astro pages that destructure `config.categories`
+
+### New fields
+
+```json
+{
+  "ageCategories": ["SEN", "V35", "V40", "V50", "V60", "V70"],
+  "maxCountingRaces": 3,
+  "individualCategories": [
+    { "id": "sen-m", "name": "Senior Men"   },
+    { "id": "sen-f", "name": "Senior Women" },
+    { "id": "v40-m", "name": "V40 Men"      },
+    { "id": "v40-f", "name": "V40 Women"    },
+    { "id": "v35-f", "name": "V35 Women"    }
+  ],
+  "teamCategories": [
+    { "id": "open",   "name": "Open",   "scorerCount": 6 },
+    { "id": "ladies", "name": "Ladies", "scorerCount": 3 },
+    { "id": "vets",   "name": "Vets",   "scorerCount": 4 }
+  ]
+}
+```
+
+**`maxCountingRaces`** — optional integer. When present, the page displays the rule (e.g. *"Best 3 races count"*) and visually marks non-counting results. When absent, all results count and no indicator is shown.
+
+**`individualCategories`** — optional array of `{ id, name }`. The `id` is referenced by the standings JSON. The categories defined here determine which tabs appear on the standings page. The external process that generates the standings decides which runners belong to which category — the site just displays what it receives.
+
+---
+
+## 2. Individual Standings JSON (`src/data/{year}/{series}/individual-standings.json`)
+
+File absence means no individual standings page is generated for that year/series.
+
+### Schema
+
+```json
+{
+  "provisional": false,
+  "races": ["fell-race-1", "fell-race-2", "fell-race-3", "fell-race-4"],
+  "categories": [
+    {
+      "category": "sen-m",
+      "runners": [
+        {
+          "position": 1,
+          "name": "Luke Minns",
+          "club": "blackpool",
+          "sex": "M",
+          "ageCategory": "SEN",
+          "total": 47,
+          "results": {
+            "fell-race-1": { "points": 25, "counting": true },
+            "fell-race-3": { "points": 22, "counting": true }
+          }
+        },
+        {
+          "position": 2,
+          "name": "J. Smith",
+          "club": "wesham",
+          "sex": "M",
+          "ageCategory": "SEN",
+          "total": 38,
+          "results": {
+            "fell-race-1": { "points": 20, "counting": true },
+            "fell-race-2": { "points": 18, "counting": true },
+            "fell-race-3": { "points": 15, "counting": false }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Field notes
+
+| Field | Notes |
+|---|---|
+| `provisional` | When `true`, a warning badge is shown on the page |
+| `races` | Ordered list of race IDs — defines column order in the table |
+| `categories[].category` | References an `id` in `config.individualCategories` |
+| `runners[].sex` | `"M"` or `"F"` — stored separately for filtering |
+| `runners[].ageCategory` | e.g. `"SEN"`, `"V40"` — stored separately for filtering |
+| `runners[].results` | Sparse map — only races the runner actually ran are present; no `null` entries |
+| `results[raceId].counting` | `false` when the runner ran more races than `maxCountingRaces` and this result didn't score |
+| `runners[].total` | Pre-computed and stored explicitly |
+
+---
+
+## 3. TypeScript Types (`src/lib/types.ts`)
+
+```typescript
+// Rename in SeriesConfig:
+export interface SeriesConfig {
+  ageCategories: string[];           // renamed from categories
+  maxCountingRaces?: number;
+  individualCategories?: IndividualCategory[];
+  teamCategories?: TeamCategory[];
+}
+
+// New types:
+export interface IndividualCategory {
+  id: string;
+  name: string;
+}
+
+export interface IndividualRaceResult {
+  points: number;
+  counting: boolean;
+}
+
+export interface IndividualStandingsRunner {
+  position: number;
+  name: string;
+  club: string;
+  sex: string;          // 'M' or 'F'
+  ageCategory: string;  // e.g. 'SEN', 'V40'
+  total: number;
+  results: Record<string, IndividualRaceResult>;  // keyed by race id
+}
+
+export interface IndividualStandingsCategory {
+  category: string;   // id → IndividualCategory lookup via config
+  runners: IndividualStandingsRunner[];
+}
+
+export interface IndividualStandings {
+  provisional: boolean;
+  races: string[];
+  categories: IndividualStandingsCategory[];
+}
+```
+
+---
+
+## 4. Data Loading (`src/lib/results.ts`)
+
+- Update `config.categories` references → `config.ageCategories` throughout
+- Add `getIndividualStandingsStaticPaths(series: Series)` — mirrors `getTeamStandingsStaticPaths`:
+  - Loads `individual-standings.json` files via `import.meta.glob`
+  - Parses path to extract year
+  - Loads the matching `clubs.json` and `config.json`
+  - Returns an array of static path entries; empty array when no files found
+
+---
+
+## 5. New Page (`src/pages/{series}/[year]/individual-standings.astro`)
+
+Generated only when `individual-standings.json` exists. Follows the same static paths pattern as `team-standings.astro`.
+
+Linked from the series year index page (e.g. `/fell/2026`) when it exists — same treatment as the team standings link.
+
+### Heading area
+
+- Title: *"Individual Standings"*
+- Subtitle: *"{year} Inter Club Fell Championship"*
+- Provisional badge (when `provisional: true`)
+- When `maxCountingRaces` is set: a note below the title — *"Best {n} races count"*
+
+### Category tabs
+
+One tab per entry in `standings.categories`, labelled using the matching `config.individualCategories[].name`. Tab pattern identical to team standings.
+
+### Desktop table (≥ sm breakpoint)
+
+Columns: `#` · `Name` · `Club` · `Category` · *one column per race in `standings.races`* · `Total`
+
+**Category column** — displays `sex + ageCategory` as a combined label: `MSEN`, `FV40`, `FV35` etc.
+
+**Race columns** — header links to the individual results page when results exist (same as team standings). For each runner/race cell:
+- Runner ran this race, result counts → show points normally
+- Runner ran this race, result does not count → show points dimmed with strikethrough
+- Runner did not run this race → empty cell (no dash — keeps the table uncluttered)
+
+**Filter controls** — above the table, per category tab:
+- Sex toggle: `M` / `F` buttons (shows all when none selected)
+- Age category filter: one toggle per distinct age category present in the tab's data
+- Filters operate on the underlying `sex` and `ageCategory` fields independently
+- Row position numbers are left as-is (not recalculated on filter — original standings positions are preserved)
+
+### Mobile view (< sm breakpoint)
+
+Expandable accordion rows per runner:
+- Collapsed: `position` · `Name` · **Total** · chevron
+- Expanded:
+  - `Club` (labelled)
+  - `Category` (combined label, e.g. `FV40`)
+  - Race result chips — one per race the runner actually ran, labelled with `race.shortName` (falls back to race id)
+    - Counting result: solid chip background, points value
+    - Non-counting result: dimmed chip, points value with strikethrough
+  - Chips link to the individual results page where available
+- Filter controls appear above the list (same M/F + age category toggles, compact)
+
+---
+
+## 6. Navigation
+
+The series year index page (`/fell/{year}`, `/road-gp/{year}`) gains an *"Individual Standings"* link alongside the existing *"Team Standings"* link. The link is only rendered when the individual standings page exists for that year.
+
+---
+
+## Out of Scope
+
+- Computing standings from CSVs at build time — standings are always pre-computed externally
+- Runner profiles or cross-race linking by runner identity
+- Historical data migration — this spec covers the format only; data entry is a separate process

--- a/src/components/RaceList.astro
+++ b/src/components/RaceList.astro
@@ -13,9 +13,10 @@ interface Props {
   seriesBasePath: string;
   seriesLabel: string;
   standingsUrl?: string;
+  individualStandingsUrl?: string;
 }
 
-const { races, year, series, availableYears, currentYear, seriesBasePath, seriesLabel, standingsUrl } = Astro.props;
+const { races, year, series, availableYears, currentYear, seriesBasePath, seriesLabel, standingsUrl, individualStandingsUrl } = Astro.props;
 ---
 
 <div>
@@ -31,11 +32,18 @@ const { races, year, series, availableYears, currentYear, seriesBasePath, series
     )}
   </div>
 
-  {standingsUrl && (
-    <div class="mb-4">
-      <a href={standingsUrl} class="btn btn-sm btn-outline gap-1">
-        Team Standings →
-      </a>
+  {(standingsUrl || individualStandingsUrl) && (
+    <div class="mb-4 flex gap-2 flex-wrap">
+      {standingsUrl && (
+        <a href={standingsUrl} class="btn btn-sm btn-outline gap-1">
+          Team Standings →
+        </a>
+      )}
+      {individualStandingsUrl && (
+        <a href={individualStandingsUrl} class="btn btn-sm btn-outline gap-1">
+          Individual Standings →
+        </a>
+      )}
     </div>
   )}
 

--- a/src/data/2026/fell/config.json
+++ b/src/data/2026/fell/config.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["SEN", "V40", "V50", "V60", "V70"],
+  "ageCategories": ["SEN", "V40", "V50", "V60", "V70"],
   "teamCategories": [
     { "id": "open",   "name": "Open",   "scorerCount": 6 },
     { "id": "ladies", "name": "Ladies", "scorerCount": 3 },

--- a/src/data/2026/fell/config.json
+++ b/src/data/2026/fell/config.json
@@ -1,5 +1,12 @@
 {
   "ageCategories": ["SEN", "V40", "V50", "V60", "V70"],
+  "maxCountingRaces": 3,
+  "individualCategories": [
+    { "id": "sen-m", "name": "Senior Men"   },
+    { "id": "sen-f", "name": "Senior Women" },
+    { "id": "v40-m", "name": "V40 Men"      },
+    { "id": "v40-f", "name": "V40 Women"    }
+  ],
   "teamCategories": [
     { "id": "open",   "name": "Open",   "scorerCount": 6 },
     { "id": "ladies", "name": "Ladies", "scorerCount": 3 },

--- a/src/data/2026/fell/individual-standings.json
+++ b/src/data/2026/fell/individual-standings.json
@@ -1,0 +1,52 @@
+{
+  "provisional": true,
+  "races": ["fell-race-1", "fell-race-2", "fell-race-3", "fell-race-4"],
+  "categories": [
+    {
+      "category": "sen-m",
+      "runners": [
+        {
+          "position": 1,
+          "name": "Luke Minns",
+          "club": "blackpool",
+          "sex": "M",
+          "ageCategory": "SEN",
+          "total": 47,
+          "results": {
+            "fell-race-1": { "points": 25, "counting": true },
+            "fell-race-3": { "points": 22, "counting": true }
+          }
+        },
+        {
+          "position": 2,
+          "name": "J. Smith",
+          "club": "wesham",
+          "sex": "M",
+          "ageCategory": "SEN",
+          "total": 38,
+          "results": {
+            "fell-race-1": { "points": 20, "counting": true },
+            "fell-race-2": { "points": 18, "counting": true },
+            "fell-race-3": { "points": 15, "counting": false }
+          }
+        }
+      ]
+    },
+    {
+      "category": "sen-f",
+      "runners": [
+        {
+          "position": 1,
+          "name": "A. Jones",
+          "club": "chorley",
+          "sex": "F",
+          "ageCategory": "SEN",
+          "total": 30,
+          "results": {
+            "fell-race-2": { "points": 30, "counting": true }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/2026/road-gp/config.json
+++ b/src/data/2026/road-gp/config.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["U17", "U20", "U23", "SEN", "V35", "V40", "V45", "V50", "V55", "V60", "V65", "V70", "V75", "V80"],
+  "ageCategories": ["U17", "U20", "U23", "SEN", "V35", "V40", "V45", "V50", "V55", "V60", "V65", "V70", "V75", "V80"],
   "teamCategories": [
     { "id": "open",   "name": "Open",    "scorerCount": 10 },
     { "id": "ladies", "name": "Ladies",  "scorerCount": 5  },

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -1,4 +1,4 @@
-import type { Club, RaceResult, Series, SeriesConfig, TeamResults, TeamStandings } from './types';
+import type { Club, IndividualStandings, RaceResult, Series, SeriesConfig, TeamResults, TeamStandings } from './types';
 
 export function parseResultsCsv(csv: string): RaceResult[] {
   const lines = csv.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim().split('\n');
@@ -58,6 +58,17 @@ const fellStandingsFiles = import.meta.glob<{ default: TeamStandings }>(
 
 function standingsFilesForSeries(series: Series) {
   return series === 'road-gp' ? roadStandingsFiles : fellStandingsFiles;
+}
+
+const roadIndividualStandingsFiles = import.meta.glob<{ default: IndividualStandings }>(
+  '../data/*/road-gp/individual-standings.json', { eager: true }
+);
+const fellIndividualStandingsFiles = import.meta.glob<{ default: IndividualStandings }>(
+  '../data/*/fell/individual-standings.json', { eager: true }
+);
+
+function individualStandingsFilesForSeries(series: Series) {
+  return series === 'road-gp' ? roadIndividualStandingsFiles : fellIndividualStandingsFiles;
 }
 
 export function parseTeamResultsPath(path: string): { year: number; raceId: string; provisional: boolean } | null {
@@ -230,5 +241,35 @@ export function getClubs(year: number): Club[] {
 
 export function getSeriesConfig(year: number, series: Series): SeriesConfig {
   const files = series === 'road-gp' ? roadConfigFiles : fellConfigFiles;
-  return files[`../data/${year}/${series}/config.json`]?.default ?? { categories: [] };
+  return files[`../data/${year}/${series}/config.json`]?.default ?? { ageCategories: [] };
+}
+
+export function parseIndividualStandingsPath(path: string): { year: number } | null {
+  const match = path.match(/\/data\/(\d+)\/[^/]+\/individual-standings\.json$/);
+  if (!match) return null;
+  return { year: parseInt(match[1], 10) };
+}
+
+export function hasIndividualStandings(year: number, series: Series): boolean {
+  const files = individualStandingsFilesForSeries(series);
+  return `../data/${year}/${series}/individual-standings.json` in files;
+}
+
+export function getIndividualStandingsStaticPaths(series: Series) {
+  const files = individualStandingsFilesForSeries(series);
+  return Object.keys(files).flatMap(path => {
+    const parsed = parseIndividualStandingsPath(path);
+    if (!parsed) return [];
+    const { year } = parsed;
+    const standings = files[path].default;
+    const clubs = getClubs(year);
+    const config = getSeriesConfig(year, series);
+    const linkedRaceIds = standings.races.filter(raceId =>
+      hasResults(year, series, raceId)
+    );
+    return [{
+      params: { year: String(year) },
+      props: { year, standings, clubs, config, linkedRaceIds },
+    }];
+  });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -34,8 +34,15 @@ export interface Club {
   logo: string;        // filename in /public/images/clubs/, may not exist yet
 }
 
+export interface IndividualCategory {
+  id: string;
+  name: string;
+}
+
 export interface SeriesConfig {
-  categories: string[];
+  ageCategories: string[];           // renamed from categories
+  maxCountingRaces?: number;         // optional; when set, the page shows "Best N races count"
+  individualCategories?: IndividualCategory[];
   teamCategories?: TeamCategory[];
 }
 
@@ -84,4 +91,30 @@ export interface TeamStandings {
   provisional: boolean;
   races: string[];
   categories: TeamStandingsCategory[];
+}
+
+export interface IndividualRaceResult {
+  points: number;
+  counting: boolean;
+}
+
+export interface IndividualStandingsRunner {
+  position: number;
+  name: string;
+  club: string;
+  sex: string;          // 'M' or 'F'
+  ageCategory: string;  // e.g. 'SEN', 'V40'
+  total: number;
+  results: Record<string, IndividualRaceResult>;  // keyed by race id; only races the runner entered
+}
+
+export interface IndividualStandingsCategory {
+  category: string;   // id → IndividualCategory lookup via config.individualCategories
+  runners: IndividualStandingsRunner[];
+}
+
+export interface IndividualStandings {
+  provisional: boolean;
+  races: string[];    // ordered list of race ids; defines column order
+  categories: IndividualStandingsCategory[];
 }

--- a/src/pages/fell/[year]/[raceId]/results.astro
+++ b/src/pages/fell/[year]/[raceId]/results.astro
@@ -54,7 +54,7 @@ const showTeamResults = hasTeamResults(year, 'fell', raceId);
     </select>
     <select id="filter-cat" class="select select-bordered select-sm w-full sm:w-auto">
       <option value="">All Categories</option>
-      {config.categories.map(cat => <option value={cat}>{cat}</option>)}
+      {(config.ageCategories ?? []).map(cat => <option value={cat}>{cat}</option>)}
     </select>
     <div class="flex gap-1">
       <button class="btn btn-sm btn-active" data-sex="">All</button>

--- a/src/pages/fell/[year]/index.astro
+++ b/src/pages/fell/[year]/index.astro
@@ -3,7 +3,7 @@
 import Layout from '../../../components/Layout.astro';
 import RaceList from '../../../components/RaceList.astro';
 import { getCurrentYear, getAvailableYears, getRaces } from '../../../lib/data';
-import { hasTeamStandings } from '../../../lib/results';
+import { hasTeamStandings, hasIndividualStandings } from '../../../lib/results';
 
 export async function getStaticPaths() {
   const current = getCurrentYear();
@@ -19,6 +19,9 @@ const races = getRaces(year, 'fell');
 const standingsUrl = hasTeamStandings(year, 'fell')
   ? `/fell/${year}/team-standings`
   : undefined;
+const individualStandingsUrl = hasIndividualStandings(year, 'fell')
+  ? `/fell/${year}/individual-standings`
+  : undefined;
 ---
 
 <Layout title={`Fell Championship ${year}`}>
@@ -31,5 +34,6 @@ const standingsUrl = hasTeamStandings(year, 'fell')
     seriesBasePath="/fell"
     seriesLabel="Fell Championship"
     standingsUrl={standingsUrl}
+    individualStandingsUrl={individualStandingsUrl}
   />
 </Layout>

--- a/src/pages/fell/[year]/individual-standings.astro
+++ b/src/pages/fell/[year]/individual-standings.astro
@@ -1,0 +1,303 @@
+---
+// src/pages/fell/[year]/individual-standings.astro
+import Layout from '../../../components/Layout.astro';
+import { getRaces } from '../../../lib/data';
+import { getIndividualStandingsStaticPaths } from '../../../lib/results';
+import type { Club, SeriesConfig, IndividualStandings } from '../../../lib/types';
+
+export async function getStaticPaths() {
+  return getIndividualStandingsStaticPaths('fell');
+}
+
+interface Props {
+  year: number;
+  standings: IndividualStandings;
+  clubs: Club[];
+  config: SeriesConfig;
+  linkedRaceIds: string[];
+}
+
+const { year, standings, clubs, config } = Astro.props;
+const linkedRaceIds = new Set(Astro.props.linkedRaceIds);
+const races = getRaces(year, 'fell');
+const raceById = Object.fromEntries(races.map(r => [r.id, r]));
+const categoryById = Object.fromEntries((config.individualCategories ?? []).map(c => [c.id, c]));
+const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
+---
+
+<Layout title={`Fell Championship ${year} — Individual Standings`}>
+  <div class="mb-4">
+    <a href={`/fell/${year}`} class="btn btn-ghost btn-sm gap-1 -ml-3">← Fell Championship {year}</a>
+  </div>
+
+  <div class="mb-6">
+    <div class="flex items-center gap-3 flex-wrap">
+      <h1 class="text-2xl font-bold">Individual Standings</h1>
+      {standings.provisional && (
+        <span class="badge badge-warning badge-lg">Provisional</span>
+      )}
+    </div>
+    <p class="text-sm text-base-content/60 mt-1">{year} Inter Club Fell Championship</p>
+    {config.maxCountingRaces && (
+      <p class="text-sm text-base-content/60 mt-0.5">Best {config.maxCountingRaces} races count</p>
+    )}
+  </div>
+
+  <!-- Category tabs -->
+  <div class="overflow-x-auto -mx-4 px-4 mb-1">
+    <div class="flex border-b border-base-200 min-w-max" role="tablist">
+      {standings.categories.map((cat, i) => {
+        const label = categoryById[cat.category]?.name ?? cat.category;
+        return (
+          <button
+            class:list={[
+              'tab-btn px-4 py-2 text-sm border-b-2 -mb-px whitespace-nowrap transition-colors',
+              i === 0
+                ? 'border-primary font-medium'
+                : 'border-transparent text-base-content/50 hover:text-base-content',
+            ]}
+            data-target={`cat-panel-${i}`}
+            role="tab"
+            aria-selected={i === 0 ? 'true' : 'false'}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  </div>
+
+  <!-- Category panels -->
+  {standings.categories.map((cat, i) => {
+    const distinctAgeCats = [...new Set(cat.runners.map(r => r.ageCategory))].sort();
+    return (
+      <div id={`cat-panel-${i}`} data-panel class:list={['pt-3', i > 0 && 'hidden']} role="tabpanel">
+
+        <!-- Filter controls -->
+        <div class="flex flex-wrap gap-2 mb-3 items-center">
+          <div class="flex gap-1">
+            <button class="filter-sex btn btn-xs btn-active" data-value="">All</button>
+            <button class="filter-sex btn btn-xs btn-ghost" data-value="M">M</button>
+            <button class="filter-sex btn btn-xs btn-ghost" data-value="F">F</button>
+          </div>
+          {distinctAgeCats.length > 1 && (
+            <div class="flex gap-1 flex-wrap">
+              {distinctAgeCats.map(age => (
+                <button class="filter-age btn btn-xs btn-ghost" data-value={age}>{age}</button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <!-- Desktop table -->
+        <div class="hidden sm:block overflow-x-auto">
+          <table class="w-full border-collapse text-sm">
+            <thead>
+              <tr class="border-b border-base-200">
+                <th class="text-left py-2 pr-3 text-base-content/40 font-medium w-8">#</th>
+                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Name</th>
+                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Club</th>
+                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Cat</th>
+                {standings.races.map(raceId => {
+                  const race = raceById[raceId];
+                  const label = race?.shortName ?? raceId;
+                  const href = linkedRaceIds.has(raceId) ? `/fell/${year}/${raceId}/results` : null;
+                  return (
+                    <th class="text-right py-2 px-2 font-medium whitespace-nowrap">
+                      {href
+                        ? <a href={href} class="text-primary hover:underline">{label}</a>
+                        : <span class="text-base-content/20">{label}</span>
+                      }
+                    </th>
+                  );
+                })}
+                <th class="text-right py-2 pl-4 text-base-content/40 font-medium">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {cat.runners.map(runner => {
+                const clubName = clubById[runner.club]?.name ?? runner.club;
+                const catLabel = `${runner.sex}${runner.ageCategory}`;
+                return (
+                  <tr
+                    class="border-b border-base-200/50 last:border-0 hover:bg-base-200/30"
+                    data-sex={runner.sex}
+                    data-age-cat={runner.ageCategory}
+                  >
+                    <td class="py-2.5 pr-3 text-base-content/40 tabular-nums">{runner.position}</td>
+                    <td class="py-2.5 pr-4 font-semibold">{runner.name}</td>
+                    <td class="py-2.5 pr-4">{clubName}</td>
+                    <td class="py-2.5 pr-4 text-base-content/60 text-xs tabular-nums">{catLabel}</td>
+                    {standings.races.map(raceId => {
+                      const result = runner.results[raceId];
+                      if (!result) return <td class="py-2.5 px-2" />;
+                      return (
+                        <td class:list={[
+                          'py-2.5 px-2 text-right tabular-nums',
+                          !result.counting && 'text-base-content/30',
+                        ]}>
+                          <span class:list={[!result.counting && 'line-through']}>
+                            {result.points}
+                          </span>
+                        </td>
+                      );
+                    })}
+                    <td class="py-2.5 pl-4 text-right">
+                      <strong class="text-base-content/80">{runner.total}</strong>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Mobile view -->
+        <div class="sm:hidden">
+          <!-- Race key -->
+          <div class="flex flex-wrap gap-x-3 gap-y-1 py-3 border-b border-base-200 mb-1 text-xs text-base-content/40">
+            {standings.races.map(raceId => {
+              const race = raceById[raceId];
+              const label = race?.shortName ?? raceId;
+              const href = linkedRaceIds.has(raceId) ? `/fell/${year}/${raceId}/results` : null;
+              return (
+                <span>
+                  {href
+                    ? <a href={href} class="text-primary">{label}</a>
+                    : label
+                  }
+                  {' = '}{race?.name ?? raceId}
+                </span>
+              );
+            })}
+          </div>
+
+          {cat.runners.map((runner, runnerIdx) => {
+            const clubName = clubById[runner.club]?.name ?? runner.club;
+            const catLabel = `${runner.sex}${runner.ageCategory}`;
+            const detailId = `detail-${i}-${runnerIdx}`;
+            return (
+              <div
+                class="runner-card border-b border-base-200 last:border-0"
+                data-sex={runner.sex}
+                data-age-cat={runner.ageCategory}
+              >
+                <button
+                  class="standings-toggle w-full flex items-center gap-2 py-2.5 text-left"
+                  data-target={detailId}
+                  aria-expanded="false"
+                >
+                  <span class="w-6 shrink-0 text-sm text-base-content/40 tabular-nums">{runner.position}</span>
+                  <span class="flex-1 font-semibold">{runner.name}</span>
+                  <strong class="text-base-content/80">{runner.total}</strong>
+                  <span class="chevron text-base-content/30 text-xs ml-1 transition-transform">▾</span>
+                </button>
+                <div id={detailId} class="hidden pb-3 pl-8">
+                  <p class="text-sm text-base-content/60 mb-1.5">
+                    {clubName} · <span class="font-mono text-xs">{catLabel}</span>
+                  </p>
+                  <div class="flex flex-wrap gap-1.5">
+                    {standings.races.filter(raceId => runner.results[raceId]).map(raceId => {
+                      const result = runner.results[raceId];
+                      const race = raceById[raceId];
+                      const label = race?.shortName ?? raceId;
+                      const href = linkedRaceIds.has(raceId) ? `/fell/${year}/${raceId}/results` : null;
+                      return (
+                        <div class:list={[
+                          'rounded px-2.5 py-1 text-center text-sm min-w-[44px]',
+                          result.counting ? 'bg-base-200' : 'bg-base-200/40',
+                        ]}>
+                          {href
+                            ? <a href={href} class:list={['block text-[10px] mb-0.5', result.counting ? 'text-primary' : 'text-base-content/30']}>{label}</a>
+                            : <span class:list={['block text-[10px] mb-0.5', result.counting ? 'text-base-content/40' : 'text-base-content/20']}>{label}</span>
+                          }
+                          <span class:list={[
+                            result.counting ? 'font-semibold' : 'text-base-content/30 line-through',
+                          ]}>{result.points}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+      </div>
+    );
+  })}
+</Layout>
+
+<script>
+  // Tab switching
+  const tabs = document.querySelectorAll<HTMLButtonElement>('.tab-btn');
+  tabs.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const targetId = btn.dataset.target!;
+      tabs.forEach(t => {
+        const active = t === btn;
+        t.classList.toggle('border-primary', active);
+        t.classList.toggle('font-medium', active);
+        t.classList.toggle('border-transparent', !active);
+        t.classList.toggle('text-base-content/50', !active);
+        t.setAttribute('aria-selected', active ? 'true' : 'false');
+      });
+      document.querySelectorAll<HTMLElement>('[id^="cat-panel-"]').forEach(panel => {
+        panel.classList.toggle('hidden', panel.id !== targetId);
+      });
+    });
+  });
+
+  // Mobile accordion
+  document.querySelectorAll<HTMLButtonElement>('.standings-toggle').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const targetId = btn.dataset.target!;
+      const detail = document.getElementById(targetId)!;
+      const isOpen = !detail.classList.contains('hidden');
+      detail.classList.toggle('hidden', isOpen);
+      btn.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+      btn.querySelector('.chevron')?.classList.toggle('rotate-180', !isOpen);
+    });
+  });
+
+  // Filtering
+  function filterPanel(panel: HTMLElement) {
+    const activeSex = panel.querySelector<HTMLElement>('.filter-sex.btn-active')?.dataset.value ?? '';
+    const activeAges = [...panel.querySelectorAll<HTMLElement>('.filter-age.btn-active')]
+      .map(b => b.dataset.value ?? '');
+
+    panel.querySelectorAll<HTMLElement>('tr[data-sex]').forEach(row => {
+      const sexMatch = !activeSex || row.dataset.sex === activeSex;
+      const ageMatch = activeAges.length === 0 || activeAges.includes(row.dataset.ageCat ?? '');
+      row.style.display = sexMatch && ageMatch ? '' : 'none';
+    });
+
+    panel.querySelectorAll<HTMLElement>('.runner-card').forEach(card => {
+      const sexMatch = !activeSex || card.dataset.sex === activeSex;
+      const ageMatch = activeAges.length === 0 || activeAges.includes(card.dataset.ageCat ?? '');
+      card.style.display = sexMatch && ageMatch ? '' : 'none';
+    });
+  }
+
+  document.querySelectorAll<HTMLButtonElement>('.filter-sex').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const panel = btn.closest<HTMLElement>('[data-panel]')!;
+      panel.querySelectorAll<HTMLElement>('.filter-sex').forEach(b => {
+        const active = b === btn;
+        b.classList.toggle('btn-active', active);
+        b.classList.toggle('btn-ghost', !active);
+      });
+      filterPanel(panel);
+    });
+  });
+
+  document.querySelectorAll<HTMLButtonElement>('.filter-age').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const panel = btn.closest<HTMLElement>('[data-panel]')!;
+      btn.classList.toggle('btn-active');
+      btn.classList.toggle('btn-ghost');
+      filterPanel(panel);
+    });
+  });
+</script>

--- a/src/pages/road-gp/[year]/[raceId]/results.astro
+++ b/src/pages/road-gp/[year]/[raceId]/results.astro
@@ -54,7 +54,7 @@ const showTeamResults = hasTeamResults(year, 'road-gp', raceId);
     </select>
     <select id="filter-cat" class="select select-bordered select-sm w-full sm:w-auto">
       <option value="">All Categories</option>
-      {config.categories.map(cat => <option value={cat}>{cat}</option>)}
+      {(config.ageCategories ?? []).map(cat => <option value={cat}>{cat}</option>)}
     </select>
     <div class="flex gap-1">
       <button class="btn btn-sm btn-active" data-sex="">All</button>

--- a/src/pages/road-gp/[year]/index.astro
+++ b/src/pages/road-gp/[year]/index.astro
@@ -3,7 +3,7 @@
 import Layout from '../../../components/Layout.astro';
 import RaceList from '../../../components/RaceList.astro';
 import { getCurrentYear, getAvailableYears, getRaces } from '../../../lib/data';
-import { hasTeamStandings } from '../../../lib/results';
+import { hasTeamStandings, hasIndividualStandings } from '../../../lib/results';
 
 export async function getStaticPaths() {
   const current = getCurrentYear();
@@ -19,6 +19,9 @@ const races = getRaces(year, 'road-gp');
 const standingsUrl = hasTeamStandings(year, 'road-gp')
   ? `/road-gp/${year}/team-standings`
   : undefined;
+const individualStandingsUrl = hasIndividualStandings(year, 'road-gp')
+  ? `/road-gp/${year}/individual-standings`
+  : undefined;
 ---
 
 <Layout title={`Road Grand Prix ${year}`}>
@@ -31,5 +34,6 @@ const standingsUrl = hasTeamStandings(year, 'road-gp')
     seriesBasePath="/road-gp"
     seriesLabel="Road Grand Prix"
     standingsUrl={standingsUrl}
+    individualStandingsUrl={individualStandingsUrl}
   />
 </Layout>

--- a/src/pages/road-gp/[year]/individual-standings.astro
+++ b/src/pages/road-gp/[year]/individual-standings.astro
@@ -1,0 +1,303 @@
+---
+// src/pages/road-gp/[year]/individual-standings.astro
+import Layout from '../../../components/Layout.astro';
+import { getRaces } from '../../../lib/data';
+import { getIndividualStandingsStaticPaths } from '../../../lib/results';
+import type { Club, SeriesConfig, IndividualStandings } from '../../../lib/types';
+
+export async function getStaticPaths() {
+  return getIndividualStandingsStaticPaths('road-gp');
+}
+
+interface Props {
+  year: number;
+  standings: IndividualStandings;
+  clubs: Club[];
+  config: SeriesConfig;
+  linkedRaceIds: string[];
+}
+
+const { year, standings, clubs, config } = Astro.props;
+const linkedRaceIds = new Set(Astro.props.linkedRaceIds);
+const races = getRaces(year, 'road-gp');
+const raceById = Object.fromEntries(races.map(r => [r.id, r]));
+const categoryById = Object.fromEntries((config.individualCategories ?? []).map(c => [c.id, c]));
+const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
+---
+
+<Layout title={`Road Grand Prix ${year} — Individual Standings`}>
+  <div class="mb-4">
+    <a href={`/road-gp/${year}`} class="btn btn-ghost btn-sm gap-1 -ml-3">← Road Grand Prix {year}</a>
+  </div>
+
+  <div class="mb-6">
+    <div class="flex items-center gap-3 flex-wrap">
+      <h1 class="text-2xl font-bold">Individual Standings</h1>
+      {standings.provisional && (
+        <span class="badge badge-warning badge-lg">Provisional</span>
+      )}
+    </div>
+    <p class="text-sm text-base-content/60 mt-1">{year} Inter Club Road Grand Prix</p>
+    {config.maxCountingRaces && (
+      <p class="text-sm text-base-content/60 mt-0.5">Best {config.maxCountingRaces} races count</p>
+    )}
+  </div>
+
+  <!-- Category tabs -->
+  <div class="overflow-x-auto -mx-4 px-4 mb-1">
+    <div class="flex border-b border-base-200 min-w-max" role="tablist">
+      {standings.categories.map((cat, i) => {
+        const label = categoryById[cat.category]?.name ?? cat.category;
+        return (
+          <button
+            class:list={[
+              'tab-btn px-4 py-2 text-sm border-b-2 -mb-px whitespace-nowrap transition-colors',
+              i === 0
+                ? 'border-primary font-medium'
+                : 'border-transparent text-base-content/50 hover:text-base-content',
+            ]}
+            data-target={`cat-panel-${i}`}
+            role="tab"
+            aria-selected={i === 0 ? 'true' : 'false'}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  </div>
+
+  <!-- Category panels -->
+  {standings.categories.map((cat, i) => {
+    const distinctAgeCats = [...new Set(cat.runners.map(r => r.ageCategory))].sort();
+    return (
+      <div id={`cat-panel-${i}`} data-panel class:list={['pt-3', i > 0 && 'hidden']} role="tabpanel">
+
+        <!-- Filter controls -->
+        <div class="flex flex-wrap gap-2 mb-3 items-center">
+          <div class="flex gap-1">
+            <button class="filter-sex btn btn-xs btn-active" data-value="">All</button>
+            <button class="filter-sex btn btn-xs btn-ghost" data-value="M">M</button>
+            <button class="filter-sex btn btn-xs btn-ghost" data-value="F">F</button>
+          </div>
+          {distinctAgeCats.length > 1 && (
+            <div class="flex gap-1 flex-wrap">
+              {distinctAgeCats.map(age => (
+                <button class="filter-age btn btn-xs btn-ghost" data-value={age}>{age}</button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <!-- Desktop table -->
+        <div class="hidden sm:block overflow-x-auto">
+          <table class="w-full border-collapse text-sm">
+            <thead>
+              <tr class="border-b border-base-200">
+                <th class="text-left py-2 pr-3 text-base-content/40 font-medium w-8">#</th>
+                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Name</th>
+                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Club</th>
+                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Cat</th>
+                {standings.races.map(raceId => {
+                  const race = raceById[raceId];
+                  const label = race?.shortName ?? raceId;
+                  const href = linkedRaceIds.has(raceId) ? `/road-gp/${year}/${raceId}/results` : null;
+                  return (
+                    <th class="text-right py-2 px-2 font-medium whitespace-nowrap">
+                      {href
+                        ? <a href={href} class="text-primary hover:underline">{label}</a>
+                        : <span class="text-base-content/20">{label}</span>
+                      }
+                    </th>
+                  );
+                })}
+                <th class="text-right py-2 pl-4 text-base-content/40 font-medium">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {cat.runners.map(runner => {
+                const clubName = clubById[runner.club]?.name ?? runner.club;
+                const catLabel = `${runner.sex}${runner.ageCategory}`;
+                return (
+                  <tr
+                    class="border-b border-base-200/50 last:border-0 hover:bg-base-200/30"
+                    data-sex={runner.sex}
+                    data-age-cat={runner.ageCategory}
+                  >
+                    <td class="py-2.5 pr-3 text-base-content/40 tabular-nums">{runner.position}</td>
+                    <td class="py-2.5 pr-4 font-semibold">{runner.name}</td>
+                    <td class="py-2.5 pr-4">{clubName}</td>
+                    <td class="py-2.5 pr-4 text-base-content/60 text-xs tabular-nums">{catLabel}</td>
+                    {standings.races.map(raceId => {
+                      const result = runner.results[raceId];
+                      if (!result) return <td class="py-2.5 px-2" />;
+                      return (
+                        <td class:list={[
+                          'py-2.5 px-2 text-right tabular-nums',
+                          !result.counting && 'text-base-content/30',
+                        ]}>
+                          <span class:list={[!result.counting && 'line-through']}>
+                            {result.points}
+                          </span>
+                        </td>
+                      );
+                    })}
+                    <td class="py-2.5 pl-4 text-right">
+                      <strong class="text-base-content/80">{runner.total}</strong>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Mobile view -->
+        <div class="sm:hidden">
+          <!-- Race key -->
+          <div class="flex flex-wrap gap-x-3 gap-y-1 py-3 border-b border-base-200 mb-1 text-xs text-base-content/40">
+            {standings.races.map(raceId => {
+              const race = raceById[raceId];
+              const label = race?.shortName ?? raceId;
+              const href = linkedRaceIds.has(raceId) ? `/road-gp/${year}/${raceId}/results` : null;
+              return (
+                <span>
+                  {href
+                    ? <a href={href} class="text-primary">{label}</a>
+                    : label
+                  }
+                  {' = '}{race?.name ?? raceId}
+                </span>
+              );
+            })}
+          </div>
+
+          {cat.runners.map((runner, runnerIdx) => {
+            const clubName = clubById[runner.club]?.name ?? runner.club;
+            const catLabel = `${runner.sex}${runner.ageCategory}`;
+            const detailId = `detail-${i}-${runnerIdx}`;
+            return (
+              <div
+                class="runner-card border-b border-base-200 last:border-0"
+                data-sex={runner.sex}
+                data-age-cat={runner.ageCategory}
+              >
+                <button
+                  class="standings-toggle w-full flex items-center gap-2 py-2.5 text-left"
+                  data-target={detailId}
+                  aria-expanded="false"
+                >
+                  <span class="w-6 shrink-0 text-sm text-base-content/40 tabular-nums">{runner.position}</span>
+                  <span class="flex-1 font-semibold">{runner.name}</span>
+                  <strong class="text-base-content/80">{runner.total}</strong>
+                  <span class="chevron text-base-content/30 text-xs ml-1 transition-transform">▾</span>
+                </button>
+                <div id={detailId} class="hidden pb-3 pl-8">
+                  <p class="text-sm text-base-content/60 mb-1.5">
+                    {clubName} · <span class="font-mono text-xs">{catLabel}</span>
+                  </p>
+                  <div class="flex flex-wrap gap-1.5">
+                    {standings.races.filter(raceId => runner.results[raceId]).map(raceId => {
+                      const result = runner.results[raceId];
+                      const race = raceById[raceId];
+                      const label = race?.shortName ?? raceId;
+                      const href = linkedRaceIds.has(raceId) ? `/road-gp/${year}/${raceId}/results` : null;
+                      return (
+                        <div class:list={[
+                          'rounded px-2.5 py-1 text-center text-sm min-w-[44px]',
+                          result.counting ? 'bg-base-200' : 'bg-base-200/40',
+                        ]}>
+                          {href
+                            ? <a href={href} class:list={['block text-[10px] mb-0.5', result.counting ? 'text-primary' : 'text-base-content/30']}>{label}</a>
+                            : <span class:list={['block text-[10px] mb-0.5', result.counting ? 'text-base-content/40' : 'text-base-content/20']}>{label}</span>
+                          }
+                          <span class:list={[
+                            result.counting ? 'font-semibold' : 'text-base-content/30 line-through',
+                          ]}>{result.points}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+      </div>
+    );
+  })}
+</Layout>
+
+<script>
+  // Tab switching
+  const tabs = document.querySelectorAll<HTMLButtonElement>('.tab-btn');
+  tabs.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const targetId = btn.dataset.target!;
+      tabs.forEach(t => {
+        const active = t === btn;
+        t.classList.toggle('border-primary', active);
+        t.classList.toggle('font-medium', active);
+        t.classList.toggle('border-transparent', !active);
+        t.classList.toggle('text-base-content/50', !active);
+        t.setAttribute('aria-selected', active ? 'true' : 'false');
+      });
+      document.querySelectorAll<HTMLElement>('[id^="cat-panel-"]').forEach(panel => {
+        panel.classList.toggle('hidden', panel.id !== targetId);
+      });
+    });
+  });
+
+  // Mobile accordion
+  document.querySelectorAll<HTMLButtonElement>('.standings-toggle').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const targetId = btn.dataset.target!;
+      const detail = document.getElementById(targetId)!;
+      const isOpen = !detail.classList.contains('hidden');
+      detail.classList.toggle('hidden', isOpen);
+      btn.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+      btn.querySelector('.chevron')?.classList.toggle('rotate-180', !isOpen);
+    });
+  });
+
+  // Filtering
+  function filterPanel(panel: HTMLElement) {
+    const activeSex = panel.querySelector<HTMLElement>('.filter-sex.btn-active')?.dataset.value ?? '';
+    const activeAges = [...panel.querySelectorAll<HTMLElement>('.filter-age.btn-active')]
+      .map(b => b.dataset.value ?? '');
+
+    panel.querySelectorAll<HTMLElement>('tr[data-sex]').forEach(row => {
+      const sexMatch = !activeSex || row.dataset.sex === activeSex;
+      const ageMatch = activeAges.length === 0 || activeAges.includes(row.dataset.ageCat ?? '');
+      row.style.display = sexMatch && ageMatch ? '' : 'none';
+    });
+
+    panel.querySelectorAll<HTMLElement>('.runner-card').forEach(card => {
+      const sexMatch = !activeSex || card.dataset.sex === activeSex;
+      const ageMatch = activeAges.length === 0 || activeAges.includes(card.dataset.ageCat ?? '');
+      card.style.display = sexMatch && ageMatch ? '' : 'none';
+    });
+  }
+
+  document.querySelectorAll<HTMLButtonElement>('.filter-sex').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const panel = btn.closest<HTMLElement>('[data-panel]')!;
+      panel.querySelectorAll<HTMLElement>('.filter-sex').forEach(b => {
+        const active = b === btn;
+        b.classList.toggle('btn-active', active);
+        b.classList.toggle('btn-ghost', !active);
+      });
+      filterPanel(panel);
+    });
+  });
+
+  document.querySelectorAll<HTMLButtonElement>('.filter-age').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const panel = btn.closest<HTMLElement>('[data-panel]')!;
+      btn.classList.toggle('btn-active');
+      btn.classList.toggle('btn-ghost');
+      filterPanel(panel);
+    });
+  });
+</script>

--- a/tests/lib/results.test.ts
+++ b/tests/lib/results.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseResultsCsv, parseTeamResultsPath, parseTeamStandingsPath } from '../../src/lib/results';
+import { parseResultsCsv, parseTeamResultsPath, parseTeamStandingsPath, parseIndividualStandingsPath } from '../../src/lib/results';
 
 describe('parseResultsCsv', () => {
   const sample = [
@@ -102,6 +102,33 @@ describe('parseTeamStandingsPath', () => {
 
   it('returns null for a config path', () => {
     expect(parseTeamStandingsPath('../data/2026/road-gp/config.json'))
+      .toBeNull();
+  });
+});
+
+describe('parseIndividualStandingsPath', () => {
+  it('parses a road-gp individual standings path', () => {
+    expect(parseIndividualStandingsPath('../data/2026/road-gp/individual-standings.json'))
+      .toEqual({ year: 2026 });
+  });
+
+  it('parses a fell individual standings path', () => {
+    expect(parseIndividualStandingsPath('../data/2026/fell/individual-standings.json'))
+      .toEqual({ year: 2026 });
+  });
+
+  it('returns null for a team-standings path', () => {
+    expect(parseIndividualStandingsPath('../data/2026/fell/team-standings.json'))
+      .toBeNull();
+  });
+
+  it('returns null for a config path', () => {
+    expect(parseIndividualStandingsPath('../data/2026/fell/config.json'))
+      .toBeNull();
+  });
+
+  it('returns null for an individual results path', () => {
+    expect(parseIndividualStandingsPath('../data/2026/fell/results/race-1.csv'))
       .toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Adds individual standings pages for both the Fell Championship and Road Grand Prix series, rendered from pre-computed `individual-standings.json` files (same pattern as existing team standings)
- Renames `SeriesConfig.categories` → `ageCategories` throughout (types, config files, consuming pages) and adds `maxCountingRaces` and `individualCategories` config fields
- Non-counting race results (when a runner does more races than count toward their total) are shown dimmed with strikethrough; pages display "Best N races count" when configured

## Key design decisions

- **Sparse data format**: each runner's `results` is a map keyed by race ID — only races they actually ran are present, keeping the JSON compact for runners who did just 1–2 races
- **Pre-computed externally**: standings are generated outside the build and dropped as JSON files; the site just renders them
- **Category tabs + filtering**: standings split into configurable `individualCategories` tabs (e.g. Senior Men, V40 Women); each tab has sex (M/F/All) and age-category toggle filters using `data-sex`/`data-age-cat` attributes on rows
- **Mobile-first accordion**: collapsed rows show name + total; expanded shows club, combined category label (e.g. `MSEN`, `FV40`), and race chips matching the desktop column order

## Test Plan

- [ ] All 31 unit tests pass (`npm test`)
- [ ] `npm run build` succeeds (18 pages including the new `/fell/2026/individual-standings`)
- [ ] Navigate to `/fell/2026` — "Individual Standings →" button appears alongside "Team Standings →"
- [ ] Navigate to `/fell/2026/individual-standings` — provisional badge shown, "Best 3 races count" note, two category tabs (Senior Men / Senior Women)
- [ ] Senior Men tab: J. Smith's fell-race-3 score (15) is dimmed with strikethrough
- [ ] M / F filter buttons hide/show rows correctly
- [ ] On narrow viewport (< 640px): accordion rows appear, expanded detail shows club, category, and race chips
- [ ] Non-counting chip (fell-race-3 for J. Smith) is dimmed with strikethrough on the chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)