### PR TITLE
feat: add GitHub Pages deployment with Node.js 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Install, build, and upload your site
         uses: withastro/action@v2
 


### PR DESCRIPTION
## Summary
- Configure Astro with GitHub Pages site and base path
- Add GitHub Actions workflow for automatic deployment
- Specify Node.js 22 to meet Astro version requirement (>=22.12.0)

## Details
Site will be deployed to https://whortleberrybearer.github.io/InterClub on each push to main.

## Test plan
- [ ] After merge: enable GitHub Pages in repository settings to select 'GitHub Actions' as deployment source
- [ ] After merge: verify site deploys successfully on next push to main