### PR TITLE
fix: prefix all internal links with /InterClub base path

### DIFF
--- a/src/components/HistoryRaceList.astro
+++ b/src/components/HistoryRaceList.astro
@@ -5,6 +5,7 @@ import SeriesAwards from './SeriesAwards.astro';
 import YearFilter from './YearFilter.astro';
 import { formatRaceDate } from '../lib/format';
 import { hasResults, hasTeamResults } from '../lib/results';
+import { siteUrl } from '../lib/url';
 
 interface Props {
   races: Race[];
@@ -54,10 +55,10 @@ const {
     <div class="divide-y divide-base-200">
       {races.map(race => {
         const resultsUrl = hasResults(year, series, race.id)
-          ? `/${series}/${year}/${race.id}/results/`
+          ? siteUrl(`/${series}/${year}/${race.id}/results/`)
           : null;
         const teamResultsUrl = hasTeamResults(year, series, race.id)
-          ? `/${series}/${year}/${race.id}/team-results/`
+          ? siteUrl(`/${series}/${year}/${race.id}/team-results/`)
           : null;
         return (
           <div class="flex items-baseline gap-4 py-3">

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -6,10 +6,12 @@ interface Props {
 }
 
 const { title } = Astro.props;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const currentPath = Astro.url.pathname;
 
-function isActive(base: string): boolean {
-  return currentPath === base || currentPath.startsWith(base + '/');
+function isActive(path: string): boolean {
+  const fullPath = base + path;
+  return currentPath === fullPath || currentPath.startsWith(fullPath + '/');
 }
 ---
 
@@ -19,21 +21,21 @@ function isActive(base: string): boolean {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title} — Inter Club</title>
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={`${base}/favicon.svg`} />
   </head>
   <body class="min-h-screen bg-base-200 flex flex-col">
     <header class="bg-base-100 shadow-sm">
       <div class="navbar max-w-4xl mx-auto px-4">
         <div class="navbar-start">
-          <a href="/" class="btn btn-ghost text-lg font-bold tracking-tight">Inter Club</a>
+          <a href={`${base}/`} class="btn btn-ghost text-lg font-bold tracking-tight">Inter Club</a>
         </div>
         <div class="navbar-end gap-1">
           <a
-            href="/road-gp/"
+            href={`${base}/road-gp/`}
             class={`btn btn-ghost btn-sm ${isActive('/road-gp') ? 'btn-active' : ''}`}
           >Road GP</a>
           <a
-            href="/fell/"
+            href={`${base}/fell/`}
             class={`btn btn-ghost btn-sm ${isActive('/fell') ? 'btn-active' : ''}`}
           >Fell</a>
         </div>

--- a/src/components/RaceCard.astro
+++ b/src/components/RaceCard.astro
@@ -2,6 +2,7 @@
 // src/components/RaceCard.astro
 import type { Race, Series } from '../lib/types';
 import { formatRaceDate } from '../lib/format';
+import { siteUrl } from '../lib/url';
 
 interface Props {
   race: Race;
@@ -13,13 +14,13 @@ const { race, year, series } = Astro.props;
 const { id, name, date, time, location, distance, detailsUrl, image } = race;
 
 const formattedDate = formatRaceDate(date, time);
-const pageUrl = `/${series}/${year}/${id}/`;
+const pageUrl = siteUrl(`/${series}/${year}/${id}/`);
 ---
 
 <a href={pageUrl} class="card bg-base-100 shadow-sm border border-base-200 hover:shadow-md transition-shadow no-underline">
   {image && (
     <figure>
-      <img src={`/images/${image}`} alt={name} class="w-full h-44 object-cover" loading="lazy" />
+      <img src={siteUrl(`/images/${image}`)} alt={name} class="w-full h-44 object-cover" loading="lazy" />
     </figure>
   )}
   <div class="card-body gap-1 py-4">

--- a/src/components/YearFilter.astro
+++ b/src/components/YearFilter.astro
@@ -1,5 +1,7 @@
 ---
 // src/components/YearFilter.astro
+import { siteUrl } from '../lib/url';
+
 interface Props {
   years: number[];
   activeYear: number;
@@ -10,7 +12,7 @@ interface Props {
 const { years, activeYear, seriesBasePath, currentYear } = Astro.props;
 
 function yearUrl(year: number): string {
-  return year === currentYear ? `${seriesBasePath}/` : `${seriesBasePath}/${year}/`;
+  return year === currentYear ? siteUrl(`${seriesBasePath}/`) : siteUrl(`${seriesBasePath}/${year}/`);
 }
 ---
 

--- a/src/lib/runners.ts
+++ b/src/lib/runners.ts
@@ -4,6 +4,7 @@ import type {
 } from './types';
 import { parseResultsCsv, hasResults, getSeriesConfig } from './results';
 import { getRaces } from './data';
+import { siteUrl } from './url';
 
 // All import.meta.glob calls MUST be at module level (Vite constraint)
 const globalRunnerFile = import.meta.glob<{ default: GlobalRunner[] }>(
@@ -61,7 +62,7 @@ export function buildRunnerUrlMap(year: number, series: Series): Record<number, 
   const map: Record<number, string> = {};
   for (const sr of seriesRunners) {
     const global = globalById[sr.runnerId];
-    if (global) map[sr.id] = `/runners/${runnerSlug(global)}/`;
+    if (global) map[sr.id] = siteUrl(`/runners/${runnerSlug(global)}/`);
   }
   return map;
 }

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,5 @@
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+export function siteUrl(path: string): string {
+  return `${BASE}${path}`;
+}

--- a/src/pages/fell/[year]/[raceId].astro
+++ b/src/pages/fell/[year]/[raceId].astro
@@ -4,6 +4,7 @@ import Layout from '../../../components/Layout.astro';
 import { getAvailableYears, getRaces, getCurrentYear } from '../../../lib/data';
 import { formatRaceDate } from '../../../lib/format';
 import { hasResults } from '../../../lib/results';
+import { siteUrl } from '../../../lib/url';
 import type { Race } from '../../../lib/types';
 
 export async function getStaticPaths() {
@@ -25,7 +26,7 @@ const { race, year } = Astro.props;
 const { name, date, time, location, distance, detailsUrl, image } = race;
 const formattedDate = formatRaceDate(date, time);
 const currentYear = getCurrentYear();
-const backUrl = year === currentYear ? '/fell/' : `/fell/${year}/`;
+const backUrl = year === currentYear ? siteUrl('/fell/') : siteUrl(`/fell/${year}/`);
 const resultsExist = hasResults(year, 'fell', race.id);
 ---
 
@@ -37,7 +38,7 @@ const resultsExist = hasResults(year, 'fell', race.id);
   <div class="card bg-base-100 shadow-sm border border-base-200">
     {image && (
       <figure>
-        <img src={`/images/${image}`} alt={name} class="w-full h-56 object-cover" />
+        <img src={siteUrl(`/images/${image}`)} alt={name} class="w-full h-56 object-cover" />
       </figure>
     )}
     <div class="card-body gap-3">
@@ -69,7 +70,7 @@ const resultsExist = hasResults(year, 'fell', race.id);
             </a>
           )}
           {resultsExist && (
-            <a href={`/fell/${year}/${race.id}/results`} class="btn btn-outline">
+            <a href={siteUrl(`/fell/${year}/${race.id}/results`)} class="btn btn-outline">
               View Results
             </a>
           )}

--- a/src/pages/fell/[year]/[raceId]/results.astro
+++ b/src/pages/fell/[year]/[raceId]/results.astro
@@ -4,6 +4,7 @@ import Layout from '../../../../components/Layout.astro';
 import { getRace } from '../../../../lib/data';
 import { getResultsStaticPaths, hasTeamResults } from '../../../../lib/results';
 import { buildRunnerUrlMap } from '../../../../lib/runners';
+import { siteUrl } from '../../../../lib/url';
 import type { Club, RaceResult, SeriesConfig } from '../../../../lib/types';
 
 export async function getStaticPaths() {
@@ -32,7 +33,7 @@ const showTeamResults = hasTeamResults(year, 'fell', raceId);
 
 <Layout title={`${title} — Results`}>
   <div class="mb-4 flex items-center gap-2">
-    <a href={`/fell/${year}/${raceId}`} class="btn btn-ghost btn-sm gap-1 -ml-3">← {title}</a>
+    <a href={siteUrl(`/fell/${year}/${raceId}`)} class="btn btn-ghost btn-sm gap-1 -ml-3">← {title}</a>
   </div>
 
   <div class="mb-6">

--- a/src/pages/fell/[year]/[raceId]/team-results.astro
+++ b/src/pages/fell/[year]/[raceId]/team-results.astro
@@ -3,6 +3,7 @@
 import Layout from '../../../../components/Layout.astro';
 import { getRace } from '../../../../lib/data';
 import { getTeamResultsStaticPaths } from '../../../../lib/results';
+import { siteUrl } from '../../../../lib/url';
 import type { Club, SeriesConfig, TeamResults } from '../../../../lib/types';
 
 export async function getStaticPaths() {
@@ -27,7 +28,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
 
 <Layout title={`${title} — Team Results`}>
   <div class="mb-4">
-    <a href={`/fell/${year}/${raceId}/results`} class="btn btn-ghost btn-sm gap-1 -ml-3">← Individual Results</a>
+    <a href={siteUrl(`/fell/${year}/${raceId}/results`)} class="btn btn-ghost btn-sm gap-1 -ml-3">← Individual Results</a>
   </div>
 
   <div class="mb-6">

--- a/src/pages/fell/[year]/index.astro
+++ b/src/pages/fell/[year]/index.astro
@@ -6,6 +6,7 @@ import { getCurrentYear, getAvailableYears, getRaces } from '../../../lib/data';
 import { getAwards, getClubs, getSeriesConfig, hasAwards, hasIndividualStandings, hasTeamStandings } from '../../../lib/results';
 import type { ResolvedSeriesAwards } from '../../../lib/types';
 import { buildRunnerUrlMap } from '../../../lib/runners';
+import { siteUrl } from '../../../lib/url';
 
 export async function getStaticPaths() {
   const current = getCurrentYear();
@@ -19,10 +20,10 @@ const currentYear = getCurrentYear();
 const availableYears = getAvailableYears('fell');
 const races = getRaces(year, 'fell');
 const standingsUrl = hasTeamStandings(year, 'fell')
-  ? `/fell/${year}/team-standings`
+  ? siteUrl(`/fell/${year}/team-standings`)
   : undefined;
 const individualStandingsUrl = hasIndividualStandings(year, 'fell')
-  ? `/fell/${year}/individual-standings`
+  ? siteUrl(`/fell/${year}/individual-standings`)
   : undefined;
 const config = getSeriesConfig(year, 'fell');
 

--- a/src/pages/fell/[year]/individual-standings.astro
+++ b/src/pages/fell/[year]/individual-standings.astro
@@ -5,6 +5,7 @@ import { getRaces } from '../../../lib/data';
 import { getIndividualStandingsStaticPaths } from '../../../lib/results';
 import type { Club, SeriesConfig, IndividualStandings } from '../../../lib/types';
 import { buildRunnerUrlMap } from '../../../lib/runners';
+import { siteUrl } from '../../../lib/url';
 
 export async function getStaticPaths() {
   return getIndividualStandingsStaticPaths('fell').map(p => ({
@@ -32,7 +33,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
 
 <Layout title={`Fell Championship ${year} — Individual Standings`}>
   <div class="mb-4">
-    <a href={`/fell/${year}`} class="btn btn-ghost btn-sm gap-1 -ml-3">← Fell Championship {year}</a>
+    <a href={siteUrl(`/fell/${year}`)} class="btn btn-ghost btn-sm gap-1 -ml-3">← Fell Championship {year}</a>
   </div>
 
   <div class="mb-6">
@@ -106,7 +107,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                 {standings.races.map(raceId => {
                   const race = raceById[raceId];
                   const label = race?.shortName ?? raceId;
-                  const href = linkedRaceIds.has(raceId) ? `/fell/${year}/${raceId}/results` : null;
+                  const href = linkedRaceIds.has(raceId) ? siteUrl(`/fell/${year}/${raceId}/results`) : null;
                   return (
                     <th class="text-right py-2 px-2 font-medium whitespace-nowrap">
                       {href
@@ -168,7 +169,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
             {standings.races.map(raceId => {
               const race = raceById[raceId];
               const label = race?.shortName ?? raceId;
-              const href = linkedRaceIds.has(raceId) ? `/fell/${year}/${raceId}/results` : null;
+              const href = linkedRaceIds.has(raceId) ? siteUrl(`/fell/${year}/${raceId}/results`) : null;
               return (
                 <span>
                   {href
@@ -214,7 +215,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                       const result = runner.results[raceId];
                       const race = raceById[raceId];
                       const label = race?.shortName ?? raceId;
-                      const href = linkedRaceIds.has(raceId) ? `/fell/${year}/${raceId}/results` : null;
+                      const href = linkedRaceIds.has(raceId) ? siteUrl(`/fell/${year}/${raceId}/results`) : null;
                       return (
                         <div class:list={[
                           'rounded px-2.5 py-1 text-center text-sm min-w-[44px]',

--- a/src/pages/fell/[year]/team-standings.astro
+++ b/src/pages/fell/[year]/team-standings.astro
@@ -4,6 +4,7 @@ import Layout from '../../../components/Layout.astro';
 import { getRaces } from '../../../lib/data';
 import { getTeamStandingsStaticPaths } from '../../../lib/results';
 import type { Club, SeriesConfig, TeamStandings } from '../../../lib/types';
+import { siteUrl } from '../../../lib/url';
 
 export async function getStaticPaths() {
   return getTeamStandingsStaticPaths('fell');
@@ -27,7 +28,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
 
 <Layout title={`Fell Championship ${year} — Team Standings`}>
   <div class="mb-4">
-    <a href={`/fell/${year}`} class="btn btn-ghost btn-sm gap-1 -ml-3">← Fell Championship {year}</a>
+    <a href={siteUrl(`/fell/${year}`)} class="btn btn-ghost btn-sm gap-1 -ml-3">← Fell Championship {year}</a>
   </div>
 
   <div class="mb-6">
@@ -79,7 +80,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
                 const race = raceById[raceId];
                 const label = race?.shortName ?? raceId;
                 const href = linkedRaceIds.has(raceId)
-                  ? `/fell/${year}/${raceId}/team-results`
+                  ? siteUrl(`/fell/${year}/${raceId}/team-results`)
                   : null;
                 return (
                   <th class="text-right py-2 px-2 font-medium whitespace-nowrap">
@@ -161,7 +162,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
                     const race = raceById[raceId];
                     const label = race?.shortName ?? raceId;
                     const href = linkedRaceIds.has(raceId)
-                      ? `/fell/${year}/${raceId}/team-results`
+                      ? siteUrl(`/fell/${year}/${raceId}/team-results`)
                       : null;
                     const isEmpty = pts === null;
                     return (

--- a/src/pages/fell/index.astro
+++ b/src/pages/fell/index.astro
@@ -4,12 +4,13 @@ import Layout from '../../components/Layout.astro';
 import RaceList from '../../components/RaceList.astro';
 import { getCurrentYear, getAvailableYears, getRaces } from '../../lib/data';
 import { hasTeamStandings } from '../../lib/results';
+import { siteUrl } from '../../lib/url';
 
 const currentYear = getCurrentYear();
 const availableYears = getAvailableYears('fell');
 const races = getRaces(currentYear, 'fell');
 const standingsUrl = hasTeamStandings(currentYear, 'fell')
-  ? `/fell/${currentYear}/team-standings`
+  ? siteUrl(`/fell/${currentYear}/team-standings`)
   : undefined;
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import Layout from '../components/Layout.astro';
 import { getCurrentYear, getRaces } from '../lib/data';
 import { hasResults, hasTeamStandings, hasIndividualStandings } from '../lib/results';
 import { formatRaceDate } from '../lib/format';
+import { siteUrl } from '../lib/url';
 import type { Race } from '../lib/types';
 
 const currentYear = getCurrentYear();
@@ -45,9 +46,9 @@ const heroLabel = heroMode === 'recent'
 // Standings links: prefer individual standings, fall back to team standings
 function getStandingsUrl(series: 'road-gp' | 'fell'): string | undefined {
   if (hasIndividualStandings(currentYear, series))
-    return `/${series}/${currentYear}/individual-standings`;
+    return siteUrl(`/${series}/${currentYear}/individual-standings`);
   if (hasTeamStandings(currentYear, series))
-    return `/${series}/${currentYear}/team-standings`;
+    return siteUrl(`/${series}/${currentYear}/team-standings`);
   return undefined;
 }
 
@@ -85,11 +86,11 @@ function isNext(races: Race[], race: Race): boolean {
             </p>
           </div>
           {heroMode === 'recent' ? (
-            <a href={`/road-gp/${currentYear}/${heroRace.id}/results`} class={`btn btn-sm border-0 shrink-0 bg-white text-success hover:bg-base-200`}>
+            <a href={siteUrl(`/road-gp/${currentYear}/${heroRace.id}/results`)} class={`btn btn-sm border-0 shrink-0 bg-white text-success hover:bg-base-200`}>
               View results →
             </a>
           ) : (
-            <a href={`/road-gp/${currentYear}/${heroRace.id}`} class={`btn btn-sm border-0 shrink-0 bg-white text-primary hover:bg-base-200`}>
+            <a href={siteUrl(`/road-gp/${currentYear}/${heroRace.id}`)} class={`btn btn-sm border-0 shrink-0 bg-white text-primary hover:bg-base-200`}>
               Race info →
             </a>
           )}
@@ -114,10 +115,10 @@ function isNext(races: Race[], race: Race): boolean {
                 </td>
                 <td class="text-right">
                   {past && hasResults(currentYear, 'road-gp', race.id) && (
-                    <a href={`/road-gp/${currentYear}/${race.id}/results`} class="link link-primary text-sm">Results</a>
+                    <a href={siteUrl(`/road-gp/${currentYear}/${race.id}/results`)} class="link link-primary text-sm">Results</a>
                   )}
                   {next && (
-                    <a href={`/road-gp/${currentYear}/${race.id}`} class="link link-primary text-sm">Info</a>
+                    <a href={siteUrl(`/road-gp/${currentYear}/${race.id}`)} class="link link-primary text-sm">Info</a>
                   )}
                 </td>
               </tr>
@@ -154,10 +155,10 @@ function isNext(races: Race[], race: Race): boolean {
                 </td>
                 <td class="text-right">
                   {past && hasResults(currentYear, 'fell', race.id) && (
-                    <a href={`/fell/${currentYear}/${race.id}/results`} class="link link-primary text-sm">Results</a>
+                    <a href={siteUrl(`/fell/${currentYear}/${race.id}/results`)} class="link link-primary text-sm">Results</a>
                   )}
                   {next && (
-                    <a href={`/fell/${currentYear}/${race.id}`} class="link link-primary text-sm">Info</a>
+                    <a href={siteUrl(`/fell/${currentYear}/${race.id}`)} class="link link-primary text-sm">Info</a>
                   )}
                 </td>
               </tr>

--- a/src/pages/road-gp/[year]/[raceId].astro
+++ b/src/pages/road-gp/[year]/[raceId].astro
@@ -4,6 +4,7 @@ import Layout from '../../../components/Layout.astro';
 import { getAvailableYears, getRaces, getCurrentYear } from '../../../lib/data';
 import { formatRaceDate } from '../../../lib/format';
 import { hasResults } from '../../../lib/results';
+import { siteUrl } from '../../../lib/url';
 import type { Race } from '../../../lib/types';
 
 export async function getStaticPaths() {
@@ -25,7 +26,7 @@ const { race, year } = Astro.props;
 const { name, date, time, location, distance, detailsUrl, image } = race;
 const formattedDate = formatRaceDate(date, time);
 const currentYear = getCurrentYear();
-const backUrl = year === currentYear ? '/road-gp/' : `/road-gp/${year}/`;
+const backUrl = year === currentYear ? siteUrl('/road-gp/') : siteUrl(`/road-gp/${year}/`);
 const resultsExist = hasResults(year, 'road-gp', race.id);
 ---
 
@@ -37,7 +38,7 @@ const resultsExist = hasResults(year, 'road-gp', race.id);
   <div class="card bg-base-100 shadow-sm border border-base-200">
     {image && (
       <figure>
-        <img src={`/images/${image}`} alt={name} class="w-full h-56 object-cover" />
+        <img src={siteUrl(`/images/${image}`)} alt={name} class="w-full h-56 object-cover" />
       </figure>
     )}
     <div class="card-body gap-3">
@@ -69,7 +70,7 @@ const resultsExist = hasResults(year, 'road-gp', race.id);
             </a>
           )}
           {resultsExist && (
-            <a href={`/road-gp/${year}/${race.id}/results`} class="btn btn-outline">
+            <a href={siteUrl(`/road-gp/${year}/${race.id}/results`)} class="btn btn-outline">
               View Results
             </a>
           )}

--- a/src/pages/road-gp/[year]/[raceId]/results.astro
+++ b/src/pages/road-gp/[year]/[raceId]/results.astro
@@ -4,6 +4,7 @@ import Layout from '../../../../components/Layout.astro';
 import { getRace } from '../../../../lib/data';
 import { getResultsStaticPaths, hasTeamResults } from '../../../../lib/results';
 import { buildRunnerUrlMap } from '../../../../lib/runners';
+import { siteUrl } from '../../../../lib/url';
 import type { Club, RaceResult, SeriesConfig } from '../../../../lib/types';
 
 export async function getStaticPaths() {
@@ -32,7 +33,7 @@ const showTeamResults = hasTeamResults(year, 'road-gp', raceId);
 
 <Layout title={`${title} — Results`}>
   <div class="mb-4 flex items-center gap-2">
-    <a href={`/road-gp/${year}/${raceId}`} class="btn btn-ghost btn-sm gap-1 -ml-3">← {title}</a>
+    <a href={siteUrl(`/road-gp/${year}/${raceId}`)} class="btn btn-ghost btn-sm gap-1 -ml-3">← {title}</a>
   </div>
 
   <div class="mb-6">

--- a/src/pages/road-gp/[year]/[raceId]/team-results.astro
+++ b/src/pages/road-gp/[year]/[raceId]/team-results.astro
@@ -3,6 +3,7 @@
 import Layout from '../../../../components/Layout.astro';
 import { getRace } from '../../../../lib/data';
 import { getTeamResultsStaticPaths } from '../../../../lib/results';
+import { siteUrl } from '../../../../lib/url';
 import type { Club, SeriesConfig, TeamResults } from '../../../../lib/types';
 
 export async function getStaticPaths() {
@@ -27,7 +28,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
 
 <Layout title={`${title} — Team Results`}>
   <div class="mb-4">
-    <a href={`/road-gp/${year}/${raceId}/results`} class="btn btn-ghost btn-sm gap-1 -ml-3">← Individual Results</a>
+    <a href={siteUrl(`/road-gp/${year}/${raceId}/results`)} class="btn btn-ghost btn-sm gap-1 -ml-3">← Individual Results</a>
   </div>
 
   <div class="mb-6">

--- a/src/pages/road-gp/[year]/index.astro
+++ b/src/pages/road-gp/[year]/index.astro
@@ -4,6 +4,7 @@ import Layout from '../../../components/Layout.astro';
 import HistoryRaceList from '../../../components/HistoryRaceList.astro';
 import { getCurrentYear, getAvailableYears, getRaces } from '../../../lib/data';
 import { getAwards, getClubs, getSeriesConfig, hasAwards, hasIndividualStandings, hasTeamStandings } from '../../../lib/results';
+import { siteUrl } from '../../../lib/url';
 import type { ResolvedSeriesAwards } from '../../../lib/types';
 import { buildRunnerUrlMap } from '../../../lib/runners';
 
@@ -19,10 +20,10 @@ const currentYear = getCurrentYear();
 const availableYears = getAvailableYears('road-gp');
 const races = getRaces(year, 'road-gp');
 const standingsUrl = hasTeamStandings(year, 'road-gp')
-  ? `/road-gp/${year}/team-standings`
+  ? siteUrl(`/road-gp/${year}/team-standings`)
   : undefined;
 const individualStandingsUrl = hasIndividualStandings(year, 'road-gp')
-  ? `/road-gp/${year}/individual-standings`
+  ? siteUrl(`/road-gp/${year}/individual-standings`)
   : undefined;
 const config = getSeriesConfig(year, 'road-gp');
 

--- a/src/pages/road-gp/[year]/individual-standings.astro
+++ b/src/pages/road-gp/[year]/individual-standings.astro
@@ -5,6 +5,7 @@ import { getRaces } from '../../../lib/data';
 import { getIndividualStandingsStaticPaths } from '../../../lib/results';
 import type { Club, SeriesConfig, IndividualStandings } from '../../../lib/types';
 import { buildRunnerUrlMap } from '../../../lib/runners';
+import { siteUrl } from '../../../lib/url';
 
 export async function getStaticPaths() {
   return getIndividualStandingsStaticPaths('road-gp').map(p => ({
@@ -32,7 +33,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
 
 <Layout title={`Road Grand Prix ${year} — Individual Standings`}>
   <div class="mb-4">
-    <a href={`/road-gp/${year}`} class="btn btn-ghost btn-sm gap-1 -ml-3">← Road Grand Prix {year}</a>
+    <a href={siteUrl(`/road-gp/${year}`)} class="btn btn-ghost btn-sm gap-1 -ml-3">← Road Grand Prix {year}</a>
   </div>
 
   <div class="mb-6">
@@ -106,7 +107,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                 {standings.races.map(raceId => {
                   const race = raceById[raceId];
                   const label = race?.shortName ?? raceId;
-                  const href = linkedRaceIds.has(raceId) ? `/road-gp/${year}/${raceId}/results` : null;
+                  const href = linkedRaceIds.has(raceId) ? siteUrl(`/road-gp/${year}/${raceId}/results`) : null;
                   return (
                     <th class="text-right py-2 px-2 font-medium whitespace-nowrap">
                       {href
@@ -168,7 +169,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
             {standings.races.map(raceId => {
               const race = raceById[raceId];
               const label = race?.shortName ?? raceId;
-              const href = linkedRaceIds.has(raceId) ? `/road-gp/${year}/${raceId}/results` : null;
+              const href = linkedRaceIds.has(raceId) ? siteUrl(`/road-gp/${year}/${raceId}/results`) : null;
               return (
                 <span>
                   {href
@@ -214,7 +215,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                       const result = runner.results[raceId];
                       const race = raceById[raceId];
                       const label = race?.shortName ?? raceId;
-                      const href = linkedRaceIds.has(raceId) ? `/road-gp/${year}/${raceId}/results` : null;
+                      const href = linkedRaceIds.has(raceId) ? siteUrl(`/road-gp/${year}/${raceId}/results`) : null;
                       return (
                         <div class:list={[
                           'rounded px-2.5 py-1 text-center text-sm min-w-[44px]',

--- a/src/pages/road-gp/[year]/team-standings.astro
+++ b/src/pages/road-gp/[year]/team-standings.astro
@@ -4,6 +4,7 @@ import Layout from '../../../components/Layout.astro';
 import { getRaces } from '../../../lib/data';
 import { getTeamStandingsStaticPaths } from '../../../lib/results';
 import type { Club, SeriesConfig, TeamStandings } from '../../../lib/types';
+import { siteUrl } from '../../../lib/url';
 
 export async function getStaticPaths() {
   return getTeamStandingsStaticPaths('road-gp');
@@ -27,7 +28,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
 
 <Layout title={`Road GP ${year} — Team Standings`}>
   <div class="mb-4">
-    <a href={`/road-gp/${year}`} class="btn btn-ghost btn-sm gap-1 -ml-3">← Road GP {year}</a>
+    <a href={siteUrl(`/road-gp/${year}`)} class="btn btn-ghost btn-sm gap-1 -ml-3">← Road GP {year}</a>
   </div>
 
   <div class="mb-6">
@@ -79,7 +80,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
                 const race = raceById[raceId];
                 const label = race?.shortName ?? raceId;
                 const href = linkedRaceIds.has(raceId)
-                  ? `/road-gp/${year}/${raceId}/team-results`
+                  ? siteUrl(`/road-gp/${year}/${raceId}/team-results`)
                   : null;
                 return (
                   <th class="text-right py-2 px-2 font-medium whitespace-nowrap">
@@ -163,7 +164,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
                     const race = raceById[raceId];
                     const label = race?.shortName ?? raceId;
                     const href = linkedRaceIds.has(raceId)
-                      ? `/road-gp/${year}/${raceId}/team-results`
+                      ? siteUrl(`/road-gp/${year}/${raceId}/team-results`)
                       : null;
                     const isEmpty = pts === null;
                     return (

--- a/src/pages/road-gp/index.astro
+++ b/src/pages/road-gp/index.astro
@@ -4,12 +4,13 @@ import Layout from '../../components/Layout.astro';
 import RaceList from '../../components/RaceList.astro';
 import { getCurrentYear, getAvailableYears, getRaces } from '../../lib/data';
 import { hasTeamStandings } from '../../lib/results';
+import { siteUrl } from '../../lib/url';
 
 const currentYear = getCurrentYear();
 const availableYears = getAvailableYears('road-gp');
 const races = getRaces(currentYear, 'road-gp');
 const standingsUrl = hasTeamStandings(currentYear, 'road-gp')
-  ? `/road-gp/${currentYear}/team-standings`
+  ? siteUrl(`/road-gp/${currentYear}/team-standings`)
   : undefined;
 ---
 

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../../components/Layout.astro';
 import { getRunnerProfileStaticPaths } from '../../lib/runners';
+import { siteUrl } from '../../lib/url';
 import type { GlobalRunner, RunnerYearBlock } from '../../lib/types';
 
 export async function getStaticPaths() {
@@ -64,7 +65,7 @@ function positionLabel(pos: number): string {
           <div data-series="road-gp" class="mb-5">
             <h3 class="text-xs font-bold uppercase tracking-wider text-base-content/50 mb-2">Road GP</h3>
             {block.roadGp.awards.map(award => (
-              <a href={`/road-gp/${block.year}/`} class="inline-flex items-center gap-1 text-sm text-success hover:underline mb-2">
+              <a href={siteUrl(`/road-gp/${block.year}/`)} class="inline-flex items-center gap-1 text-sm text-success hover:underline mb-2">
                 🏆 {award.categoryName} — {positionLabel(award.position)}
               </a>
             ))}
@@ -75,7 +76,7 @@ function positionLabel(pos: number): string {
                     <td class="text-base-content/50 text-xs w-12 tabular-nums">{formatDateShort(race.date)}</td>
                     <td>
                       {race.hasResults
-                        ? <a href={`/road-gp/${block.year}/${race.raceId}/results`} class="link link-hover">{race.raceName}</a>
+                        ? <a href={siteUrl(`/road-gp/${block.year}/${race.raceId}/results`)} class="link link-hover">{race.raceName}</a>
                         : race.raceName}
                     </td>
                     <td class="text-right tabular-nums font-mono text-sm">{race.time || '–'}</td>
@@ -90,7 +91,7 @@ function positionLabel(pos: number): string {
           <div data-series="fell" class="mb-5">
             <h3 class="text-xs font-bold uppercase tracking-wider text-base-content/50 mb-2">Fell</h3>
             {block.fell.awards.map(award => (
-              <a href={`/fell/${block.year}/`} class="inline-flex items-center gap-1 text-sm text-success hover:underline mb-2">
+              <a href={siteUrl(`/fell/${block.year}/`)} class="inline-flex items-center gap-1 text-sm text-success hover:underline mb-2">
                 🏆 {award.categoryName} — {positionLabel(award.position)}
               </a>
             ))}
@@ -101,7 +102,7 @@ function positionLabel(pos: number): string {
                     <td class="text-base-content/50 text-xs w-12 tabular-nums">{formatDateShort(race.date)}</td>
                     <td>
                       {race.hasResults
-                        ? <a href={`/fell/${block.year}/${race.raceId}/results`} class="link link-hover">{race.raceName}</a>
+                        ? <a href={siteUrl(`/fell/${block.year}/${race.raceId}/results`)} class="link link-hover">{race.raceName}</a>
                         : race.raceName}
                     </td>
                     <td class="text-right tabular-nums font-mono text-sm">{race.time || '–'}</td>


### PR DESCRIPTION
## Summary
- Add `src/lib/url.ts` with a `siteUrl()` helper that prepends `BASE_URL` to every internal path
- Apply `siteUrl()` across all pages and components so every link works under `/InterClub` on GitHub Pages
- Fix `Layout.astro` nav links that were generating broken `/InterClubroad-gp/` style URLs

## Root cause
`import.meta.env.BASE_URL` is `/InterClub` (no trailing slash). Concatenating directly — `${BASE_URL}road-gp/` — produced `/InterClubroad-gp/`. The `siteUrl()` helper takes a path that starts with `/` and prepends the base, giving `/InterClub/road-gp/`.

## Files changed
- `src/lib/url.ts` — new helper
- `astro.config.mjs` — `base: '/InterClub'`
- `src/lib/runners.ts` — runner profile URLs
- `src/components/Layout.astro` — nav + favicon
- `src/components/YearFilter.astro` — year dropdown
- `src/components/HistoryRaceList.astro` — results links
- `src/components/RaceCard.astro` — card href + image src
- All `src/pages/road-gp/**` and `src/pages/fell/**` pages
- `src/pages/index.astro` and `src/pages/runners/[slug].astro`

## Test plan
- [x] `npm run build` passes (173 pages)
- [x] Built HTML confirms all hrefs are `/InterClub/...`
- [ ] After merge: verify deployed site at https://whortleberrybearer.github.io/InterClub/