### PR TITLE
feat: add series info content to Road GP and Fell Championship index pages

### DIFF
--- a/docs/superpowers/plans/2026-05-03-series-info-pages.md
+++ b/docs/superpowers/plans/2026-05-03-series-info-pages.md
@@ -1,0 +1,255 @@
+# Series Info Pages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add series descriptions, key rules, team categories, team scoring rules, and individual awards information to the Road Grand Prix and Fell Championship landing pages.
+
+**Architecture:** Static HTML content blocks are added inline in `src/pages/road-gp/index.astro` and `src/pages/fell/index.astro`. The `<RaceList>` component stays in both files but is repositioned to sit between the intro/rules sections and the team/awards sections. No new components or data loading are introduced.
+
+**Tech Stack:** Astro v6, Tailwind CSS v4, DaisyUI v5. Verification via `npm run build` (catches Astro/TypeScript errors) and `npm run dev` for visual inspection.
+
+---
+
+### Task 1: Update Road Grand Prix index page
+
+**Files:**
+- Modify: `src/pages/road-gp/index.astro`
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace `src/pages/road-gp/index.astro` with the following. The frontmatter is unchanged; the template gains a description paragraph, a Key Rules card, then the existing `<RaceList>`, then Team Categories, Team Scoring, and Individual Awards cards.
+
+```astro
+---
+// src/pages/road-gp/index.astro
+import Layout from '../../components/Layout.astro';
+import RaceList from '../../components/RaceList.astro';
+import { getCurrentYear, getAvailableYears, getRaces } from '../../lib/data';
+import { hasTeamStandings } from '../../lib/results';
+
+const currentYear = getCurrentYear();
+const availableYears = getAvailableYears('road-gp');
+const races = getRaces(currentYear, 'road-gp');
+const standingsUrl = hasTeamStandings(currentYear, 'road-gp')
+  ? `/road-gp/${currentYear}/team-standings`
+  : undefined;
+---
+
+<Layout title="Road Grand Prix">
+  <p class="mb-6 text-base-content/80">
+    The Inter Club Road Grand Prix is a series of seven races of between four and five miles, held
+    midweek from April to September. Races are free to enter and run in a spirit of fun as well as
+    being quite competitive. Each host club provides a complimentary buffet after their event. Race
+    numbers are assigned before the season and remain valid throughout.
+  </p>
+
+  <div class="card bg-base-100 shadow-sm mb-6">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Key Rules</h2>
+      <ul class="list-disc list-inside space-y-1 text-sm text-base-content/80">
+        <li>No headphones or similar devices are permitted in IC Road races</li>
+        <li>Minimum age is 15 on the day of competition</li>
+        <li>Club members only — no guest runners</li>
+        <li>Club vest or top must be worn; athletes not in club kit may be removed from official results</li>
+        <li>Race number must be worn; athletes without a number will be shown as Non-Counter in the results</li>
+      </ul>
+    </div>
+  </div>
+
+  <RaceList
+    races={races}
+    year={currentYear}
+    series="road-gp"
+    availableYears={availableYears}
+    currentYear={currentYear}
+    seriesBasePath="/road-gp"
+    seriesLabel="Road Grand Prix"
+    standingsUrl={standingsUrl}
+  />
+
+  <div class="card bg-base-100 shadow-sm mt-6">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Team Categories</h2>
+      <div class="overflow-x-auto">
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th>Scorers</th>
+              <th>Eligibility</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>Open</td><td>10</td><td>All finishers</td></tr>
+            <tr><td>Ladies</td><td>5</td><td>Women</td></tr>
+            <tr><td>FV40</td><td>5</td><td>Women 40+</td></tr>
+            <tr><td>Vets</td><td>6</td><td>Men 40+, Women 35+</td></tr>
+            <tr><td>Vet 50s</td><td>4</td><td>Men &amp; Women 50+</td></tr>
+            <tr><td>Vet 60s</td><td>3</td><td>Men &amp; Women 60+</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-sm mt-4">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Team Scoring</h2>
+      <ul class="list-disc list-inside space-y-1 text-sm text-base-content/80">
+        <li>1st team 7 points, 2nd team 6 points … 7th team 1 point</li>
+        <li>Incomplete teams still score and are ordered by number of finishing runners</li>
+        <li>Where multiple clubs have the same number of finishers, normal scoring rules apply</li>
+        <li>Clubs with no finishers score 0 points</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-sm mt-4">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Individual Awards</h2>
+      <p class="text-sm text-base-content/80">
+        Individual standings are based on the lowest total positions from your best 4 of 7 races.
+        Awards are presented to the 1st, 2nd, and 3rd place finishers overall, and to the top 2 in
+        each veteran category. Awards are presented at the following season's buffet. Only one award
+        per athlete.
+      </p>
+    </div>
+  </div>
+</Layout>
+```
+
+- [ ] **Step 2: Run the build to verify no errors**
+
+```bash
+npm run build
+```
+
+Expected: build completes with no errors. TypeScript errors in Astro pages only surface here, not via `npm test`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/road-gp/index.astro
+git commit -m "feat: add series info content to Road GP index page"
+```
+
+---
+
+### Task 2: Update Fell Championship index page
+
+**Files:**
+- Modify: `src/pages/fell/index.astro`
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace `src/pages/fell/index.astro` with the following. Same structure as the Road GP page with fell-specific content — two key rules, three fewer team categories, and "best 3 of 4" in the awards section.
+
+```astro
+---
+// src/pages/fell/index.astro
+import Layout from '../../components/Layout.astro';
+import RaceList from '../../components/RaceList.astro';
+import { getCurrentYear, getAvailableYears, getRaces } from '../../lib/data';
+import { hasTeamStandings } from '../../lib/results';
+
+const currentYear = getCurrentYear();
+const availableYears = getAvailableYears('fell');
+const races = getRaces(currentYear, 'fell');
+const standingsUrl = hasTeamStandings(currentYear, 'fell')
+  ? `/fell/${currentYear}/team-standings`
+  : undefined;
+---
+
+<Layout title="Fell Championship">
+  <p class="mb-6 text-base-content/80">
+    The Inter Club Fell Championship is a series of four fell races held during the summer. Races
+    run within pre-existing open events governed by FRA or BOFRA regulations, across varied fell
+    terrain. Unlike the Road Grand Prix, races are not free — entry fees must be paid by each
+    competitor.
+  </p>
+
+  <div class="card bg-base-100 shadow-sm mb-6">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Key Rules</h2>
+      <ul class="list-disc list-inside space-y-1 text-sm text-base-content/80">
+        <li>Competitors are responsible for their own safety on the fells and must obey all rules set by race organisers</li>
+        <li>Additional mandatory kit and protective clothing may be required; failure to carry required kit risks disqualification</li>
+      </ul>
+    </div>
+  </div>
+
+  <RaceList
+    races={races}
+    year={currentYear}
+    series="fell"
+    availableYears={availableYears}
+    currentYear={currentYear}
+    seriesBasePath="/fell"
+    seriesLabel="Fell Championship"
+    standingsUrl={standingsUrl}
+  />
+
+  <div class="card bg-base-100 shadow-sm mt-6">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Team Categories</h2>
+      <div class="overflow-x-auto">
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th>Scorers</th>
+              <th>Eligibility</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>Open</td><td>5</td><td>Any age, any sex</td></tr>
+            <tr><td>Ladies</td><td>3</td><td>Women</td></tr>
+            <tr><td>Vets</td><td>4</td><td>Men &amp; Women 40+</td></tr>
+            <tr><td>Vet 50</td><td>3</td><td>Men &amp; Women 50+</td></tr>
+            <tr><td>Vet 60</td><td>2</td><td>Men &amp; Women 60+</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-sm mt-4">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Team Scoring</h2>
+      <ul class="list-disc list-inside space-y-1 text-sm text-base-content/80">
+        <li>1st team 7 points, 2nd team 6 points … 7th team 1 point</li>
+        <li>Incomplete teams still score and are ordered by number of finishing runners</li>
+        <li>Where multiple clubs have the same number of finishers, normal scoring rules apply</li>
+        <li>Clubs with no finishers score 0 points</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-sm mt-4">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Individual Awards</h2>
+      <p class="text-sm text-base-content/80">
+        Individual standings are based on the lowest total positions from your best 3 of 4 races.
+        Awards are presented to the 1st, 2nd, and 3rd place finishers overall, and to the top 2 in
+        each veteran category. Awards are presented at the following season's buffet. Only one award
+        per athlete.
+      </p>
+    </div>
+  </div>
+</Layout>
+```
+
+- [ ] **Step 2: Run the build to verify no errors**
+
+```bash
+npm run build
+```
+
+Expected: build completes with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/fell/index.astro
+git commit -m "feat: add series info content to Fell Championship index page"
+```

--- a/docs/superpowers/specs/2026-05-03-series-info-pages-design.md
+++ b/docs/superpowers/specs/2026-05-03-series-info-pages-design.md
@@ -78,7 +78,6 @@ The Inter Club Fell Championship is a series of four fell races held during the 
 
 ### 2. Key Rules
 
-- Entry fees must be paid — these are not free races
 - Competitors are responsible for their own safety on the fells and must obey all rules set by race organisers
 - Additional mandatory kit and protective clothing may be required; failure to carry required kit risks disqualification
 

--- a/docs/superpowers/specs/2026-05-03-series-info-pages-design.md
+++ b/docs/superpowers/specs/2026-05-03-series-info-pages-design.md
@@ -9,27 +9,32 @@ Both `/road-gp/` and `/fell/` index pages currently render nothing but a race li
 
 ## Approach
 
-Add a static content block directly inline in each `index.astro` page, above the existing `<RaceList>` component. No new components are needed — the content is substantively different between the two series and changes rarely enough that inline HTML is simpler and easier to maintain independently.
+Add static content blocks directly inline in each `index.astro` page. The `<RaceList>` component moves to sit between the intro/rules content and the team/scoring/awards sections — so runners see the race schedule in context, before the more detailed team and award information.
 
-## Content Structure
+No new components are needed — the content is substantively different between the two series and changes rarely enough that inline HTML is simpler and easier to maintain independently.
 
-Both pages follow the same five-section structure:
+## Page Layout (both series)
 
-1. **Intro paragraph** — brief description of the series
-2. **Key Rules** — bullet list of participation rules with consequences where applicable
-3. **Team Categories** — table of category names and scorer counts
-4. **Team Scoring** — fixed points rules and incomplete-team rules
-5. **Individual Awards** — how individual awards are determined, with the one-award-per-athlete note
+```
+<Layout>
+  1. Intro / description
+  2. Key Rules
+  3. <RaceList> (race schedule)
+  4. Team Categories
+  5. Team Scoring
+  6. Individual Awards
+</Layout>
+```
 
 ---
 
 ## Road Grand Prix (`src/pages/road-gp/index.astro`)
 
-### Intro
+### 1. Intro
 
-Seven Lancashire clubs compete across free 4–5 mile road races held midweek from April to September. Individual standings are based on your best 4 of 7 races.
+The Inter Club Road Grand Prix is a series of seven races of between four and five miles, held midweek from April to September. Races are free to enter and run in a spirit of fun as well as being quite competitive. Each host club provides a complimentary buffet after their event. Race numbers are assigned before the season and remain valid throughout.
 
-### Key Rules
+### 2. Key Rules
 
 - No headphones or similar devices are permitted in IC Road races
 - Minimum age is 15 on the day of competition
@@ -37,69 +42,75 @@ Seven Lancashire clubs compete across free 4–5 mile road races held midweek fr
 - Club vest or top must be worn; athletes not in club kit may be removed from official results
 - Race number must be worn; athletes without a number will be shown as Non-Counter in the results
 
-### Team Categories
+### 3. Race List
 
-| Category | Scorers |
-|----------|---------|
-| Open     | 10      |
-| Ladies   | 5       |
-| FV40     | 5       |
-| Vets     | 6       |
-| Vet 50s  | 4       |
-| Vet 60s  | 3       |
+`<RaceList>` rendered here (current position in the component).
 
-### Team Scoring
+### 4. Team Categories
+
+| Category | Scorers | Eligibility        |
+|----------|---------|--------------------|
+| Open     | 10      | All finishers      |
+| Ladies   | 5       | Women              |
+| FV40     | 5       | Women 40+          |
+| Vets     | 6       | Men 40+, Women 35+ |
+| Vet 50s  | 4       | Men & Women 50+    |
+| Vet 60s  | 3       | Men & Women 60+    |
+
+### 5. Team Scoring
 
 - 1st team 7 points, 2nd team 6 points … 7th team 1 point
 - Incomplete teams still score and are ordered by number of finishing runners
 - Where multiple clubs have the same number of finishers, normal scoring rules apply
 - Clubs with no finishers score 0 points
 
-### Individual Awards
+### 6. Individual Awards
 
-Awards are presented to the top 3 finishers per individual category, based on each athlete's best 4 of 7 races. Awards are presented at the following season's buffet. Only one award per athlete.
+Individual standings are based on the lowest total positions from your best 4 of 7 races. Awards are presented to the 1st, 2nd, and 3rd place finishers overall, and to the top 2 in each veteran category. Awards are presented at the following season's buffet. Only one award per athlete.
 
 ---
 
 ## Fell Championship (`src/pages/fell/index.astro`)
 
-### Intro
+### 1. Intro
 
-Four fell races during summer, run under FRA/BOFRA rules. Unlike the Road Grand Prix, entry fees are required for all races. Individual standings are based on your best 3 of 4 races.
+The Inter Club Fell Championship is a series of four fell races held during the summer. Races run within pre-existing open events governed by FRA or BOFRA regulations, across varied fell terrain. Unlike the Road Grand Prix, races are not free — entry fees must be paid by each competitor.
 
-### Key Rules
+### 2. Key Rules
 
-- These races are not free — entry fees must be paid
+- Entry fees must be paid — these are not free races
 - Competitors are responsible for their own safety on the fells and must obey all rules set by race organisers
 - Additional mandatory kit and protective clothing may be required; failure to carry required kit risks disqualification
 
-### Team Categories
+### 3. Race List
 
-| Category | Scorers |
-|----------|---------|
-| Open     | 6       |
-| Ladies   | 3       |
-| Vets     | 4       |
+`<RaceList>` rendered here (current position in the component).
 
-### Team Scoring
+### 4. Team Categories
 
-Same rules as Road Grand Prix:
+| Category | Scorers | Eligibility     |
+|----------|---------|-----------------|
+| Open     | 6       | All finishers   |
+| Ladies   | 3       | Women           |
+| Vets     | 4       | Men & Women 40+ |
+
+### 5. Team Scoring
 
 - 1st team 7 points, 2nd team 6 points … 7th team 1 point
 - Incomplete teams still score and are ordered by number of finishing runners
 - Where multiple clubs have the same number of finishers, normal scoring rules apply
 - Clubs with no finishers score 0 points
 
-### Individual Awards
+### 6. Individual Awards
 
-Awards are presented to the top 3 finishers per individual category, based on each athlete's best 3 of 4 races. Awards are presented at the following season's buffet. Only one award per athlete.
+Individual standings are based on the lowest total positions from your best 3 of 4 races. Awards are presented to the 1st, 2nd, and 3rd place finishers overall, and to the top 2 in each veteran category. Awards are presented at the following season's buffet. Only one award per athlete.
 
 ---
 
 ## Implementation Notes
 
 - Content is added inline in `src/pages/road-gp/index.astro` and `src/pages/fell/index.astro`
-- The info block sits between the `<Layout>` opening and the `<RaceList>` component
-- Styling follows existing Tailwind/DaisyUI conventions (e.g. `card bg-base-100` for the container, `text-lg font-semibold` for section headings, `list-disc` for bullet lists)
+- The `<RaceList>` component moves from the bottom of the page to sit between Key Rules and Team Categories
+- Styling follows existing Tailwind/DaisyUI conventions (`card bg-base-100` for grouped sections, `text-lg font-semibold` for section headings, `list-disc` for bullet lists)
 - No new components, no new data loading, no tests required
-- Team categories are hardcoded; if categories change in future, update the page directly
+- Team categories are hardcoded; if categories change in a future season, update the page directly

--- a/docs/superpowers/specs/2026-05-03-series-info-pages-design.md
+++ b/docs/superpowers/specs/2026-05-03-series-info-pages-design.md
@@ -88,11 +88,13 @@ The Inter Club Fell Championship is a series of four fell races held during the 
 
 ### 4. Team Categories
 
-| Category | Scorers | Eligibility     |
-|----------|---------|-----------------|
-| Open     | 6       | All finishers   |
-| Ladies   | 3       | Women           |
-| Vets     | 4       | Men & Women 40+ |
+| Category | Scorers | Eligibility              |
+|----------|---------|--------------------------|
+| Open     | 5       | Any age, any sex         |
+| Ladies   | 3       | Women                    |
+| Vets     | 4       | Men & Women 40+          |
+| Vet 50   | 3       | Men & Women 50+          |
+| Vet 60   | 2       | Men & Women 60+          |
 
 ### 5. Team Scoring
 

--- a/docs/superpowers/specs/2026-05-03-series-info-pages-design.md
+++ b/docs/superpowers/specs/2026-05-03-series-info-pages-design.md
@@ -1,0 +1,105 @@
+# Series Info Pages Design
+
+**Date:** 2026-05-03
+**Scope:** Add informational content to the Road Grand Prix and Fell Championship landing pages.
+
+## Problem
+
+Both `/road-gp/` and `/fell/` index pages currently render nothing but a race list. There is no series description, no rules, and no context — the pages are blank to newcomers and uninformative to club runners checking eligibility or scoring rules.
+
+## Approach
+
+Add a static content block directly inline in each `index.astro` page, above the existing `<RaceList>` component. No new components are needed — the content is substantively different between the two series and changes rarely enough that inline HTML is simpler and easier to maintain independently.
+
+## Content Structure
+
+Both pages follow the same five-section structure:
+
+1. **Intro paragraph** — brief description of the series
+2. **Key Rules** — bullet list of participation rules with consequences where applicable
+3. **Team Categories** — table of category names and scorer counts
+4. **Team Scoring** — fixed points rules and incomplete-team rules
+5. **Individual Awards** — how individual awards are determined, with the one-award-per-athlete note
+
+---
+
+## Road Grand Prix (`src/pages/road-gp/index.astro`)
+
+### Intro
+
+Seven Lancashire clubs compete across free 4–5 mile road races held midweek from April to September. Individual standings are based on your best 4 of 7 races.
+
+### Key Rules
+
+- No headphones or similar devices are permitted in IC Road races
+- Minimum age is 15 on the day of competition
+- Club members only — no guest runners
+- Club vest or top must be worn; athletes not in club kit may be removed from official results
+- Race number must be worn; athletes without a number will be shown as Non-Counter in the results
+
+### Team Categories
+
+| Category | Scorers |
+|----------|---------|
+| Open     | 10      |
+| Ladies   | 5       |
+| FV40     | 5       |
+| Vets     | 6       |
+| Vet 50s  | 4       |
+| Vet 60s  | 3       |
+
+### Team Scoring
+
+- 1st team 7 points, 2nd team 6 points … 7th team 1 point
+- Incomplete teams still score and are ordered by number of finishing runners
+- Where multiple clubs have the same number of finishers, normal scoring rules apply
+- Clubs with no finishers score 0 points
+
+### Individual Awards
+
+Awards are presented to the top 3 finishers per individual category, based on each athlete's best 4 of 7 races. Awards are presented at the following season's buffet. Only one award per athlete.
+
+---
+
+## Fell Championship (`src/pages/fell/index.astro`)
+
+### Intro
+
+Four fell races during summer, run under FRA/BOFRA rules. Unlike the Road Grand Prix, entry fees are required for all races. Individual standings are based on your best 3 of 4 races.
+
+### Key Rules
+
+- These races are not free — entry fees must be paid
+- Competitors are responsible for their own safety on the fells and must obey all rules set by race organisers
+- Additional mandatory kit and protective clothing may be required; failure to carry required kit risks disqualification
+
+### Team Categories
+
+| Category | Scorers |
+|----------|---------|
+| Open     | 6       |
+| Ladies   | 3       |
+| Vets     | 4       |
+
+### Team Scoring
+
+Same rules as Road Grand Prix:
+
+- 1st team 7 points, 2nd team 6 points … 7th team 1 point
+- Incomplete teams still score and are ordered by number of finishing runners
+- Where multiple clubs have the same number of finishers, normal scoring rules apply
+- Clubs with no finishers score 0 points
+
+### Individual Awards
+
+Awards are presented to the top 3 finishers per individual category, based on each athlete's best 3 of 4 races. Awards are presented at the following season's buffet. Only one award per athlete.
+
+---
+
+## Implementation Notes
+
+- Content is added inline in `src/pages/road-gp/index.astro` and `src/pages/fell/index.astro`
+- The info block sits between the `<Layout>` opening and the `<RaceList>` component
+- Styling follows existing Tailwind/DaisyUI conventions (e.g. `card bg-base-100` for the container, `text-lg font-semibold` for section headings, `list-disc` for bullet lists)
+- No new components, no new data loading, no tests required
+- Team categories are hardcoded; if categories change in future, update the page directly

--- a/src/pages/fell/index.astro
+++ b/src/pages/fell/index.astro
@@ -14,6 +14,23 @@ const standingsUrl = hasTeamStandings(currentYear, 'fell')
 ---
 
 <Layout title="Fell Championship">
+  <p class="mb-6 text-base-content/80">
+    The Inter Club Fell Championship is a series of four fell races held during the summer. Races
+    run within pre-existing open events governed by FRA or BOFRA regulations, across varied fell
+    terrain. Unlike the Road Grand Prix, races are not free — entry fees must be paid by each
+    competitor.
+  </p>
+
+  <div class="card bg-base-100 shadow-sm mb-6">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Key Rules</h2>
+      <ul class="list-disc list-inside space-y-1 text-sm text-base-content/80">
+        <li>Competitors are responsible for their own safety on the fells and must obey all rules set by race organisers</li>
+        <li>Additional mandatory kit and protective clothing may be required; failure to carry required kit risks disqualification</li>
+      </ul>
+    </div>
+  </div>
+
   <RaceList
     races={races}
     year={currentYear}
@@ -24,4 +41,52 @@ const standingsUrl = hasTeamStandings(currentYear, 'fell')
     seriesLabel="Fell Championship"
     standingsUrl={standingsUrl}
   />
+
+  <div class="card bg-base-100 shadow-sm mt-6">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Team Categories</h2>
+      <div class="overflow-x-auto">
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th>Scorers</th>
+              <th>Eligibility</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>Open</td><td>5</td><td>Any age, any sex</td></tr>
+            <tr><td>Ladies</td><td>3</td><td>Women</td></tr>
+            <tr><td>Vets</td><td>4</td><td>Men &amp; Women 40+</td></tr>
+            <tr><td>Vet 50</td><td>3</td><td>Men &amp; Women 50+</td></tr>
+            <tr><td>Vet 60</td><td>2</td><td>Men &amp; Women 60+</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-sm mt-4">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Team Scoring</h2>
+      <ul class="list-disc list-inside space-y-1 text-sm text-base-content/80">
+        <li>1st team 7 points, 2nd team 6 points … 7th team 1 point</li>
+        <li>Incomplete teams still score and are ordered by number of finishing runners</li>
+        <li>Where multiple clubs have the same number of finishers, normal scoring rules apply</li>
+        <li>Clubs with no finishers score 0 points</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-sm mt-4">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Individual Awards</h2>
+      <p class="text-sm text-base-content/80">
+        Individual standings are based on the lowest total positions from your best 3 of 4 races.
+        Awards are presented to the 1st, 2nd, and 3rd place finishers overall, and to the top 2 in
+        each veteran category. Awards are presented at the following season's buffet. Only one award
+        per athlete.
+      </p>
+    </div>
+  </div>
 </Layout>

--- a/src/pages/road-gp/index.astro
+++ b/src/pages/road-gp/index.astro
@@ -60,7 +60,7 @@ const standingsUrl = hasTeamStandings(currentYear, 'road-gp')
           <tbody>
             <tr><td>Open</td><td>10</td><td>All finishers</td></tr>
             <tr><td>Ladies</td><td>5</td><td>Women</td></tr>
-            <tr><td>FV40</td><td>5</td><td>Women 40+</td></tr>
+            <tr><td>Lady Vets</td><td>5</td><td>Women 40+</td></tr>
             <tr><td>Vets</td><td>6</td><td>Men 40+, Women 35+</td></tr>
             <tr><td>Vet 50s</td><td>4</td><td>Men &amp; Women 50+</td></tr>
             <tr><td>Vet 60s</td><td>3</td><td>Men &amp; Women 60+</td></tr>

--- a/src/pages/road-gp/index.astro
+++ b/src/pages/road-gp/index.astro
@@ -14,6 +14,26 @@ const standingsUrl = hasTeamStandings(currentYear, 'road-gp')
 ---
 
 <Layout title="Road Grand Prix">
+  <p class="mb-6 text-base-content/80">
+    The Inter Club Road Grand Prix is a series of seven races of between four and five miles, held
+    midweek from April to September. Races are free to enter and run in a spirit of fun as well as
+    being quite competitive. Each host club provides a complimentary buffet after their event. Race
+    numbers are assigned before the season and remain valid throughout.
+  </p>
+
+  <div class="card bg-base-100 shadow-sm mb-6">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Key Rules</h2>
+      <ul class="list-disc list-inside space-y-1 text-sm text-base-content/80">
+        <li>No headphones or similar devices are permitted in IC Road races</li>
+        <li>Minimum age is 15 on the day of competition</li>
+        <li>Club members only — no guest runners</li>
+        <li>Club vest or top must be worn; athletes not in club kit may be removed from official results</li>
+        <li>Race number must be worn; athletes without a number will be shown as Non-Counter in the results</li>
+      </ul>
+    </div>
+  </div>
+
   <RaceList
     races={races}
     year={currentYear}
@@ -24,4 +44,53 @@ const standingsUrl = hasTeamStandings(currentYear, 'road-gp')
     seriesLabel="Road Grand Prix"
     standingsUrl={standingsUrl}
   />
+
+  <div class="card bg-base-100 shadow-sm mt-6">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Team Categories</h2>
+      <div class="overflow-x-auto">
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th>Scorers</th>
+              <th>Eligibility</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>Open</td><td>10</td><td>All finishers</td></tr>
+            <tr><td>Ladies</td><td>5</td><td>Women</td></tr>
+            <tr><td>FV40</td><td>5</td><td>Women 40+</td></tr>
+            <tr><td>Vets</td><td>6</td><td>Men 40+, Women 35+</td></tr>
+            <tr><td>Vet 50s</td><td>4</td><td>Men &amp; Women 50+</td></tr>
+            <tr><td>Vet 60s</td><td>3</td><td>Men &amp; Women 60+</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-sm mt-4">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Team Scoring</h2>
+      <ul class="list-disc list-inside space-y-1 text-sm text-base-content/80">
+        <li>1st team 7 points, 2nd team 6 points … 7th team 1 point</li>
+        <li>Incomplete teams still score and are ordered by number of finishing runners</li>
+        <li>Where multiple clubs have the same number of finishers, normal scoring rules apply</li>
+        <li>Clubs with no finishers score 0 points</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-sm mt-4">
+    <div class="card-body gap-2 py-4">
+      <h2 class="text-lg font-semibold">Individual Awards</h2>
+      <p class="text-sm text-base-content/80">
+        Individual standings are based on the lowest total positions from your best 4 of 7 races.
+        Awards are presented to the 1st, 2nd, and 3rd place finishers overall, and to the top 2 in
+        each veteran category. Awards are presented at the following season's buffet. Only one award
+        per athlete.
+      </p>
+    </div>
+  </div>
 </Layout>


### PR DESCRIPTION
## Summary

- Added series description, key rules, team categories table, team scoring rules, and individual awards sections to both `/road-gp/` and `/fell/` landing pages
- Repositioned `<RaceList>` to sit between the intro/rules sections and the team/awards sections
- All content is static and inline — no new components or data loading introduced

## Test Plan

- [ ] Build passes: `npm run build`
- [ ] `/road-gp/` shows description, 5 key rules, race list, 6-row team categories table, team scoring, and individual awards
- [ ] `/fell/` shows description, 2 key rules, race list, 5-row team categories table, team scoring, and individual awards
- [ ] All 44 unit tests pass: `npm test`