### PR TITLE
feat: add race number display and search to results pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,12 +116,12 @@ Then update `src/data/config.json` to set `currentYear`. Missing `clubs.json` or
 ### Results CSV schema
 
 ```
-position,ic_position,first_name,last_name,club,category,sex,time
-1,1,Luke,Minns,blackpool,V35,M,19:35
-9,,T.,Guest,Guest,SEN,M,22:14
+position,ic_position,race_number,first_name,last_name,club,category,sex,time
+1,1,42,Luke,Minns,blackpool,V35,M,19:35
+9,, ,T.,Guest,Guest,SEN,M,22:14
 ```
 
-`club` is a club `id` from `clubs.json`, or `Guest` for non-club runners. `ic_position` is empty for guests. All fields are optional to support partial historical data.
+`club` is a club `id` from `clubs.json`, or `Guest` for non-club runners. `ic_position` is empty for guests. `race_number` is optional — the column may be omitted entirely from older CSVs or left empty for individual runners; both cases parse as `null` on `RaceResult.raceNumber`. All fields are optional to support partial historical data.
 
 ### Team results JSON schema
 

--- a/docs/superpowers/plans/2026-04-29-race-number-display-and-search.md
+++ b/docs/superpowers/plans/2026-04-29-race-number-display-and-search.md
@@ -1,0 +1,371 @@
+# Race Number Display and Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional `race_number` CSV column that displays as a `Num` column in results tables (hidden on mobile) and is searchable via the existing name/number search input.
+
+**Architecture:** Add `raceNumber: number | null` to the `RaceResult` type, parse it from the CSV, then update both results pages (Road GP and Fell) to display the column and extend the search filter to match on race number using `startsWith`.
+
+**Tech Stack:** TypeScript, Astro v6, Tailwind CSS v4 / DaisyUI v5, Vitest
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `src/lib/types.ts` | Add `raceNumber: number \| null` to `RaceResult` |
+| `src/lib/results.ts` | Read `race_number` column in `parseResultsCsv` |
+| `tests/lib/results.test.ts` | New tests for `raceNumber` parsing |
+| `src/pages/road-gp/[year]/[raceId]/results.astro` | Add Num column + update search |
+| `src/pages/fell/[year]/[raceId]/results.astro` | Same changes as Road GP page |
+
+---
+
+### Task 1: Parse `race_number` from CSV
+
+**Files:**
+- Modify: `src/lib/types.ts`
+- Modify: `src/lib/results.ts`
+- Modify: `tests/lib/results.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add these three test cases to the `describe('parseResultsCsv', ...)` block in `tests/lib/results.test.ts`:
+
+```ts
+it('parses raceNumber as a number when present', () => {
+  const csv = 'position,ic_position,race_number,first_name,last_name,club,category,sex,time\n1,1,42,Luke,Minns,blackpool,V35,M,19:35';
+  const [row] = parseResultsCsv(csv);
+  expect(row.raceNumber).toBe(42);
+});
+
+it('parses raceNumber as null when the column is empty', () => {
+  const csv = 'position,ic_position,race_number,first_name,last_name,club,category,sex,time\n1,1,,Luke,Minns,blackpool,V35,M,19:35';
+  const [row] = parseResultsCsv(csv);
+  expect(row.raceNumber).toBeNull();
+});
+
+it('parses raceNumber as null when the column is absent (old CSV format)', () => {
+  const csv = 'position,ic_position,first_name,last_name,club,category,sex,time\n1,1,Luke,Minns,blackpool,V35,M,19:35';
+  const [row] = parseResultsCsv(csv);
+  expect(row.raceNumber).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test
+```
+
+Expected: 3 failures — `Property 'raceNumber' does not exist` or similar TypeScript error.
+
+- [ ] **Step 3: Add `raceNumber` to `RaceResult` in `src/lib/types.ts`**
+
+Locate the `RaceResult` interface (currently ends at `time: string`) and add the new field after `time`:
+
+```ts
+export interface RaceResult {
+  position: number | null;
+  icPosition: number | null;
+  firstName: string;
+  lastName: string;
+  club: string;        // club id (e.g. 'blackpool') or 'Guest'
+  category: string;   // e.g. 'SEN', 'V35', 'U17'
+  sex: string;        // 'M' or 'F'
+  time: string;       // 'MM:SS', may be empty
+  raceNumber: number | null;
+}
+```
+
+- [ ] **Step 4: Read `race_number` in `parseResultsCsv` in `src/lib/results.ts`**
+
+Locate the `return { ... }` object inside the `.map(line => ...)` call in `parseResultsCsv`. Add `raceNumber` after `time`:
+
+```ts
+return {
+  position: num('position'),
+  icPosition: num('ic_position'),
+  firstName: get('first_name'),
+  lastName: get('last_name'),
+  club: get('club'),
+  category: get('category'),
+  sex: get('sex'),
+  time: get('time'),
+  raceNumber: num('race_number'),
+};
+```
+
+The existing `num()` helper handles the absent-column case: `idx('race_number')` returns `-1` when the header is missing, `cols[-1]` is `undefined`, `get()` returns `''`, and `num()` returns `null` because of the `v ? ... : null` guard.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+npm test
+```
+
+Expected: all tests pass, including the 3 new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/types.ts src/lib/results.ts tests/lib/results.test.ts
+git commit -m "feat: add raceNumber field to RaceResult and parse from CSV"
+```
+
+---
+
+### Task 2: Update Road GP results page
+
+**Files:**
+- Modify: `src/pages/road-gp/[year]/[raceId]/results.astro`
+
+There are four changes in this file: the `<thead>`, the static `<tbody>` rows, the client-side `row()` function, and the search `render()` function. Also update the type annotation and the search input placeholder.
+
+- [ ] **Step 1: Add `Num` column to `<thead>`**
+
+Locate the `<thead>` block. Add the `Num` header between `IC` and `Name`:
+
+```html
+<thead>
+  <tr>
+    <th class="hidden sm:table-cell">Pos</th>
+    <th>IC</th>
+    <th class="hidden sm:table-cell">Num</th>
+    <th>Name</th>
+    <th>Cat</th>
+    <th>Club</th>
+    <th class="text-right">Time</th>
+  </tr>
+</thead>
+```
+
+- [ ] **Step 2: Add `Num` cell to static `<tbody>` rows**
+
+Locate the `{results.map(r => (` block. Add the `Num` cell between the IC cell and the Name cell:
+
+```astro
+{results.map(r => (
+  <tr>
+    <td class="hidden sm:table-cell">{r.position ?? '–'}</td>
+    <td>{r.club === 'Guest' ? '–' : (r.icPosition ?? '–')}</td>
+    <td class="hidden sm:table-cell">{r.raceNumber ?? '–'}</td>
+    <td>
+      <span class="sm:hidden">{r.firstName[0] ?? ''}. {r.lastName}</span>
+      <span class="hidden sm:inline">{r.firstName} {r.lastName}</span>
+    </td>
+    <td>{r.category}</td>
+    <td>
+      <span class="sm:hidden">{r.club === 'Guest' ? 'Guest' : (clubById[r.club]?.shortName ?? r.club)}</span>
+      <span class="hidden sm:inline">{r.club === 'Guest' ? 'Guest' : (clubById[r.club]?.name ?? r.club)}</span>
+    </td>
+    <td class="text-right tabular-nums">{r.time || '–'}</td>
+  </tr>
+))}
+```
+
+- [ ] **Step 3: Update the search input placeholder**
+
+Locate the `<input id="filter-name" ...>` element and change its `placeholder`:
+
+```html
+<input
+  id="filter-name"
+  type="search"
+  placeholder="Search name or number…"
+  class="input input-bordered input-sm w-full sm:w-40"
+/>
+```
+
+- [ ] **Step 4: Update the client-side type annotation**
+
+Locate the `const allResults: Array<{ ... }>` declaration in the `<script>` block and add `raceNumber`:
+
+```ts
+const allResults: Array<{
+  position: number | null; icPosition: number | null;
+  raceNumber: number | null;
+  firstName: string; lastName: string;
+  club: string; category: string; sex: string; time: string;
+}> = JSON.parse(document.getElementById('results-data')!.textContent!);
+```
+
+- [ ] **Step 5: Add `Num` cell to the client-side `row()` function**
+
+Locate the `function row(r: typeof allResults[0]): string` and add the `Num` cell between the IC cell and the Name cell:
+
+```ts
+function row(r: typeof allResults[0]): string {
+  const name = r.firstName[0] ? `${esc(r.firstName[0])}.` : '';
+  const clubShort = r.club === 'Guest' ? 'Guest' : esc(clubById[r.club]?.shortName ?? r.club);
+  const clubFull = r.club === 'Guest' ? 'Guest' : esc(clubById[r.club]?.name ?? r.club);
+  return `<tr>
+    <td class="hidden sm:table-cell">${r.position ?? '–'}</td>
+    <td>${r.club === 'Guest' ? '–' : (r.icPosition ?? '–')}</td>
+    <td class="hidden sm:table-cell">${r.raceNumber ?? '–'}</td>
+    <td>
+      <span class="sm:hidden">${name} ${esc(r.lastName)}</span>
+      <span class="hidden sm:inline">${esc(r.firstName)} ${esc(r.lastName)}</span>
+    </td>
+    <td>${esc(r.category)}</td>
+    <td>
+      <span class="sm:hidden">${clubShort}</span>
+      <span class="hidden sm:inline">${clubFull}</span>
+    </td>
+    <td class="text-right tabular-nums">${esc(r.time || '–')}</td>
+  </tr>`;
+}
+```
+
+- [ ] **Step 6: Extend the `render()` filter to match on race number**
+
+Locate the `render()` function. Replace the name filter line:
+
+```ts
+if (name && !r.firstName.toLowerCase().includes(name) && !r.lastName.toLowerCase().includes(name)) return false;
+```
+
+with:
+
+```ts
+if (name && !r.firstName.toLowerCase().includes(name) && !r.lastName.toLowerCase().includes(name) && !(r.raceNumber !== null && String(r.raceNumber).startsWith(name))) return false;
+```
+
+- [ ] **Step 7: Build to verify no TypeScript errors**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds with no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pages/road-gp/[year]/[raceId]/results.astro
+git commit -m "feat: add Num column and name-or-number search to Road GP results page"
+```
+
+---
+
+### Task 3: Update Fell results page
+
+**Files:**
+- Modify: `src/pages/fell/[year]/[raceId]/results.astro`
+
+This page is structurally identical to the Road GP page. Apply the exact same six changes.
+
+- [ ] **Step 1: Add `Num` column to `<thead>`**
+
+```html
+<thead>
+  <tr>
+    <th class="hidden sm:table-cell">Pos</th>
+    <th>IC</th>
+    <th class="hidden sm:table-cell">Num</th>
+    <th>Name</th>
+    <th>Cat</th>
+    <th>Club</th>
+    <th class="text-right">Time</th>
+  </tr>
+</thead>
+```
+
+- [ ] **Step 2: Add `Num` cell to static `<tbody>` rows**
+
+```astro
+{results.map(r => (
+  <tr>
+    <td class="hidden sm:table-cell">{r.position ?? '–'}</td>
+    <td>{r.club === 'Guest' ? '–' : (r.icPosition ?? '–')}</td>
+    <td class="hidden sm:table-cell">{r.raceNumber ?? '–'}</td>
+    <td>
+      <span class="sm:hidden">{r.firstName[0] ?? ''}. {r.lastName}</span>
+      <span class="hidden sm:inline">{r.firstName} {r.lastName}</span>
+    </td>
+    <td>{r.category}</td>
+    <td>
+      <span class="sm:hidden">{r.club === 'Guest' ? 'Guest' : (clubById[r.club]?.shortName ?? r.club)}</span>
+      <span class="hidden sm:inline">{r.club === 'Guest' ? 'Guest' : (clubById[r.club]?.name ?? r.club)}</span>
+    </td>
+    <td class="text-right tabular-nums">{r.time || '–'}</td>
+  </tr>
+))}
+```
+
+- [ ] **Step 3: Update the search input placeholder**
+
+```html
+<input
+  id="filter-name"
+  type="search"
+  placeholder="Search name or number…"
+  class="input input-bordered input-sm w-full sm:w-40"
+/>
+```
+
+- [ ] **Step 4: Update the client-side type annotation**
+
+```ts
+const allResults: Array<{
+  position: number | null; icPosition: number | null;
+  raceNumber: number | null;
+  firstName: string; lastName: string;
+  club: string; category: string; sex: string; time: string;
+}> = JSON.parse(document.getElementById('results-data')!.textContent!);
+```
+
+- [ ] **Step 5: Add `Num` cell to the client-side `row()` function**
+
+```ts
+function row(r: typeof allResults[0]): string {
+  const name = r.firstName[0] ? `${esc(r.firstName[0])}.` : '';
+  const clubShort = r.club === 'Guest' ? 'Guest' : esc(clubById[r.club]?.shortName ?? r.club);
+  const clubFull = r.club === 'Guest' ? 'Guest' : esc(clubById[r.club]?.name ?? r.club);
+  return `<tr>
+    <td class="hidden sm:table-cell">${r.position ?? '–'}</td>
+    <td>${r.club === 'Guest' ? '–' : (r.icPosition ?? '–')}</td>
+    <td class="hidden sm:table-cell">${r.raceNumber ?? '–'}</td>
+    <td>
+      <span class="sm:hidden">${name} ${esc(r.lastName)}</span>
+      <span class="hidden sm:inline">${esc(r.firstName)} ${esc(r.lastName)}</span>
+    </td>
+    <td>${esc(r.category)}</td>
+    <td>
+      <span class="sm:hidden">${clubShort}</span>
+      <span class="hidden sm:inline">${clubFull}</span>
+    </td>
+    <td class="text-right tabular-nums">${esc(r.time || '–')}</td>
+  </tr>`;
+}
+```
+
+- [ ] **Step 6: Extend the `render()` filter to match on race number**
+
+Replace:
+
+```ts
+if (name && !r.firstName.toLowerCase().includes(name) && !r.lastName.toLowerCase().includes(name)) return false;
+```
+
+with:
+
+```ts
+if (name && !r.firstName.toLowerCase().includes(name) && !r.lastName.toLowerCase().includes(name) && !(r.raceNumber !== null && String(r.raceNumber).startsWith(name))) return false;
+```
+
+- [ ] **Step 7: Build to verify no TypeScript errors**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds with no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add "src/pages/fell/[year]/[raceId]/results.astro"
+git commit -m "feat: add Num column and name-or-number search to Fell results page"
+```

--- a/docs/superpowers/specs/2026-04-29-race-number-display-and-search-design.md
+++ b/docs/superpowers/specs/2026-04-29-race-number-display-and-search-design.md
@@ -1,0 +1,78 @@
+# Race Number Display and Search
+
+**Date:** 2026-04-29
+
+## Overview
+
+Race results CSVs sometimes include a bib/race number for each runner. This number should be stored in the data, displayed in the results table, and searchable via the existing name search input.
+
+## Data Layer
+
+### CSV schema
+
+Add an optional `race_number` column to result CSVs. The column may be absent (old files) or present with empty cells (runner has no number). Position in the header row is not significant — the parser uses header names.
+
+```
+position,ic_position,race_number,first_name,last_name,club,category,sex,time
+1,1,42,Luke,Minns,blackpool,V35,M,19:35
+9,, ,T.,Guest,Guest,SEN,M,22:14
+```
+
+### `RaceResult` type (`src/lib/types.ts`)
+
+Add one field:
+
+```ts
+raceNumber: number | null;
+```
+
+### Parser (`src/lib/results.ts` — `parseResultsCsv`)
+
+Read `race_number` using the existing `num()` helper:
+
+```ts
+raceNumber: num('race_number'),
+```
+
+When the column is absent, `idx('race_number')` returns `-1`, `cols[-1]` is `undefined`, and `num()` returns `null`. Old CSVs continue to parse correctly with no code changes required beyond adding the field.
+
+## Table Display
+
+A `Num` column is inserted between the IC and Name columns. It is hidden on mobile using `hidden sm:table-cell` — the same pattern as the existing `Pos` column. When `raceNumber` is null the cell renders `–`.
+
+| Pos | IC | Num | Name | Cat | Club | Time |
+|---|---|---|---|---|---|---|
+| 1 | 1 | 42 | Luke Minns | V35 | Blackpool | 19:35 |
+| 9 | – | – | T. Guest | SEN | Guest | 22:14 |
+
+The `Num` column is added in:
+- The static Astro table (`<thead>` and `<tbody>`) in both `results.astro` pages
+- The `row()` function in the client-side `<script>` block (used during filtered renders)
+
+The race number is included in the JSON data island (`results-data`) so the client-side script can access it for filtering.
+
+## Search
+
+The existing "Search name…" input is repurposed to search name **or** race number. No second input is added.
+
+**Placeholder text:** `Search name or number…`
+
+**Filter logic:** on each keystroke, the input value is checked against:
+1. `firstName` (substring, case-insensitive) — existing behaviour
+2. `lastName` (substring, case-insensitive) — existing behaviour
+3. `raceNumber` converted to string, checked with `startsWith` — new behaviour
+
+Typing `42` matches runners whose race number starts with `42` (e.g. 42, 420). Typing `Smith` matches on name as before. Both checks run simultaneously — no mode switching or type detection.
+
+## Affected Files
+
+- `src/lib/types.ts` — add `raceNumber: number | null` to `RaceResult`
+- `src/lib/results.ts` — read `race_number` column in `parseResultsCsv`
+- `src/pages/road-gp/[year]/[raceId]/results.astro` — add Num column, update search
+- `src/pages/fell/[year]/[raceId]/results.astro` — same changes as road-gp page
+
+## Out of Scope
+
+- Team results, individual standings, and awards pages — race numbers are not relevant there
+- HistoryRaceList — archive view does not show result detail
+- Any validation that race numbers are unique within a race

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -20,6 +20,7 @@ export function parseResultsCsv(csv: string): RaceResult[] {
       category: get('category'),
       sex: get('sex'),
       time: get('time'),
+      raceNumber: num('race_number'),
     };
   });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,6 +25,7 @@ export interface RaceResult {
   category: string;   // e.g. 'SEN', 'V35', 'U17'
   sex: string;        // 'M' or 'F'
   time: string;       // 'MM:SS', may be empty
+  raceNumber: number | null;
 }
 
 export interface Club {

--- a/src/pages/fell/[year]/[raceId]/results.astro
+++ b/src/pages/fell/[year]/[raceId]/results.astro
@@ -45,7 +45,7 @@ const showTeamResults = hasTeamResults(year, 'fell', raceId);
     <input
       id="filter-name"
       type="search"
-      placeholder="Search name…"
+      placeholder="Search name or number…"
       class="input input-bordered input-sm w-full sm:w-40"
     />
     <select id="filter-club" class="select select-bordered select-sm w-full sm:w-auto">
@@ -70,6 +70,7 @@ const showTeamResults = hasTeamResults(year, 'fell', raceId);
         <tr>
           <th class="hidden sm:table-cell">Pos</th>
           <th>IC</th>
+          <th class="hidden sm:table-cell">Num</th>
           <th>Name</th>
           <th>Cat</th>
           <th>Club</th>
@@ -81,6 +82,7 @@ const showTeamResults = hasTeamResults(year, 'fell', raceId);
           <tr>
             <td class="hidden sm:table-cell">{r.position ?? '–'}</td>
             <td>{r.club === 'Guest' ? '–' : (r.icPosition ?? '–')}</td>
+            <td class="hidden sm:table-cell">{r.raceNumber ?? '–'}</td>
             <td>
               <span class="sm:hidden">{r.firstName[0] ?? ''}. {r.lastName}</span>
               <span class="hidden sm:inline">{r.firstName} {r.lastName}</span>
@@ -113,6 +115,7 @@ const showTeamResults = hasTeamResults(year, 'fell', raceId);
 <script>
   const allResults: Array<{
     position: number | null; icPosition: number | null;
+    raceNumber: number | null;
     firstName: string; lastName: string;
     club: string; category: string; sex: string; time: string;
   }> = JSON.parse(document.getElementById('results-data')!.textContent!);
@@ -154,6 +157,7 @@ const showTeamResults = hasTeamResults(year, 'fell', raceId);
     return `<tr>
       <td class="hidden sm:table-cell">${r.position ?? '–'}</td>
       <td>${r.club === 'Guest' ? '–' : (r.icPosition ?? '–')}</td>
+      <td class="hidden sm:table-cell">${r.raceNumber ?? '–'}</td>
       <td>
         <span class="sm:hidden">${name} ${esc(r.lastName)}</span>
         <span class="hidden sm:inline">${esc(r.firstName)} ${esc(r.lastName)}</span>
@@ -173,7 +177,7 @@ const showTeamResults = hasTeamResults(year, 'fell', raceId);
     const cat = catSelect.value;
 
     const filtered = allResults.filter(r => {
-      if (name && !r.firstName.toLowerCase().includes(name) && !r.lastName.toLowerCase().includes(name)) return false;
+      if (name && !r.firstName.toLowerCase().includes(name) && !r.lastName.toLowerCase().includes(name) && !(r.raceNumber !== null && String(r.raceNumber).startsWith(name))) return false;
       if (club && r.club !== club) return false;
       if (cat && r.category !== cat) return false;
       if (activeSex && r.sex !== activeSex) return false;

--- a/src/pages/road-gp/[year]/[raceId]/results.astro
+++ b/src/pages/road-gp/[year]/[raceId]/results.astro
@@ -45,7 +45,7 @@ const showTeamResults = hasTeamResults(year, 'road-gp', raceId);
     <input
       id="filter-name"
       type="search"
-      placeholder="Search name…"
+      placeholder="Search name or number…"
       class="input input-bordered input-sm w-full sm:w-40"
     />
     <select id="filter-club" class="select select-bordered select-sm w-full sm:w-auto">
@@ -70,6 +70,7 @@ const showTeamResults = hasTeamResults(year, 'road-gp', raceId);
         <tr>
           <th class="hidden sm:table-cell">Pos</th>
           <th>IC</th>
+          <th class="hidden sm:table-cell">Num</th>
           <th>Name</th>
           <th>Cat</th>
           <th>Club</th>
@@ -81,6 +82,7 @@ const showTeamResults = hasTeamResults(year, 'road-gp', raceId);
           <tr>
             <td class="hidden sm:table-cell">{r.position ?? '–'}</td>
             <td>{r.club === 'Guest' ? '–' : (r.icPosition ?? '–')}</td>
+            <td class="hidden sm:table-cell">{r.raceNumber ?? '–'}</td>
             <td>
               <span class="sm:hidden">{r.firstName[0] ?? ''}. {r.lastName}</span>
               <span class="hidden sm:inline">{r.firstName} {r.lastName}</span>
@@ -113,6 +115,7 @@ const showTeamResults = hasTeamResults(year, 'road-gp', raceId);
 <script>
   const allResults: Array<{
     position: number | null; icPosition: number | null;
+    raceNumber: number | null;
     firstName: string; lastName: string;
     club: string; category: string; sex: string; time: string;
   }> = JSON.parse(document.getElementById('results-data')!.textContent!);
@@ -154,6 +157,7 @@ const showTeamResults = hasTeamResults(year, 'road-gp', raceId);
     return `<tr>
       <td class="hidden sm:table-cell">${r.position ?? '–'}</td>
       <td>${r.club === 'Guest' ? '–' : (r.icPosition ?? '–')}</td>
+      <td class="hidden sm:table-cell">${r.raceNumber ?? '–'}</td>
       <td>
         <span class="sm:hidden">${name} ${esc(r.lastName)}</span>
         <span class="hidden sm:inline">${esc(r.firstName)} ${esc(r.lastName)}</span>
@@ -173,7 +177,7 @@ const showTeamResults = hasTeamResults(year, 'road-gp', raceId);
     const cat = catSelect.value;
 
     const filtered = allResults.filter(r => {
-      if (name && !r.firstName.toLowerCase().includes(name) && !r.lastName.toLowerCase().includes(name)) return false;
+      if (name && !r.firstName.toLowerCase().includes(name) && !r.lastName.toLowerCase().includes(name) && !(r.raceNumber !== null && String(r.raceNumber).startsWith(name))) return false;
       if (club && r.club !== club) return false;
       if (cat && r.category !== cat) return false;
       if (activeSex && r.sex !== activeSex) return false;

--- a/tests/lib/results.test.ts
+++ b/tests/lib/results.test.ts
@@ -52,6 +52,24 @@ describe('parseResultsCsv', () => {
   it('returns empty array for empty string', () => {
     expect(parseResultsCsv('')).toHaveLength(0);
   });
+
+  it('parses raceNumber as a number when present', () => {
+    const csv = 'position,ic_position,race_number,first_name,last_name,club,category,sex,time\n1,1,42,Luke,Minns,blackpool,V35,M,19:35';
+    const [row] = parseResultsCsv(csv);
+    expect(row.raceNumber).toBe(42);
+  });
+
+  it('parses raceNumber as null when the column is empty', () => {
+    const csv = 'position,ic_position,race_number,first_name,last_name,club,category,sex,time\n1,1,,Luke,Minns,blackpool,V35,M,19:35';
+    const [row] = parseResultsCsv(csv);
+    expect(row.raceNumber).toBeNull();
+  });
+
+  it('parses raceNumber as null when the column is absent (old CSV format)', () => {
+    const csv = 'position,ic_position,first_name,last_name,club,category,sex,time\n1,1,Luke,Minns,blackpool,V35,M,19:35';
+    const [row] = parseResultsCsv(csv);
+    expect(row.raceNumber).toBeNull();
+  });
 });
 
 describe('parseTeamResultsPath', () => {


### PR DESCRIPTION
## Summary

- Added optional `race_number` column to results CSVs, parsed into a new `raceNumber: number | null` field on `RaceResult` — old CSVs without the column continue to work unchanged
- Added a `Num` column to the results table on both Road GP and Fell results pages, hidden on mobile (`hidden sm:table-cell`)
- Extended the name search input to also match race numbers via prefix (`startsWith`), with placeholder updated to "Search name or number…"

## Test Plan

- [ ] Run `npm test` — all 34 tests pass (includes 3 new tests for `raceNumber` parsing: present, empty column, absent column)
- [ ] Run `npm run build` — builds cleanly with no TypeScript errors
- [ ] Load a results page on desktop — verify `Num` column appears between IC and Name, showing `–` for runners without a race number
- [ ] Resize to mobile — verify `Num` column is hidden
- [ ] Type a number in the search box — verify matching runner appears; clear search — all runners return
- [ ] Type a name in the search box — verify name search still works as before