### PR TITLE
fix: upgrade actions/deploy-pages to v5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,4 +31,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Update `actions/deploy-pages` from `@v2` to `@v5`

## Why
The build was failing — `@v5` is the current supported version of the deploy-pages action.