### PR TITLE
feat: add series awards section to year index pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,5 +244,33 @@ Season individual standings are computed externally and placed at `src/data/{yea
 
 - `ageCategories` — age bands shown in the results filter bar (note: formerly named `categories` — do not use the old name)
 - `maxCountingRaces` — optional; when set, individual standings page shows "Best N races count" and marks non-counting results
-- `individualCategories` — optional; defines which tabs appear on the individual standings page and in what order; `id` is referenced by `individual-standings.json`
-- `teamCategories` — defines team scoring groups; `id` is referenced by team results JSON files
+- `individualCategories` — optional; defines which tabs appear on the individual standings page and in what order; `id` is referenced by `individual-standings.json` and `awards.json`; optional `sex: "M" | "F"` field controls column placement on the awards section (absent = Overall, full-width)
+- `teamCategories` — defines team scoring groups; `id` is referenced by team results JSON files and `awards.json`
+
+### Awards JSON schema
+
+End-of-season award winners are placed at `src/data/{year}/{series}/awards.json`. File absence means no awards section is shown on the series index page.
+
+```json
+{
+  "teamAwards": [
+    { "category": "open",   "club": "wesham" },
+    { "category": "ladies", "club": "lytham" }
+  ],
+  "individualAwards": [
+    {
+      "category": "sen-m",
+      "awards": [
+        { "position": 1, "name": "L. Minns", "club": "blackpool" },
+        { "position": 3, "name": "T. Guest", "club": "red-rose" }
+      ]
+    }
+  ]
+}
+```
+
+- `teamAwards[].category` — id matching `teamCategories[].id` in `config.json`; one award per team category (the winning club only)
+- `individualAwards[].category` — id matching `individualCategories[].id` in `config.json`
+- `individualAwards[].awards[].position` — explicit; gaps are allowed (e.g. position 2 absent means no 2nd-place award was given)
+- `club` — id matching `clubs.json[].id`; display name resolved at build time
+- The awards section appears above the race list and only renders when this file exists

--- a/docs/superpowers/plans/2026-04-28-series-awards.md
+++ b/docs/superpowers/plans/2026-04-28-series-awards.md
@@ -1,0 +1,660 @@
+# Series Awards Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Series Winners" section above the race list on series year index pages, driven by a manually-authored `awards.json` file per year/series.
+
+**Architecture:** New `awards.json` data files are loaded via `import.meta.glob` in `results.ts`. Index pages resolve category and club display names from config/clubs data, then pass a fully-resolved `ResolvedSeriesAwards` object to `RaceList`, which delegates rendering to a new `SeriesAwards.astro` component. The component renders team winners as compact pills and individual winners in an Overall (full-width) + Male/Female two-column grid.
+
+**Tech Stack:** Astro v6, TypeScript (strict), Tailwind CSS v4, DaisyUI v5. Build validation via `npm run build`. No new unit tests — all new functions depend on `import.meta.glob` and are validated by the build per the project's established pattern.
+
+---
+
+### Task 1: Add types to `src/lib/types.ts`
+
+**Files:**
+- Modify: `src/lib/types.ts`
+
+- [ ] **Step 1: Add `sex` to `IndividualCategory` and add all new interfaces**
+
+Replace the existing `IndividualCategory` interface and append the new types at the end of `src/lib/types.ts`:
+
+```typescript
+// Replace lines 37-40 (IndividualCategory interface):
+export interface IndividualCategory {
+  id: string;
+  name: string;
+  sex?: 'M' | 'F';
+}
+```
+
+Append to the end of `src/lib/types.ts`:
+
+```typescript
+// Raw awards data (from awards.json)
+export interface TeamAward {
+  category: string;  // references teamCategories[].id in config.json
+  club: string;      // references clubs.json id
+}
+
+export interface IndividualAwardEntry {
+  position: number;
+  name: string;
+  club: string;      // references clubs.json id
+}
+
+export interface IndividualAward {
+  category: string;  // references individualCategories[].id in config.json
+  awards: IndividualAwardEntry[];
+}
+
+export interface SeriesAwards {
+  teamAwards: TeamAward[];
+  individualAwards: IndividualAward[];
+}
+
+// Resolved awards data (display names looked up, categories partitioned by sex)
+export interface ResolvedTeamAward {
+  categoryName: string;
+  clubName: string;
+}
+
+export interface ResolvedIndividualAwardEntry {
+  position: number;
+  name: string;
+  clubName: string;
+}
+
+export interface ResolvedIndividualAward {
+  categoryName: string;
+  awards: ResolvedIndividualAwardEntry[];
+}
+
+export interface ResolvedSeriesAwards {
+  teamAwards: ResolvedTeamAward[];
+  overallAwards: ResolvedIndividualAward[];  // sex field absent on config category
+  maleAwards: ResolvedIndividualAward[];     // sex === 'M' on config category
+  femaleAwards: ResolvedIndividualAward[];   // sex === 'F' on config category
+}
+```
+
+- [ ] **Step 2: Verify build still compiles**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds with no TypeScript errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/types.ts
+git commit -m "feat: add SeriesAwards and ResolvedSeriesAwards types"
+```
+
+---
+
+### Task 2: Add data loading to `src/lib/results.ts`
+
+**Files:**
+- Modify: `src/lib/results.ts`
+
+- [ ] **Step 1: Add glob declarations after the existing `fellIndividualStandingsFiles` glob block (around line 68)**
+
+Add these lines immediately after the `fellIndividualStandingsFiles` block:
+
+```typescript
+const roadAwardsFiles = import.meta.glob<{ default: SeriesAwards }>(
+  '../data/*/road-gp/awards.json', { eager: true }
+);
+const fellAwardsFiles = import.meta.glob<{ default: SeriesAwards }>(
+  '../data/*/fell/awards.json', { eager: true }
+);
+
+function awardsFilesForSeries(series: Series) {
+  return series === 'road-gp' ? roadAwardsFiles : fellAwardsFiles;
+}
+```
+
+- [ ] **Step 2: Update the import at the top of `results.ts` to include `SeriesAwards`**
+
+The current import line is:
+```typescript
+import type { Club, IndividualStandings, RaceResult, Series, SeriesConfig, TeamResults, TeamStandings } from './types';
+```
+
+Replace it with:
+```typescript
+import type { Club, IndividualStandings, RaceResult, Series, SeriesAwards, SeriesConfig, TeamResults, TeamStandings } from './types';
+```
+
+- [ ] **Step 3: Add `hasAwards` and `getAwards` export functions**
+
+Add these two functions at the end of `results.ts`, after `getIndividualStandingsStaticPaths`:
+
+```typescript
+export function hasAwards(year: number, series: Series): boolean {
+  const files = awardsFilesForSeries(series);
+  return `../data/${year}/${series}/awards.json` in files;
+}
+
+export function getAwards(year: number, series: Series): SeriesAwards | null {
+  const files = awardsFilesForSeries(series);
+  return files[`../data/${year}/${series}/awards.json`]?.default ?? null;
+}
+```
+
+- [ ] **Step 4: Verify build still compiles**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds with no TypeScript errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/results.ts
+git commit -m "feat: add hasAwards and getAwards data loaders"
+```
+
+---
+
+### Task 3: Create `src/components/SeriesAwards.astro`
+
+**Files:**
+- Create: `src/components/SeriesAwards.astro`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/SeriesAwards.astro` with the following content:
+
+```astro
+---
+import type { ResolvedSeriesAwards } from '../lib/types';
+
+interface Props {
+  awards: ResolvedSeriesAwards;
+}
+
+const { awards } = Astro.props;
+
+function positionLabel(pos: number): string {
+  if (pos === 1) return '🥇';
+  if (pos === 2) return '🥈';
+  if (pos === 3) return '🥉';
+  const mod10 = pos % 10;
+  const mod100 = pos % 100;
+  const suffix =
+    mod10 === 1 && mod100 !== 11 ? 'st' :
+    mod10 === 2 && mod100 !== 12 ? 'nd' :
+    mod10 === 3 && mod100 !== 13 ? 'rd' : 'th';
+  return `${pos}${suffix}`;
+}
+
+const hasMF = awards.maleAwards.length > 0 || awards.femaleAwards.length > 0;
+---
+
+<div class="card bg-base-200 mb-6">
+  <div class="card-body p-4 gap-4">
+    <h2 class="card-title text-base">🏆 Series Winners</h2>
+
+    {awards.teamAwards.length > 0 && (
+      <div>
+        <p class="text-xs uppercase tracking-wider text-base-content/50 mb-2">Team</p>
+        <div class="flex flex-wrap gap-2">
+          {awards.teamAwards.map(ta => (
+            <span class="badge badge-lg gap-1 font-normal">
+              🏆 <span class="text-base-content/60">{ta.categoryName}:</span>
+              <span class="font-semibold">{ta.clubName}</span>
+            </span>
+          ))}
+        </div>
+      </div>
+    )}
+
+    {(awards.overallAwards.length > 0 || hasMF) && (
+      <div>
+        <p class="text-xs uppercase tracking-wider text-base-content/50 mb-2">Individual</p>
+
+        {awards.overallAwards.length > 0 && (
+          <div class="flex flex-col gap-2 mb-3">
+            {awards.overallAwards.map(cat => (
+              <div class="bg-base-100 rounded-lg p-3">
+                <p class="text-xs text-base-content/50 mb-1">{cat.categoryName}</p>
+                <div class="flex flex-col gap-1">
+                  {cat.awards.map(a => (
+                    <div class="flex items-baseline gap-2 text-sm">
+                      <span class="w-6 shrink-0">{positionLabel(a.position)}</span>
+                      <span class="font-medium">{a.name}</span>
+                      <span class="text-base-content/50 text-xs">{a.clubName}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {hasMF && (
+          <div class="grid grid-cols-2 gap-2">
+            <div class="flex flex-col gap-2">
+              {awards.maleAwards.map(cat => (
+                <div class="bg-base-100 rounded-lg p-3">
+                  <p class="text-xs text-base-content/50 mb-1">{cat.categoryName}</p>
+                  <div class="flex flex-col gap-1">
+                    {cat.awards.map(a => (
+                      <div class="flex items-baseline gap-2 text-sm">
+                        <span class="w-6 shrink-0">{positionLabel(a.position)}</span>
+                        <span class="font-medium">{a.name}</span>
+                        <span class="text-base-content/50 text-xs">{a.clubName}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div class="flex flex-col gap-2">
+              {awards.femaleAwards.map(cat => (
+                <div class="bg-base-100 rounded-lg p-3">
+                  <p class="text-xs text-base-content/50 mb-1">{cat.categoryName}</p>
+                  <div class="flex flex-col gap-1">
+                    {cat.awards.map(a => (
+                      <div class="flex items-baseline gap-2 text-sm">
+                        <span class="w-6 shrink-0">{positionLabel(a.position)}</span>
+                        <span class="font-medium">{a.name}</span>
+                        <span class="text-base-content/50 text-xs">{a.clubName}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    )}
+  </div>
+</div>
+```
+
+- [ ] **Step 2: Verify build still compiles**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds. (Component is not yet used, so no visible change.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/SeriesAwards.astro
+git commit -m "feat: add SeriesAwards component"
+```
+
+---
+
+### Task 4: Wire awards into `RaceList` and both index pages
+
+**Files:**
+- Modify: `src/components/RaceList.astro`
+- Modify: `src/pages/fell/[year]/index.astro`
+- Modify: `src/pages/road-gp/[year]/index.astro`
+
+- [ ] **Step 1: Update `src/components/RaceList.astro`**
+
+Replace the full file with:
+
+```astro
+---
+// src/components/RaceList.astro
+import type { Race, ResolvedSeriesAwards, Series } from '../lib/types';
+import RaceCard from './RaceCard.astro';
+import SeriesAwards from './SeriesAwards.astro';
+import YearFilter from './YearFilter.astro';
+
+interface Props {
+  races: Race[];
+  year: number;
+  series: Series;
+  availableYears: number[];
+  currentYear: number;
+  seriesBasePath: string;
+  seriesLabel: string;
+  standingsUrl?: string;
+  individualStandingsUrl?: string;
+  awards?: ResolvedSeriesAwards;
+}
+
+const { races, year, series, availableYears, currentYear, seriesBasePath, seriesLabel, standingsUrl, individualStandingsUrl, awards } = Astro.props;
+---
+
+<div>
+  <div class="flex items-center justify-between mb-6 flex-wrap gap-3">
+    <h1 class="text-2xl font-bold">{seriesLabel} — {year}</h1>
+    {availableYears.length > 1 && (
+      <YearFilter
+        years={availableYears}
+        activeYear={year}
+        seriesBasePath={seriesBasePath}
+        currentYear={currentYear}
+      />
+    )}
+  </div>
+
+  {(standingsUrl || individualStandingsUrl) && (
+    <div class="mb-4 flex gap-2 flex-wrap">
+      {standingsUrl && (
+        <a href={standingsUrl} class="btn btn-sm btn-outline gap-1">
+          Team Standings →
+        </a>
+      )}
+      {individualStandingsUrl && (
+        <a href={individualStandingsUrl} class="btn btn-sm btn-outline gap-1">
+          Individual Standings →
+        </a>
+      )}
+    </div>
+  )}
+
+  {awards && <SeriesAwards awards={awards} />}
+
+  {races.length === 0 ? (
+    <p class="text-base-content/60">No races found for {year}.</p>
+  ) : (
+    <div class="flex flex-col gap-4">
+      {races.map(race => (
+        <RaceCard race={race} year={year} series={series} />
+      ))}
+    </div>
+  )}
+</div>
+```
+
+- [ ] **Step 2: Update `src/pages/fell/[year]/index.astro`**
+
+Replace the full file with:
+
+```astro
+---
+// src/pages/fell/[year]/index.astro
+import Layout from '../../../components/Layout.astro';
+import RaceList from '../../../components/RaceList.astro';
+import { getCurrentYear, getAvailableYears, getRaces } from '../../../lib/data';
+import { getAwards, getClubs, getSeriesConfig, hasAwards, hasIndividualStandings, hasTeamStandings } from '../../../lib/results';
+import type { ResolvedSeriesAwards } from '../../../lib/types';
+
+export async function getStaticPaths() {
+  const current = getCurrentYear();
+  const years = getAvailableYears('fell').filter(y => y !== current);
+  return years.map(year => ({ params: { year: String(year) } }));
+}
+
+const { year: yearParam } = Astro.params;
+const year = parseInt(yearParam);
+const currentYear = getCurrentYear();
+const availableYears = getAvailableYears('fell');
+const races = getRaces(year, 'fell');
+const standingsUrl = hasTeamStandings(year, 'fell')
+  ? `/fell/${year}/team-standings`
+  : undefined;
+const individualStandingsUrl = hasIndividualStandings(year, 'fell')
+  ? `/fell/${year}/individual-standings`
+  : undefined;
+
+let awards: ResolvedSeriesAwards | undefined;
+if (hasAwards(year, 'fell')) {
+  const raw = getAwards(year, 'fell')!;
+  const config = getSeriesConfig(year, 'fell');
+  const clubs = getClubs(year);
+
+  const resolveClub = (id: string) => clubs.find(c => c.id === id)?.name ?? id;
+  const resolveTeamCategoryName = (id: string) =>
+    config.teamCategories?.find(c => c.id === id)?.name ?? id;
+  const resolveIndividualCategory = (id: string) =>
+    config.individualCategories?.find(c => c.id === id);
+
+  const partitioned = raw.individualAwards.map(ia => {
+    const cat = resolveIndividualCategory(ia.category);
+    return {
+      sex: cat?.sex,
+      resolved: {
+        categoryName: cat?.name ?? ia.category,
+        awards: ia.awards.map(a => ({
+          position: a.position,
+          name: a.name,
+          clubName: resolveClub(a.club),
+        })),
+      },
+    };
+  });
+
+  awards = {
+    teamAwards: raw.teamAwards.map(ta => ({
+      categoryName: resolveTeamCategoryName(ta.category),
+      clubName: resolveClub(ta.club),
+    })),
+    overallAwards: partitioned.filter(x => !x.sex).map(x => x.resolved),
+    maleAwards:    partitioned.filter(x => x.sex === 'M').map(x => x.resolved),
+    femaleAwards:  partitioned.filter(x => x.sex === 'F').map(x => x.resolved),
+  };
+}
+---
+
+<Layout title={`Fell Championship ${year}`}>
+  <RaceList
+    races={races}
+    year={year}
+    series="fell"
+    availableYears={availableYears}
+    currentYear={currentYear}
+    seriesBasePath="/fell"
+    seriesLabel="Fell Championship"
+    standingsUrl={standingsUrl}
+    individualStandingsUrl={individualStandingsUrl}
+    awards={awards}
+  />
+</Layout>
+```
+
+- [ ] **Step 3: Update `src/pages/road-gp/[year]/index.astro`**
+
+Replace the full file with:
+
+```astro
+---
+// src/pages/road-gp/[year]/index.astro
+import Layout from '../../../components/Layout.astro';
+import RaceList from '../../../components/RaceList.astro';
+import { getCurrentYear, getAvailableYears, getRaces } from '../../../lib/data';
+import { getAwards, getClubs, getSeriesConfig, hasAwards, hasIndividualStandings, hasTeamStandings } from '../../../lib/results';
+import type { ResolvedSeriesAwards } from '../../../lib/types';
+
+export async function getStaticPaths() {
+  const current = getCurrentYear();
+  const years = getAvailableYears('road-gp').filter(y => y !== current);
+  return years.map(year => ({ params: { year: String(year) } }));
+}
+
+const { year: yearParam } = Astro.params;
+const year = parseInt(yearParam);
+const currentYear = getCurrentYear();
+const availableYears = getAvailableYears('road-gp');
+const races = getRaces(year, 'road-gp');
+const standingsUrl = hasTeamStandings(year, 'road-gp')
+  ? `/road-gp/${year}/team-standings`
+  : undefined;
+const individualStandingsUrl = hasIndividualStandings(year, 'road-gp')
+  ? `/road-gp/${year}/individual-standings`
+  : undefined;
+
+let awards: ResolvedSeriesAwards | undefined;
+if (hasAwards(year, 'road-gp')) {
+  const raw = getAwards(year, 'road-gp')!;
+  const config = getSeriesConfig(year, 'road-gp');
+  const clubs = getClubs(year);
+
+  const resolveClub = (id: string) => clubs.find(c => c.id === id)?.name ?? id;
+  const resolveTeamCategoryName = (id: string) =>
+    config.teamCategories?.find(c => c.id === id)?.name ?? id;
+  const resolveIndividualCategory = (id: string) =>
+    config.individualCategories?.find(c => c.id === id);
+
+  const partitioned = raw.individualAwards.map(ia => {
+    const cat = resolveIndividualCategory(ia.category);
+    return {
+      sex: cat?.sex,
+      resolved: {
+        categoryName: cat?.name ?? ia.category,
+        awards: ia.awards.map(a => ({
+          position: a.position,
+          name: a.name,
+          clubName: resolveClub(a.club),
+        })),
+      },
+    };
+  });
+
+  awards = {
+    teamAwards: raw.teamAwards.map(ta => ({
+      categoryName: resolveTeamCategoryName(ta.category),
+      clubName: resolveClub(ta.club),
+    })),
+    overallAwards: partitioned.filter(x => !x.sex).map(x => x.resolved),
+    maleAwards:    partitioned.filter(x => x.sex === 'M').map(x => x.resolved),
+    femaleAwards:  partitioned.filter(x => x.sex === 'F').map(x => x.resolved),
+  };
+}
+---
+
+<Layout title={`Road Grand Prix ${year}`}>
+  <RaceList
+    races={races}
+    year={year}
+    series="road-gp"
+    availableYears={availableYears}
+    currentYear={currentYear}
+    seriesBasePath="/road-gp"
+    seriesLabel="Road Grand Prix"
+    standingsUrl={standingsUrl}
+    individualStandingsUrl={individualStandingsUrl}
+    awards={awards}
+  />
+</Layout>
+```
+
+- [ ] **Step 4: Verify build compiles**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds. No awards section visible yet (no `awards.json` file exists).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/RaceList.astro src/pages/fell/[year]/index.astro src/pages/road-gp/[year]/index.astro
+git commit -m "feat: wire awards section into series index pages"
+```
+
+---
+
+### Task 5: Add sample data and validate end-to-end
+
+**Files:**
+- Modify: `src/data/2026/fell/config.json`
+- Create: `src/data/2026/fell/awards.json`
+
+- [ ] **Step 1: Add `sex` fields to `individualCategories` in `src/data/2026/fell/config.json`**
+
+Replace the file with:
+
+```json
+{
+  "ageCategories": ["SEN", "V40", "V50", "V60", "V70"],
+  "maxCountingRaces": 3,
+  "individualCategories": [
+    { "id": "sen-m", "name": "Senior Men",   "sex": "M" },
+    { "id": "sen-f", "name": "Senior Women", "sex": "F" },
+    { "id": "v40-m", "name": "V40 Men",      "sex": "M" },
+    { "id": "v40-f", "name": "V40 Women",    "sex": "F" }
+  ],
+  "teamCategories": [
+    { "id": "open",   "name": "Open",   "scorerCount": 6 },
+    { "id": "ladies", "name": "Ladies", "scorerCount": 3 },
+    { "id": "vets",   "name": "Vets",   "scorerCount": 4 }
+  ]
+}
+```
+
+- [ ] **Step 2: Create `src/data/2026/fell/awards.json`**
+
+```json
+{
+  "teamAwards": [
+    { "category": "open",   "club": "wesham" },
+    { "category": "ladies", "club": "lytham" },
+    { "category": "vets",   "club": "preston" }
+  ],
+  "individualAwards": [
+    {
+      "category": "sen-m",
+      "awards": [
+        { "position": 1, "name": "L. Minns",  "club": "blackpool" },
+        { "position": 2, "name": "J. Smith",  "club": "wesham" },
+        { "position": 3, "name": "T. Guest",  "club": "red-rose" }
+      ]
+    },
+    {
+      "category": "sen-f",
+      "awards": [
+        { "position": 1, "name": "A. Jones",  "club": "chorley" },
+        { "position": 3, "name": "B. Clarke", "club": "blackpool" }
+      ]
+    },
+    {
+      "category": "v40-m",
+      "awards": [
+        { "position": 1, "name": "D. Evans",  "club": "wesham" },
+        { "position": 2, "name": "M. Clark",  "club": "thornton" }
+      ]
+    },
+    {
+      "category": "v40-f",
+      "awards": [
+        { "position": 1, "name": "C. Hall",   "club": "wesham" },
+        { "position": 2, "name": "E. Fox",    "club": "red-rose" },
+        { "position": 3, "name": "F. Ward",   "club": "preston" }
+      ]
+    }
+  ]
+}
+```
+
+- [ ] **Step 3: Run build and confirm awards section appears**
+
+```bash
+npm run build && npm run preview
+```
+
+Navigate to `http://localhost:4321/fell/2026/` and verify:
+- "🏆 Series Winners" section appears above the race list
+- Team pills show: "🏆 Open: Wesham RR", "🏆 Ladies: Lytham St. Annes RR", "🏆 Vets: Preston Harriers"
+- Individual section shows two columns (Senior Men / Senior Women, V40 Men / V40 Women)
+- Senior Women shows positions 1st and 3rd (position 2 absent — no row rendered)
+- Club names are fully resolved (e.g. "Wesham RR", not "wesham")
+
+- [ ] **Step 4: Confirm other pages are unaffected**
+
+Navigate to `/road-gp/2026/` and verify no awards section appears (no `awards.json` for road-gp 2026).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/data/2026/fell/config.json src/data/2026/fell/awards.json
+git commit -m "feat: add sample 2026 fell awards and sex fields to config"
+```

--- a/docs/superpowers/specs/2026-04-28-series-awards-design.md
+++ b/docs/superpowers/specs/2026-04-28-series-awards-design.md
@@ -1,0 +1,218 @@
+# Series Awards Design
+
+## Overview
+
+Display end-of-season award winners on the series year index page (e.g. `/fell/2026/`, `/road-gp/2026/`). Awards are manually curated in a per-year, per-series JSON file. The section appears above the race list only when the file exists.
+
+---
+
+## Data
+
+### `src/data/{year}/{series}/awards.json`
+
+```json
+{
+  "teamAwards": [
+    { "category": "open",   "club": "wesham" },
+    { "category": "ladies", "club": "lytham" },
+    { "category": "vets",   "club": "preston" }
+  ],
+  "individualAwards": [
+    {
+      "category": "sen-m",
+      "awards": [
+        { "position": 1, "name": "L. Minns", "club": "blackpool" },
+        { "position": 2, "name": "J. Smith", "club": "wesham" },
+        { "position": 3, "name": "T. Guest", "club": "red-rose" }
+      ]
+    },
+    {
+      "category": "sen-f",
+      "awards": [
+        { "position": 1, "name": "A. Jones",   "club": "chorley" },
+        { "position": 3, "name": "B. Clarke",  "club": "blackpool" }
+      ]
+    }
+  ]
+}
+```
+
+- `teamAwards[].category` — references `teamCategories[].id` in the series `config.json`; display name resolved at build time
+- `individualAwards[].category` — references `individualCategories[].id` in the series `config.json`
+- `individualAwards[].awards[].position` — explicit; gaps are allowed (e.g. no position 2 entry means that place was not awarded)
+- One team award per category (no positions array); multiple individual placements per category
+
+### Config change: `individualCategories[].sex`
+
+Add an optional `sex` field to each entry in `individualCategories` in `config.json`:
+
+```json
+{
+  "individualCategories": [
+    { "id": "overall",  "name": "Overall"       },
+    { "id": "sen-m",   "name": "Senior Men",   "sex": "M" },
+    { "id": "sen-f",   "name": "Senior Women", "sex": "F" },
+    { "id": "v40-m",   "name": "V40 Men",      "sex": "M" },
+    { "id": "v40-f",   "name": "V40 Women",    "sex": "F" }
+  ]
+}
+```
+
+- `"sex": "M"` → rendered in the Male column
+- `"sex": "F"` → rendered in the Female column
+- absent / `undefined` → rendered full-width in the Overall zone above the M/F columns
+
+This field is optional and only relevant when `awards.json` exists; the standings pages are unaffected.
+
+---
+
+## Types (`src/lib/types.ts`)
+
+```typescript
+export interface TeamAward {
+  category: string;
+  club: string;
+}
+
+export interface IndividualAwardEntry {
+  position: number;
+  name: string;
+  club: string;
+}
+
+export interface IndividualAward {
+  category: string;
+  awards: IndividualAwardEntry[];
+}
+
+export interface SeriesAwards {
+  teamAwards: TeamAward[];
+  individualAwards: IndividualAward[];
+}
+```
+
+Also extend `IndividualCategory` (already in `types.ts` as part of `SeriesConfig`) with an optional `sex` field:
+
+```typescript
+export interface IndividualCategory {
+  id: string;
+  name: string;
+  sex?: 'M' | 'F';
+}
+```
+
+---
+
+## Data loading (`src/lib/results.ts`)
+
+Two new functions following the same pattern as `hasTeamStandings` / `getTeamStandings`:
+
+- `hasAwards(year: number, series: Series): boolean` — returns true if `awards.json` exists for that year/series
+- `getAwards(year: number, series: Series): SeriesAwards` — loads and returns the awards data via `import.meta.glob`
+
+---
+
+## Page changes
+
+### `src/pages/fell/[year]/index.astro` and `src/pages/road-gp/[year]/index.astro`
+
+When `hasAwards(year, series)` is true:
+
+1. Load `getAwards(year, series)` and `getSeriesConfig(year, series)`
+2. Resolve display names by looking up each `category` ID against `config.teamCategories` and `config.individualCategories`
+3. Partition `individualAwards` into three groups based on the resolved category's `sex` field: `overall` (no sex), `male` (sex = M), `female` (sex = F)
+4. Pass resolved data as an `awards` prop to `RaceList`
+
+Resolved shape passed into `RaceList` (avoids any config dependency in the component). These four interfaces must be added to `src/lib/types.ts` and exported so both index pages and `RaceList.astro` can import them:
+
+```typescript
+export interface ResolvedTeamAward {
+  categoryName: string;
+  clubName: string;  // looked up from clubs.json
+}
+
+export interface ResolvedIndividualAwardEntry {
+  position: number;
+  name: string;
+  clubName: string;  // looked up from clubs.json
+}
+
+export interface ResolvedIndividualAward {
+  categoryName: string;
+  awards: ResolvedIndividualAwardEntry[];
+}
+
+export interface ResolvedSeriesAwards {
+  teamAwards: ResolvedTeamAward[];
+  overallAwards: ResolvedIndividualAward[];
+  maleAwards: ResolvedIndividualAward[];
+  femaleAwards: ResolvedIndividualAward[];
+}
+```
+
+### `src/components/RaceList.astro`
+
+Add optional `awards?: ResolvedSeriesAwards` prop. When present, render `<SeriesAwards awards={awards} />` between the standings-links row and the race cards.
+
+---
+
+## Component: `src/components/SeriesAwards.astro`
+
+Renders the full awards section given `ResolvedSeriesAwards`. No config or data loading — display only.
+
+### Layout
+
+```
+┌─────────────────────────────────────────────┐
+│  🏆 Series Winners                          │
+│                                             │
+│  TEAM                                       │
+│  [🏆 Open: Wesham] [🏆 Ladies: Lytham] ...  │  ← pill badges, flex-wrap
+│                                             │
+│  INDIVIDUAL                                 │
+│  ┌─────────────────────────────────────┐    │
+│  │ Overall (full width)               │    │  ← only if overallAwards.length > 0
+│  │  🥇 L. Minns   Blackpool WF&AC     │    │
+│  └─────────────────────────────────────┘    │
+│  ┌──────────────┐  ┌──────────────┐         │
+│  │ MALE         │  │ FEMALE       │         │
+│  │ Senior Men   │  │ Senior Women │         │
+│  │  🥇 A. Jones  │  │  🥇 B. Smith │         │
+│  │  🥈 P. Brown  │  │  🥈 C. Hall  │         │
+│  │ V40 Men      │  │ V40 Women    │         │
+│  │  🥇 D. Evans  │  │  🥇 E. Fox   │         │
+│  └──────────────┘  └──────────────┘         │
+└─────────────────────────────────────────────┘
+```
+
+### Position display
+
+| Position | Display |
+|----------|---------|
+| 1 | 🥇 (gold medal emoji) |
+| 2 | 🥈 (silver medal emoji) |
+| 3 | 🥉 (bronze medal emoji) |
+| 4+ | plain ordinal text: "4th", "5th", etc. |
+
+Skipped positions (gaps in the `awards` array) simply have no row — no placeholder shown.
+
+### Conditional rendering
+
+- The entire section is omitted if `awards` prop is not provided
+- The Overall zone is omitted if `overallAwards` is empty
+- The M/F grid is omitted if both `maleAwards` and `femaleAwards` are empty
+- If only one of male/female has entries, it still renders in a two-column grid (the empty column is blank)
+
+---
+
+## File checklist
+
+| File | Change |
+|------|--------|
+| `src/lib/types.ts` | Add `TeamAward`, `IndividualAwardEntry`, `IndividualAward`, `SeriesAwards`; add `sex?` to `IndividualCategory`; add `ResolvedTeamAward`, `ResolvedIndividualAwardEntry`, `ResolvedIndividualAward`, `ResolvedSeriesAwards` |
+| `src/lib/results.ts` | Add `hasAwards`, `getAwards` |
+| `src/pages/fell/[year]/index.astro` | Load awards, resolve names, pass to RaceList |
+| `src/pages/road-gp/[year]/index.astro` | Same |
+| `src/components/RaceList.astro` | Accept `awards?` prop, render `SeriesAwards` above race cards |
+| `src/components/SeriesAwards.astro` | New component — display only |
+| `src/data/{year}/{series}/awards.json` | New data file per year/series as needed |

--- a/src/components/RaceList.astro
+++ b/src/components/RaceList.astro
@@ -1,7 +1,8 @@
 ---
 // src/components/RaceList.astro
-import type { Race, Series } from '../lib/types';
+import type { Race, ResolvedSeriesAwards, Series } from '../lib/types';
 import RaceCard from './RaceCard.astro';
+import SeriesAwards from './SeriesAwards.astro';
 import YearFilter from './YearFilter.astro';
 
 interface Props {
@@ -14,9 +15,10 @@ interface Props {
   seriesLabel: string;
   standingsUrl?: string;
   individualStandingsUrl?: string;
+  awards?: ResolvedSeriesAwards;
 }
 
-const { races, year, series, availableYears, currentYear, seriesBasePath, seriesLabel, standingsUrl, individualStandingsUrl } = Astro.props;
+const { races, year, series, availableYears, currentYear, seriesBasePath, seriesLabel, standingsUrl, individualStandingsUrl, awards } = Astro.props;
 ---
 
 <div>
@@ -46,6 +48,8 @@ const { races, year, series, availableYears, currentYear, seriesBasePath, series
       )}
     </div>
   )}
+
+  {awards && <SeriesAwards awards={awards} />}
 
   {races.length === 0 ? (
     <p class="text-base-content/60">No races found for {year}.</p>

--- a/src/components/SeriesAwards.astro
+++ b/src/components/SeriesAwards.astro
@@ -65,7 +65,7 @@ const hasMF = awards.maleAwards.length > 0 || awards.femaleAwards.length > 0;
         )}
 
         {hasMF && (
-          <div class="grid grid-cols-2 gap-2">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
             <div class="flex flex-col gap-2">
               {awards.maleAwards.map(cat => (
                 <div class="bg-base-100 rounded-lg p-3">

--- a/src/components/SeriesAwards.astro
+++ b/src/components/SeriesAwards.astro
@@ -1,0 +1,106 @@
+---
+import type { ResolvedSeriesAwards } from '../lib/types';
+
+interface Props {
+  awards: ResolvedSeriesAwards;
+}
+
+const { awards } = Astro.props;
+
+function positionLabel(pos: number): string {
+  if (pos === 1) return '🥇';
+  if (pos === 2) return '🥈';
+  if (pos === 3) return '🥉';
+  const mod10 = pos % 10;
+  const mod100 = pos % 100;
+  const suffix =
+    mod10 === 1 && mod100 !== 11 ? 'st' :
+    mod10 === 2 && mod100 !== 12 ? 'nd' :
+    mod10 === 3 && mod100 !== 13 ? 'rd' : 'th';
+  return `${pos}${suffix}`;
+}
+
+const hasMF = awards.maleAwards.length > 0 || awards.femaleAwards.length > 0;
+---
+
+<div class="card bg-base-200 mb-6">
+  <div class="card-body p-4 gap-4">
+    <h2 class="card-title text-base">🏆 Series Winners</h2>
+
+    {awards.teamAwards.length > 0 && (
+      <div>
+        <p class="text-xs uppercase tracking-wider text-base-content/50 mb-2">Team</p>
+        <div class="flex flex-wrap gap-2">
+          {awards.teamAwards.map(ta => (
+            <span class="badge badge-lg gap-1 font-normal">
+              🏆 <span class="text-base-content/60">{ta.categoryName}:</span>
+              <span class="font-semibold">{ta.clubName}</span>
+            </span>
+          ))}
+        </div>
+      </div>
+    )}
+
+    {(awards.overallAwards.length > 0 || hasMF) && (
+      <div>
+        <p class="text-xs uppercase tracking-wider text-base-content/50 mb-2">Individual</p>
+
+        {awards.overallAwards.length > 0 && (
+          <div class="flex flex-col gap-2 mb-3">
+            {awards.overallAwards.map(cat => (
+              <div class="bg-base-100 rounded-lg p-3">
+                <p class="text-xs text-base-content/50 mb-1">{cat.categoryName}</p>
+                <div class="flex flex-col gap-1">
+                  {cat.awards.map(a => (
+                    <div class="flex items-baseline gap-2 text-sm">
+                      <span class="w-6 shrink-0">{positionLabel(a.position)}</span>
+                      <span class="font-medium">{a.name}</span>
+                      <span class="text-base-content/50 text-xs">{a.clubName}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {hasMF && (
+          <div class="grid grid-cols-2 gap-2">
+            <div class="flex flex-col gap-2">
+              {awards.maleAwards.map(cat => (
+                <div class="bg-base-100 rounded-lg p-3">
+                  <p class="text-xs text-base-content/50 mb-1">{cat.categoryName}</p>
+                  <div class="flex flex-col gap-1">
+                    {cat.awards.map(a => (
+                      <div class="flex items-baseline gap-2 text-sm">
+                        <span class="w-6 shrink-0">{positionLabel(a.position)}</span>
+                        <span class="font-medium">{a.name}</span>
+                        <span class="text-base-content/50 text-xs">{a.clubName}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div class="flex flex-col gap-2">
+              {awards.femaleAwards.map(cat => (
+                <div class="bg-base-100 rounded-lg p-3">
+                  <p class="text-xs text-base-content/50 mb-1">{cat.categoryName}</p>
+                  <div class="flex flex-col gap-1">
+                    {cat.awards.map(a => (
+                      <div class="flex items-baseline gap-2 text-sm">
+                        <span class="w-6 shrink-0">{positionLabel(a.position)}</span>
+                        <span class="font-medium">{a.name}</span>
+                        <span class="text-base-content/50 text-xs">{a.clubName}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    )}
+  </div>
+</div>

--- a/src/data/2026/fell/awards.json
+++ b/src/data/2026/fell/awards.json
@@ -1,0 +1,39 @@
+{
+  "teamAwards": [
+    { "category": "open",   "club": "wesham" },
+    { "category": "ladies", "club": "lytham" },
+    { "category": "vets",   "club": "preston" }
+  ],
+  "individualAwards": [
+    {
+      "category": "sen-m",
+      "awards": [
+        { "position": 1, "name": "L. Minns",  "club": "blackpool" },
+        { "position": 2, "name": "J. Smith",  "club": "wesham" },
+        { "position": 3, "name": "T. Guest",  "club": "red-rose" }
+      ]
+    },
+    {
+      "category": "sen-f",
+      "awards": [
+        { "position": 1, "name": "A. Jones",  "club": "chorley" },
+        { "position": 3, "name": "B. Clarke", "club": "blackpool" }
+      ]
+    },
+    {
+      "category": "v40-m",
+      "awards": [
+        { "position": 1, "name": "D. Evans",  "club": "wesham" },
+        { "position": 2, "name": "M. Clark",  "club": "thornton" }
+      ]
+    },
+    {
+      "category": "v40-f",
+      "awards": [
+        { "position": 1, "name": "C. Hall",   "club": "wesham" },
+        { "position": 2, "name": "E. Fox",    "club": "red-rose" },
+        { "position": 3, "name": "F. Ward",   "club": "preston" }
+      ]
+    }
+  ]
+}

--- a/src/data/2026/fell/config.json
+++ b/src/data/2026/fell/config.json
@@ -2,10 +2,10 @@
   "ageCategories": ["SEN", "V40", "V50", "V60", "V70"],
   "maxCountingRaces": 3,
   "individualCategories": [
-    { "id": "sen-m", "name": "Senior Men"   },
-    { "id": "sen-f", "name": "Senior Women" },
-    { "id": "v40-m", "name": "V40 Men"      },
-    { "id": "v40-f", "name": "V40 Women"    }
+    { "id": "sen-m", "name": "Senior Men",   "sex": "M" },
+    { "id": "sen-f", "name": "Senior Women", "sex": "F" },
+    { "id": "v40-m", "name": "V40 Men",      "sex": "M" },
+    { "id": "v40-f", "name": "V40 Women",    "sex": "F" }
   ],
   "teamCategories": [
     { "id": "open",   "name": "Open",   "scorerCount": 6 },

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -1,4 +1,4 @@
-import type { Club, IndividualStandings, RaceResult, Series, SeriesConfig, TeamResults, TeamStandings } from './types';
+import type { Club, IndividualStandings, RaceResult, Series, SeriesAwards, SeriesConfig, TeamResults, TeamStandings } from './types';
 
 export function parseResultsCsv(csv: string): RaceResult[] {
   const lines = csv.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim().split('\n');
@@ -69,6 +69,17 @@ const fellIndividualStandingsFiles = import.meta.glob<{ default: IndividualStand
 
 function individualStandingsFilesForSeries(series: Series) {
   return series === 'road-gp' ? roadIndividualStandingsFiles : fellIndividualStandingsFiles;
+}
+
+const roadAwardsFiles = import.meta.glob<{ default: SeriesAwards }>(
+  '../data/*/road-gp/awards.json', { eager: true }
+);
+const fellAwardsFiles = import.meta.glob<{ default: SeriesAwards }>(
+  '../data/*/fell/awards.json', { eager: true }
+);
+
+function awardsFilesForSeries(series: Series) {
+  return series === 'road-gp' ? roadAwardsFiles : fellAwardsFiles;
 }
 
 export function parseTeamResultsPath(path: string): { year: number; raceId: string; provisional: boolean } | null {
@@ -272,4 +283,14 @@ export function getIndividualStandingsStaticPaths(series: Series) {
       props: { year, standings, clubs, config, linkedRaceIds },
     }];
   });
+}
+
+export function hasAwards(year: number, series: Series): boolean {
+  const files = awardsFilesForSeries(series);
+  return `../data/${year}/${series}/awards.json` in files;
+}
+
+export function getAwards(year: number, series: Series): SeriesAwards | null {
+  const files = awardsFilesForSeries(series);
+  return files[`../data/${year}/${series}/awards.json`]?.default ?? null;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -37,6 +37,7 @@ export interface Club {
 export interface IndividualCategory {
   id: string;
   name: string;
+  sex?: 'M' | 'F';
 }
 
 export interface SeriesConfig {
@@ -117,4 +118,50 @@ export interface IndividualStandings {
   provisional: boolean;
   races: string[];    // ordered list of race ids; defines column order
   categories: IndividualStandingsCategory[];
+}
+
+// Raw awards data (from awards.json)
+export interface TeamAward {
+  category: string;  // references teamCategories[].id in config.json
+  club: string;      // references clubs.json id
+}
+
+export interface IndividualAwardEntry {
+  position: number;
+  name: string;
+  club: string;      // references clubs.json id
+}
+
+export interface IndividualAward {
+  category: string;  // references individualCategories[].id in config.json
+  awards: IndividualAwardEntry[];
+}
+
+export interface SeriesAwards {
+  teamAwards: TeamAward[];
+  individualAwards: IndividualAward[];
+}
+
+// Resolved awards data (display names looked up, categories partitioned by sex)
+export interface ResolvedTeamAward {
+  categoryName: string;
+  clubName: string;
+}
+
+export interface ResolvedIndividualAwardEntry {
+  position: number;
+  name: string;
+  clubName: string;
+}
+
+export interface ResolvedIndividualAward {
+  categoryName: string;
+  awards: ResolvedIndividualAwardEntry[];
+}
+
+export interface ResolvedSeriesAwards {
+  teamAwards: ResolvedTeamAward[];
+  overallAwards: ResolvedIndividualAward[];  // sex field absent on config category
+  maleAwards: ResolvedIndividualAward[];     // sex === 'M' on config category
+  femaleAwards: ResolvedIndividualAward[];   // sex === 'F' on config category
 }

--- a/src/pages/fell/[year]/index.astro
+++ b/src/pages/fell/[year]/index.astro
@@ -3,7 +3,8 @@
 import Layout from '../../../components/Layout.astro';
 import RaceList from '../../../components/RaceList.astro';
 import { getCurrentYear, getAvailableYears, getRaces } from '../../../lib/data';
-import { hasTeamStandings, hasIndividualStandings } from '../../../lib/results';
+import { getAwards, getClubs, getSeriesConfig, hasAwards, hasIndividualStandings, hasTeamStandings } from '../../../lib/results';
+import type { ResolvedSeriesAwards } from '../../../lib/types';
 
 export async function getStaticPaths() {
   const current = getCurrentYear();
@@ -22,6 +23,44 @@ const standingsUrl = hasTeamStandings(year, 'fell')
 const individualStandingsUrl = hasIndividualStandings(year, 'fell')
   ? `/fell/${year}/individual-standings`
   : undefined;
+
+let awards: ResolvedSeriesAwards | undefined;
+if (hasAwards(year, 'fell')) {
+  const raw = getAwards(year, 'fell')!;
+  const config = getSeriesConfig(year, 'fell');
+  const clubs = getClubs(year);
+
+  const resolveClub = (id: string) => clubs.find(c => c.id === id)?.name ?? id;
+  const resolveTeamCategoryName = (id: string) =>
+    config.teamCategories?.find(c => c.id === id)?.name ?? id;
+  const resolveIndividualCategory = (id: string) =>
+    config.individualCategories?.find(c => c.id === id);
+
+  const partitioned = raw.individualAwards.map(ia => {
+    const cat = resolveIndividualCategory(ia.category);
+    return {
+      sex: cat?.sex,
+      resolved: {
+        categoryName: cat?.name ?? ia.category,
+        awards: ia.awards.map(a => ({
+          position: a.position,
+          name: a.name,
+          clubName: resolveClub(a.club),
+        })),
+      },
+    };
+  });
+
+  awards = {
+    teamAwards: raw.teamAwards.map(ta => ({
+      categoryName: resolveTeamCategoryName(ta.category),
+      clubName: resolveClub(ta.club),
+    })),
+    overallAwards: partitioned.filter(x => !x.sex).map(x => x.resolved),
+    maleAwards:    partitioned.filter(x => x.sex === 'M').map(x => x.resolved),
+    femaleAwards:  partitioned.filter(x => x.sex === 'F').map(x => x.resolved),
+  };
+}
 ---
 
 <Layout title={`Fell Championship ${year}`}>
@@ -35,5 +74,6 @@ const individualStandingsUrl = hasIndividualStandings(year, 'fell')
     seriesLabel="Fell Championship"
     standingsUrl={standingsUrl}
     individualStandingsUrl={individualStandingsUrl}
+    awards={awards}
   />
 </Layout>

--- a/src/pages/road-gp/[year]/index.astro
+++ b/src/pages/road-gp/[year]/index.astro
@@ -3,7 +3,8 @@
 import Layout from '../../../components/Layout.astro';
 import RaceList from '../../../components/RaceList.astro';
 import { getCurrentYear, getAvailableYears, getRaces } from '../../../lib/data';
-import { hasTeamStandings, hasIndividualStandings } from '../../../lib/results';
+import { getAwards, getClubs, getSeriesConfig, hasAwards, hasIndividualStandings, hasTeamStandings } from '../../../lib/results';
+import type { ResolvedSeriesAwards } from '../../../lib/types';
 
 export async function getStaticPaths() {
   const current = getCurrentYear();
@@ -22,6 +23,44 @@ const standingsUrl = hasTeamStandings(year, 'road-gp')
 const individualStandingsUrl = hasIndividualStandings(year, 'road-gp')
   ? `/road-gp/${year}/individual-standings`
   : undefined;
+
+let awards: ResolvedSeriesAwards | undefined;
+if (hasAwards(year, 'road-gp')) {
+  const raw = getAwards(year, 'road-gp')!;
+  const config = getSeriesConfig(year, 'road-gp');
+  const clubs = getClubs(year);
+
+  const resolveClub = (id: string) => clubs.find(c => c.id === id)?.name ?? id;
+  const resolveTeamCategoryName = (id: string) =>
+    config.teamCategories?.find(c => c.id === id)?.name ?? id;
+  const resolveIndividualCategory = (id: string) =>
+    config.individualCategories?.find(c => c.id === id);
+
+  const partitioned = raw.individualAwards.map(ia => {
+    const cat = resolveIndividualCategory(ia.category);
+    return {
+      sex: cat?.sex,
+      resolved: {
+        categoryName: cat?.name ?? ia.category,
+        awards: ia.awards.map(a => ({
+          position: a.position,
+          name: a.name,
+          clubName: resolveClub(a.club),
+        })),
+      },
+    };
+  });
+
+  awards = {
+    teamAwards: raw.teamAwards.map(ta => ({
+      categoryName: resolveTeamCategoryName(ta.category),
+      clubName: resolveClub(ta.club),
+    })),
+    overallAwards: partitioned.filter(x => !x.sex).map(x => x.resolved),
+    maleAwards:    partitioned.filter(x => x.sex === 'M').map(x => x.resolved),
+    femaleAwards:  partitioned.filter(x => x.sex === 'F').map(x => x.resolved),
+  };
+}
 ---
 
 <Layout title={`Road Grand Prix ${year}`}>
@@ -35,5 +74,6 @@ const individualStandingsUrl = hasIndividualStandings(year, 'road-gp')
     seriesLabel="Road Grand Prix"
     standingsUrl={standingsUrl}
     individualStandingsUrl={individualStandingsUrl}
+    awards={awards}
   />
 </Layout>


### PR DESCRIPTION
## Summary

- Adds a \"Series Winners\" section above the race list on series year index pages (`/fell/{year}/`, `/road-gp/{year}/`)
- Team winners displayed as compact pill badges (one per team category); individual winners in an Overall (full-width) + Male/Female two-column grid
- Section only appears when a manually-authored `src/data/{year}/{series}/awards.json` file exists

## Changes

- `src/lib/types.ts` — new `SeriesAwards`, `ResolvedSeriesAwards` and related interfaces; `sex?: 'M' | 'F'` added to `IndividualCategory`
- `src/lib/results.ts` — `hasAwards` and `getAwards` data loaders
- `src/components/SeriesAwards.astro` — new display component (team pills + individual grid)
- `src/components/RaceList.astro` — optional `awards` prop, renders `SeriesAwards` when present
- `src/pages/fell/[year]/index.astro` + `src/pages/road-gp/[year]/index.astro` — load and resolve awards data
- `src/data/2026/fell/awards.json` — sample data for smoke testing
- `CLAUDE.md` — documents the new `awards.json` schema and `sex` field

## Test Plan

- [ ] Navigate to `/fell/2026/` — "🏆 Series Winners" section appears above race list with team pills and individual M/F grid
- [ ] Senior Women shows positions 1st and 3rd only (position 2 absent, no row rendered)
- [ ] Club names are fully resolved (e.g. "Wesham RR", not "wesham")
- [ ] Navigate to `/road-gp/2026/` — no awards section (no awards.json for road-gp)
- [ ] All 31 unit tests pass (`npm test`)
- [ ] Build succeeds with no TypeScript errors (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)