### PR TITLE
feat: add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Trigger the workflow every time you push to the `main` branch
+  push:
+    branches: [ main ]
+  # Allows you to run this workflow manually from the Actions tab on GitHub.
+  workflow_dispatch:
+
+# Allow this job to clone the repo and create a page deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Install, build, and upload your site
+        uses: withastro/action@v2
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,8 @@ import tailwindcss from '@tailwindcss/vite';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://whortleberrybearer.github.io',
+  base: '/InterClub',
   vite: {
     plugins: [tailwindcss()]
   }


### PR DESCRIPTION
## Summary
- Configure Astro with GitHub Pages site and base path settings
- Add GitHub Actions workflow for automatic deployment
- Site will be deployed to https://whortleberrybearer.github.io/InterClub on each push to main

## Test plan
- [x] Review configuration in astro.config.mjs
- [x] Verify GitHub Actions workflow file structure
- [] After merge: enable GitHub Pages in repository settings to select "GitHub Actions" as deployment source
- [ ] After merge: verify site deploys successfully on next push to main