### PR TITLE
feat: condensed history view for past-year series pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,13 +72,14 @@ src/
   components/
     Layout.astro             # shared nav + footer wrapper
     RaceCard.astro           # individual race card
-    RaceList.astro           # race list with year filter
+    RaceList.astro           # race list with year filter (current year only)
+    HistoryRaceList.astro    # condensed archive list for past years (date, name, result links, awards)
     YearFilter.astro         # year dropdown navigation
   pages/
     index.astro              # home page
     road-gp/                 # Road GP schedule + detail pages
       [year]/
-        index.astro          # schedule for that year
+        index.astro          # condensed history view for that past year (uses HistoryRaceList)
         team-standings.astro        # season team standings (only generated when team-standings.json exists)
         individual-standings.astro  # season individual standings (only generated when individual-standings.json exists)
         [raceId]/
@@ -86,7 +87,7 @@ src/
           team-results.astro # team results page (only generated when team JSON exists)
     fell/                    # Fell Championship schedule + detail pages
       [year]/
-        index.astro
+        index.astro          # condensed history view for that past year (uses HistoryRaceList)
         team-standings.astro
         individual-standings.astro
         [raceId]/
@@ -273,4 +274,5 @@ End-of-season award winners are placed at `src/data/{year}/{series}/awards.json`
 - `individualAwards[].category` — id matching `individualCategories[].id` in `config.json`
 - `individualAwards[].awards[].position` — explicit; gaps are allowed (e.g. position 2 absent means no 2nd-place award was given)
 - `club` — id matching `clubs.json[].id`; display name resolved at build time
-- The awards section appears above the race list and only renders when this file exists
+- Awards are placed at `src/data/{year}/{series}/awards.json` for a past year — they are announced the following season, so they belong on the past-year archive page, not the current-year page
+- On past-year pages (`[year]/index.astro`) the awards section renders below the race list under a `{year} Awards` heading, only when this file exists; the current-year pages never show awards

--- a/docs/superpowers/plans/2026-04-28-history-view.md
+++ b/docs/superpowers/plans/2026-04-28-history-view.md
@@ -1,0 +1,319 @@
+# History View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the full race-card layout on past-year series pages with a condensed archive view showing date, name, and result links, followed by an awards section.
+
+**Architecture:** A new `HistoryRaceList.astro` component handles the archive layout. The two past-year index pages (`road-gp/[year]/index.astro` and `fell/[year]/index.astro`) switch from `RaceList` to `HistoryRaceList`. Current-year pages and all other pages are untouched.
+
+**Tech Stack:** Astro v6, Tailwind CSS v4 + DaisyUI v5, TypeScript strict
+
+---
+
+## File Map
+
+| File | Action |
+|------|--------|
+| `src/components/HistoryRaceList.astro` | **Create** — condensed archive layout |
+| `src/pages/road-gp/[year]/index.astro` | **Modify** — swap `RaceList` → `HistoryRaceList` |
+| `src/pages/fell/[year]/index.astro` | **Modify** — swap `RaceList` → `HistoryRaceList` |
+
+---
+
+## Task 1: Create `HistoryRaceList.astro`
+
+**Files:**
+- Create: `src/components/HistoryRaceList.astro`
+
+### Background
+
+`formatRaceDate(date, time?)` in `src/lib/format.ts` returns `"Sun 14 Jun"` when called without a time argument — the day of week, day, and month. The year is already shown in the page `h1` so it need not repeat per row.
+
+`hasResults(year, series, raceId)` and `hasTeamResults(year, series, raceId)` in `src/lib/results.ts` check whether the relevant data files exist at build time.
+
+`SeriesAwards` in `src/components/SeriesAwards.astro` takes a single `awards: ResolvedSeriesAwards` prop and renders the full awards card.
+
+`YearFilter` in `src/components/YearFilter.astro` takes `years`, `activeYear`, `seriesBasePath`, and `currentYear`.
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/HistoryRaceList.astro` with this content:
+
+```astro
+---
+// src/components/HistoryRaceList.astro
+import type { Race, ResolvedSeriesAwards, Series } from '../lib/types';
+import SeriesAwards from './SeriesAwards.astro';
+import YearFilter from './YearFilter.astro';
+import { formatRaceDate } from '../lib/format';
+import { hasResults, hasTeamResults } from '../lib/results';
+
+interface Props {
+  races: Race[];
+  year: number;
+  series: Series;
+  availableYears: number[];
+  currentYear: number;
+  seriesBasePath: string;
+  seriesLabel: string;
+  standingsUrl?: string;
+  individualStandingsUrl?: string;
+  awards?: ResolvedSeriesAwards;
+}
+
+const {
+  races, year, series, availableYears, currentYear,
+  seriesBasePath, seriesLabel, standingsUrl, individualStandingsUrl, awards,
+} = Astro.props;
+---
+
+<div>
+  <div class="flex items-center justify-between mb-6 flex-wrap gap-3">
+    <h1 class="text-2xl font-bold">{seriesLabel} — {year}</h1>
+    {availableYears.length > 1 && (
+      <YearFilter
+        years={availableYears}
+        activeYear={year}
+        seriesBasePath={seriesBasePath}
+        currentYear={currentYear}
+      />
+    )}
+  </div>
+
+  {(standingsUrl || individualStandingsUrl) && (
+    <div class="mb-4 flex gap-2 flex-wrap">
+      {standingsUrl && (
+        <a href={standingsUrl} class="btn btn-sm btn-outline gap-1">Team Standings →</a>
+      )}
+      {individualStandingsUrl && (
+        <a href={individualStandingsUrl} class="btn btn-sm btn-outline gap-1">Individual Standings →</a>
+      )}
+    </div>
+  )}
+
+  {races.length === 0 ? (
+    <p class="text-base-content/60">No races found for {year}.</p>
+  ) : (
+    <div class="divide-y divide-base-200">
+      {races.map(race => {
+        const resultsUrl = hasResults(year, series, race.id)
+          ? `/${series}/${year}/${race.id}/results/`
+          : null;
+        const teamResultsUrl = hasTeamResults(year, series, race.id)
+          ? `/${series}/${year}/${race.id}/team-results/`
+          : null;
+        return (
+          <div class="flex items-baseline gap-4 py-3">
+            <span class="text-sm text-base-content/50 w-28 shrink-0">
+              {formatRaceDate(race.date)}
+            </span>
+            <span class="flex-1 font-medium">{race.name}</span>
+            <div class="flex gap-3 text-sm shrink-0">
+              {resultsUrl && (
+                <a href={resultsUrl} class="link link-hover">Results</a>
+              )}
+              {teamResultsUrl && (
+                <a href={teamResultsUrl} class="link link-hover">Team Results</a>
+              )}
+              {!resultsUrl && !teamResultsUrl && (
+                <span class="text-base-content/30">—</span>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  )}
+
+  {awards && (
+    <div class="mt-8">
+      <h2 class="text-xl font-bold mb-4">{year} Awards</h2>
+      <SeriesAwards awards={awards} />
+    </div>
+  )}
+</div>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/HistoryRaceList.astro
+git commit -m "feat: add HistoryRaceList component for condensed archive view"
+```
+
+---
+
+## Task 2: Wire `HistoryRaceList` into the Road GP past-year page
+
+**Files:**
+- Modify: `src/pages/road-gp/[year]/index.astro`
+
+### Background
+
+The current file imports `RaceList` and passes it `races`, `year`, `series`, `availableYears`, `currentYear`, `seriesBasePath`, `seriesLabel`, `standingsUrl`, `individualStandingsUrl`, and `awards`. `HistoryRaceList` accepts the same props, so this is a straight swap of the import and component name.
+
+- [ ] **Step 1: Swap the import and component name**
+
+In `src/pages/road-gp/[year]/index.astro`, change:
+
+```astro
+import RaceList from '../../../components/RaceList.astro';
+```
+
+to:
+
+```astro
+import HistoryRaceList from '../../../components/HistoryRaceList.astro';
+```
+
+And in the template section change:
+
+```astro
+<Layout title={`Road Grand Prix ${year}`}>
+  <RaceList
+    races={races}
+    year={year}
+    series="road-gp"
+    availableYears={availableYears}
+    currentYear={currentYear}
+    seriesBasePath="/road-gp"
+    seriesLabel="Road Grand Prix"
+    standingsUrl={standingsUrl}
+    individualStandingsUrl={individualStandingsUrl}
+    awards={awards}
+  />
+</Layout>
+```
+
+to:
+
+```astro
+<Layout title={`Road Grand Prix ${year}`}>
+  <HistoryRaceList
+    races={races}
+    year={year}
+    series="road-gp"
+    availableYears={availableYears}
+    currentYear={currentYear}
+    seriesBasePath="/road-gp"
+    seriesLabel="Road Grand Prix"
+    standingsUrl={standingsUrl}
+    individualStandingsUrl={individualStandingsUrl}
+    awards={awards}
+  />
+</Layout>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/pages/road-gp/[year]/index.astro
+git commit -m "feat: use HistoryRaceList on Road GP past-year pages"
+```
+
+---
+
+## Task 3: Wire `HistoryRaceList` into the Fell past-year page
+
+**Files:**
+- Modify: `src/pages/fell/[year]/index.astro`
+
+### Background
+
+The fell past-year page is structured identically to the road-gp one. Same swap applies.
+
+- [ ] **Step 1: Swap the import and component name**
+
+In `src/pages/fell/[year]/index.astro`, change:
+
+```astro
+import RaceList from '../../../components/RaceList.astro';
+```
+
+to:
+
+```astro
+import HistoryRaceList from '../../../components/HistoryRaceList.astro';
+```
+
+And in the template section change:
+
+```astro
+<Layout title={`Fell Championship ${year}`}>
+  <RaceList
+    races={races}
+    year={year}
+    series="fell"
+    availableYears={availableYears}
+    currentYear={currentYear}
+    seriesBasePath="/fell"
+    seriesLabel="Fell Championship"
+    standingsUrl={standingsUrl}
+    individualStandingsUrl={individualStandingsUrl}
+    awards={awards}
+  />
+</Layout>
+```
+
+to:
+
+```astro
+<Layout title={`Fell Championship ${year}`}>
+  <HistoryRaceList
+    races={races}
+    year={year}
+    series="fell"
+    availableYears={availableYears}
+    currentYear={currentYear}
+    seriesBasePath="/fell"
+    seriesLabel="Fell Championship"
+    standingsUrl={standingsUrl}
+    individualStandingsUrl={individualStandingsUrl}
+    awards={awards}
+  />
+</Layout>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/pages/fell/[year]/index.astro
+git commit -m "feat: use HistoryRaceList on Fell past-year pages"
+```
+
+---
+
+## Task 4: Build verification
+
+**Files:** none (read-only check)
+
+- [ ] **Step 1: Run the build**
+
+```bash
+npm run build
+```
+
+Expected: build completes with no TypeScript errors and no Astro build failures. The output will list generated pages including `/road-gp/{year}/` and `/fell/{year}/` for each past year.
+
+- [ ] **Step 2: Spot-check the output**
+
+```bash
+npm run preview
+```
+
+Navigate to a past-year page (e.g. if 2025 data exists, go to `http://localhost:4321/road-gp/2025/`). Verify:
+- Page shows a condensed list with date, name, and result links per race
+- Races with no results show a muted dash
+- Team Results link appears only where team JSON exists
+- Awards section appears below the race list with a `{year} Awards` heading
+- Year filter dropdown is present and navigates correctly
+- Standings buttons appear when team/individual standings data exists
+- Current-year pages (`/road-gp/` and `/fell/`) are unchanged
+
+- [ ] **Step 3: Run unit tests to confirm nothing regressed**
+
+```bash
+npm test
+```
+
+Expected: all tests pass (unit tests cover pure functions in `results.ts` and `format.ts`, which were not modified).

--- a/docs/superpowers/specs/2026-04-28-history-view-design.md
+++ b/docs/superpowers/specs/2026-04-28-history-view-design.md
@@ -1,0 +1,104 @@
+# History View Design
+
+**Date:** 2026-04-28
+**Series:** InterClub static site (Astro + Tailwind + DaisyUI)
+
+## Problem
+
+Past-year series pages (`/road-gp/{year}/` and `/fell/{year}/`) currently render full race cards identical to the current-year view. This is too detailed for historical seasons — race images, locations, distances, and external links add noise when users mainly want to reach results. Awards also need a home on past-year pages, as they are announced the following season and do not belong on the live current-year view.
+
+## Goals
+
+- Condense past-year pages to date, name, and result links only
+- Place awards below the race list on past-year pages, with a clear heading
+- Leave current-year pages (`/road-gp/` and `/fell/`) completely unchanged
+
+## Out of Scope
+
+- Combined Road GP + Fell history pages
+- A new `/history/` index landing page
+- Changes to results pages, standings pages, or the `SeriesAwards` component
+
+## Architecture
+
+### New component: `HistoryRaceList.astro`
+
+Handles the archive layout. Both `src/pages/road-gp/[year]/index.astro` and `src/pages/fell/[year]/index.astro` switch from `RaceList` to `HistoryRaceList`.
+
+**Props** (same surface as `RaceList` — simplifies the page templates):
+
+```typescript
+interface Props {
+  races: Race[];
+  year: number;
+  series: Series;
+  availableYears: number[];
+  currentYear: number;
+  seriesBasePath: string;
+  seriesLabel: string;
+  standingsUrl?: string;
+  individualStandingsUrl?: string;
+  awards?: ResolvedSeriesAwards;
+}
+```
+
+### Pages unchanged
+
+- `src/pages/road-gp/index.astro` — no changes
+- `src/pages/fell/index.astro` — no changes
+- All results, team-results, standings pages — no changes
+- `RaceList`, `RaceCard`, `SeriesAwards` components — no changes
+
+## Layout
+
+### Header row
+
+Same as current: series label + year as `h1`, year filter dropdown on the right.
+
+### Standings buttons
+
+Team Standings and Individual Standings links rendered as outline buttons immediately below the header, same as today. Only shown when the respective data files exist.
+
+### Race list
+
+A simple list of rows — no cards, no images. Each row:
+
+```
+14 Jun 2026   Fell Race 1        Results  ·  Team Results
+12 Jul 2026   Fell Race 2        Results
+09 Aug 2026   Fell Race 3        —
+```
+
+- **Date** — formatted as `DD Mon YYYY` (e.g. `14 Jun 2026`). Use `formatRaceDate(date, undefined)` to suppress the time — start time is not relevant for archived races
+- **Name** — plain text, not a link
+- **Results link** — shown as `Results` only when a CSV exists for that race (use `hasResults` helper)
+- **Team Results link** — shown as `Team Results` only when a team results JSON exists (use `hasTeamResults` helper)
+- If neither results file exists, show a muted dash or nothing in that column
+- No location, distance, image, or external details link
+
+### Awards section
+
+Rendered below the race list when `awards` prop is present:
+
+```
+2025 Awards
+[SeriesAwards component]
+```
+
+- Heading: `"{year} Awards"` as `h2`
+- Body: existing `SeriesAwards` component, passed the resolved awards prop unchanged
+- Only rendered when `awards` is defined (same conditional as today in `[year]/index.astro`)
+
+## Data & helpers
+
+`hasResults` and `hasTeamResults` already exist in `src/lib/results.ts` and are used by other pages. `HistoryRaceList` uses them to determine which links to show per race. No new data loading required.
+
+The awards resolution logic currently lives in `[year]/index.astro` for both road-gp and fell. This logic stays in the page templates — `HistoryRaceList` just receives the already-resolved `ResolvedSeriesAwards` object.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `src/components/HistoryRaceList.astro` | **New** — archive layout component |
+| `src/pages/road-gp/[year]/index.astro` | Switch `RaceList` → `HistoryRaceList` |
+| `src/pages/fell/[year]/index.astro` | Switch `RaceList` → `HistoryRaceList` |

--- a/src/components/HistoryRaceList.astro
+++ b/src/components/HistoryRaceList.astro
@@ -1,0 +1,92 @@
+---
+// src/components/HistoryRaceList.astro
+import type { Race, ResolvedSeriesAwards, Series } from '../lib/types';
+import SeriesAwards from './SeriesAwards.astro';
+import YearFilter from './YearFilter.astro';
+import { formatRaceDate } from '../lib/format';
+import { hasResults, hasTeamResults } from '../lib/results';
+
+interface Props {
+  races: Race[];
+  year: number;
+  series: Series;
+  availableYears: number[];
+  currentYear: number;
+  seriesBasePath: string;
+  seriesLabel: string;
+  standingsUrl?: string;
+  individualStandingsUrl?: string;
+  awards?: ResolvedSeriesAwards;
+}
+
+const {
+  races, year, series, availableYears, currentYear,
+  seriesBasePath, seriesLabel, standingsUrl, individualStandingsUrl, awards,
+} = Astro.props;
+---
+
+<div>
+  <div class="flex items-center justify-between mb-6 flex-wrap gap-3">
+    <h1 class="text-2xl font-bold">{seriesLabel} — {year}</h1>
+    {availableYears.length > 1 && (
+      <YearFilter
+        years={availableYears}
+        activeYear={year}
+        seriesBasePath={seriesBasePath}
+        currentYear={currentYear}
+      />
+    )}
+  </div>
+
+  {(standingsUrl || individualStandingsUrl) && (
+    <div class="mb-4 flex gap-2 flex-wrap">
+      {standingsUrl && (
+        <a href={standingsUrl} class="btn btn-sm btn-outline gap-1">Team Standings →</a>
+      )}
+      {individualStandingsUrl && (
+        <a href={individualStandingsUrl} class="btn btn-sm btn-outline gap-1">Individual Standings →</a>
+      )}
+    </div>
+  )}
+
+  {races.length === 0 ? (
+    <p class="text-base-content/60">No races found for {year}.</p>
+  ) : (
+    <div class="divide-y divide-base-200">
+      {races.map(race => {
+        const resultsUrl = hasResults(year, series, race.id)
+          ? `/${series}/${year}/${race.id}/results/`
+          : null;
+        const teamResultsUrl = hasTeamResults(year, series, race.id)
+          ? `/${series}/${year}/${race.id}/team-results/`
+          : null;
+        return (
+          <div class="flex items-baseline gap-4 py-3">
+            <span class="text-sm text-base-content/50 w-28 shrink-0">
+              {formatRaceDate(race.date)}
+            </span>
+            <span class="flex-1 font-medium">{race.name}</span>
+            <div class="flex gap-3 text-sm shrink-0">
+              {resultsUrl && (
+                <a href={resultsUrl} class="link link-hover">Results</a>
+              )}
+              {teamResultsUrl && (
+                <a href={teamResultsUrl} class="link link-hover">Team Results</a>
+              )}
+              {!resultsUrl && !teamResultsUrl && (
+                <span class="text-base-content/30">—</span>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  )}
+
+  {awards && (
+    <div class="mt-8">
+      <h2 class="text-xl font-bold mb-4">{year} Awards</h2>
+      <SeriesAwards awards={awards} />
+    </div>
+  )}
+</div>

--- a/src/pages/fell/[year]/index.astro
+++ b/src/pages/fell/[year]/index.astro
@@ -1,7 +1,7 @@
 ---
 // src/pages/fell/[year]/index.astro
 import Layout from '../../../components/Layout.astro';
-import RaceList from '../../../components/RaceList.astro';
+import HistoryRaceList from '../../../components/HistoryRaceList.astro';
 import { getCurrentYear, getAvailableYears, getRaces } from '../../../lib/data';
 import { getAwards, getClubs, getSeriesConfig, hasAwards, hasIndividualStandings, hasTeamStandings } from '../../../lib/results';
 import type { ResolvedSeriesAwards } from '../../../lib/types';
@@ -64,7 +64,7 @@ if (hasAwards(year, 'fell')) {
 ---
 
 <Layout title={`Fell Championship ${year}`}>
-  <RaceList
+  <HistoryRaceList
     races={races}
     year={year}
     series="fell"

--- a/src/pages/road-gp/[year]/index.astro
+++ b/src/pages/road-gp/[year]/index.astro
@@ -1,7 +1,7 @@
 ---
 // src/pages/road-gp/[year]/index.astro
 import Layout from '../../../components/Layout.astro';
-import RaceList from '../../../components/RaceList.astro';
+import HistoryRaceList from '../../../components/HistoryRaceList.astro';
 import { getCurrentYear, getAvailableYears, getRaces } from '../../../lib/data';
 import { getAwards, getClubs, getSeriesConfig, hasAwards, hasIndividualStandings, hasTeamStandings } from '../../../lib/results';
 import type { ResolvedSeriesAwards } from '../../../lib/types';
@@ -64,7 +64,7 @@ if (hasAwards(year, 'road-gp')) {
 ---
 
 <Layout title={`Road Grand Prix ${year}`}>
-  <RaceList
+  <HistoryRaceList
     races={races}
     year={year}
     series="road-gp"


### PR DESCRIPTION
## Summary

- Add `HistoryRaceList` component that renders a condensed archive layout: date, race name, and links to results/team results only — no images, location, or distance
- Awards appear below the race list with a `{year} Awards` heading
- Wire `HistoryRaceList` into `road-gp/[year]/index.astro` and `fell/[year]/index.astro`, replacing `RaceList` on past-year pages
- Current-year pages (`/road-gp/` and `/fell/`) are unchanged

## Test Plan

- [ ] Build passes (`npm run build`) with no TypeScript errors
- [ ] Unit tests pass (`npm test`)
- [ ] Past-year series pages show condensed race list (date, name, result links only)
- [ ] Awards section appears below race list with year heading when awards data exists
- [ ] Current-year pages are unaffected