### PR TITLE
fix: prefix internal links with BASE_URL for GitHub Pages subpath

### DIFF
--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -6,10 +6,12 @@ interface Props {
 }
 
 const { title } = Astro.props;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const currentPath = Astro.url.pathname;
 
-function isActive(base: string): boolean {
-  return currentPath === base || currentPath.startsWith(base + '/');
+function isActive(path: string): boolean {
+  const fullPath = base + path;
+  return currentPath === fullPath || currentPath.startsWith(fullPath + '/');
 }
 ---
 
@@ -19,21 +21,21 @@ function isActive(base: string): boolean {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title} — Inter Club</title>
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.svg`} />
   </head>
   <body class="min-h-screen bg-base-200 flex flex-col">
     <header class="bg-base-100 shadow-sm">
       <div class="navbar max-w-4xl mx-auto px-4">
         <div class="navbar-start">
-          <a href="/" class="btn btn-ghost text-lg font-bold tracking-tight">Inter Club</a>
+          <a href={import.meta.env.BASE_URL} class="btn btn-ghost text-lg font-bold tracking-tight">Inter Club</a>
         </div>
         <div class="navbar-end gap-1">
           <a
-            href="/road-gp/"
+            href={`${import.meta.env.BASE_URL}road-gp/`}
             class={`btn btn-ghost btn-sm ${isActive('/road-gp') ? 'btn-active' : ''}`}
           >Road GP</a>
           <a
-            href="/fell/"
+            href={`${import.meta.env.BASE_URL}fell/`}
             class={`btn btn-ghost btn-sm ${isActive('/fell') ? 'btn-active' : ''}`}
           >Fell</a>
         </div>


### PR DESCRIPTION
## Summary
- Update `Layout.astro` to use `import.meta.env.BASE_URL` for all internal links
- Fixes nav links and favicon that were resolving as bare `/` paths, breaking on the `/InterClub` subpath

## Changes
- `href="/"` → `href={import.meta.env.BASE_URL}`
- `href="/road-gp/"` → `href={\`${import.meta.env.BASE_URL}road-gp/\`}`
- `href="/fell/"` → `href={\`${import.meta.env.BASE_URL}fell/\`}`
- `href="/favicon.svg"` → `href={\`${import.meta.env.BASE_URL}favicon.svg\`}`
- `isActive()` updated to prepend the base path when comparing against `Astro.url.pathname`

## Notes
The dev server always serves at `/` (standard Astro behaviour), so links appear un-prefixed locally. In the production build `BASE_URL` resolves to `/InterClub/` and all links will be correctly prefixed.