### PR TITLE
fix: use withastro/action@v6 for correct Node.js version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,12 +19,8 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
       - name: Install, build, and upload your site
-        uses: withastro/action@v2
+        uses: withastro/action@v6
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- Replace `withastro/action@v2` with `withastro/action@v6` per Astro docs
- Remove unnecessary `setup-node` step — v6 handles Node.js requirements automatically

## Why
`@v2` used Node.js 20 which is unsupported by the current version of Astro (requires >=22.12.0). `@v6` is the version recommended by the official Astro deployment docs and ships with compatible Node.js support built in.

## Reviewer notes
Previous workaround (explicit `setup-node@v4` with `node-version: 22`) is reverted — the correct fix is using the right action version.