### PR TITLE
feat: add clubs.json for historical years 1985–2011

### DIFF
--- a/src/data/1985/clubs.json
+++ b/src/data/1985/clubs.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "springfields",
+    "name": "Springfields AC",
+    "shortName": "SPR"
+  }
+]

--- a/src/data/1986/clubs.json
+++ b/src/data/1986/clubs.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "springfields",
+    "name": "Springfields AC",
+    "shortName": "SPR"
+  }
+]

--- a/src/data/1987/clubs.json
+++ b/src/data/1987/clubs.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "springfields",
+    "name": "Springfields AC",
+    "shortName": "SPR"
+  }
+]

--- a/src/data/1988/clubs.json
+++ b/src/data/1988/clubs.json
@@ -17,7 +17,7 @@
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/1988/clubs.json
+++ b/src/data/1988/clubs.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "springfields",
+    "name": "Springfields AC",
+    "shortName": "SPR"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/1989/clubs.json
+++ b/src/data/1989/clubs.json
@@ -17,7 +17,7 @@
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/1989/clubs.json
+++ b/src/data/1989/clubs.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "springfields",
+    "name": "Springfields AC",
+    "shortName": "SPR"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/1990/clubs.json
+++ b/src/data/1990/clubs.json
@@ -17,7 +17,7 @@
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/1990/clubs.json
+++ b/src/data/1990/clubs.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "springfields",
+    "name": "Springfields AC",
+    "shortName": "SPR"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/1991/clubs.json
+++ b/src/data/1991/clubs.json
@@ -17,7 +17,7 @@
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/1991/clubs.json
+++ b/src/data/1991/clubs.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "springfields",
+    "name": "Springfields AC",
+    "shortName": "SPR"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/1992/clubs.json
+++ b/src/data/1992/clubs.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "springfields",
+    "name": "Springfields AC",
+    "shortName": "SPR"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/1992/clubs.json
+++ b/src/data/1992/clubs.json
@@ -22,7 +22,7 @@
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/1993/clubs.json
+++ b/src/data/1993/clubs.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "springfields",
+    "name": "Springfields AC",
+    "shortName": "SPR"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/1993/clubs.json
+++ b/src/data/1993/clubs.json
@@ -17,7 +17,7 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
@@ -28,7 +28,7 @@
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/1994/clubs.json
+++ b/src/data/1994/clubs.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "springfields",
+    "name": "Springfields AC",
+    "shortName": "SPR"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/1994/clubs.json
+++ b/src/data/1994/clubs.json
@@ -17,7 +17,7 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
@@ -28,7 +28,7 @@
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/1995/clubs.json
+++ b/src/data/1995/clubs.json
@@ -17,13 +17,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/1995/clubs.json
+++ b/src/data/1995/clubs.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/1996/clubs.json
+++ b/src/data/1996/clubs.json
@@ -17,13 +17,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/1996/clubs.json
+++ b/src/data/1996/clubs.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/1997/clubs.json
+++ b/src/data/1997/clubs.json
@@ -17,13 +17,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/1997/clubs.json
+++ b/src/data/1997/clubs.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/1998/clubs.json
+++ b/src/data/1998/clubs.json
@@ -17,13 +17,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/1998/clubs.json
+++ b/src/data/1998/clubs.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/1999/clubs.json
+++ b/src/data/1999/clubs.json
@@ -17,13 +17,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/1999/clubs.json
+++ b/src/data/1999/clubs.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/2000/clubs.json
+++ b/src/data/2000/clubs.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "lytham",
+    "name": "Lytham St Annes Road Runners",
+    "shortName": "LSA",
+    "logo": "lytham.svg"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/2000/clubs.json
+++ b/src/data/2000/clubs.json
@@ -6,7 +6,7 @@
   },
   {
     "id": "lytham",
-    "name": "Lytham St Annes Road Runners",
+    "name": "Lytham St Annes RR",
     "shortName": "LSA",
     "logo": "lytham.svg"
   },
@@ -23,13 +23,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/2001/clubs.json
+++ b/src/data/2001/clubs.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "lytham",
+    "name": "Lytham St Annes Road Runners",
+    "shortName": "LSA",
+    "logo": "lytham.svg"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/2001/clubs.json
+++ b/src/data/2001/clubs.json
@@ -6,7 +6,7 @@
   },
   {
     "id": "lytham",
-    "name": "Lytham St Annes Road Runners",
+    "name": "Lytham St Annes RR",
     "shortName": "LSA",
     "logo": "lytham.svg"
   },
@@ -23,13 +23,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/2002/clubs.json
+++ b/src/data/2002/clubs.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "lytham",
+    "name": "Lytham St Annes Road Runners",
+    "shortName": "LSA",
+    "logo": "lytham.svg"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/2002/clubs.json
+++ b/src/data/2002/clubs.json
@@ -6,7 +6,7 @@
   },
   {
     "id": "lytham",
-    "name": "Lytham St Annes Road Runners",
+    "name": "Lytham St Annes RR",
     "shortName": "LSA",
     "logo": "lytham.svg"
   },
@@ -23,13 +23,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/2003/clubs.json
+++ b/src/data/2003/clubs.json
@@ -11,7 +11,7 @@
   },
   {
     "id": "lytham",
-    "name": "Lytham St Annes Road Runners",
+    "name": "Lytham St Annes RR",
     "shortName": "LSA",
     "logo": "lytham.svg"
   },
@@ -28,13 +28,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/2003/clubs.json
+++ b/src/data/2003/clubs.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": "blackpool-fylde",
+    "name": "Blackpool & Fylde AC",
+    "shortName": "BFA"
+  },
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "lytham",
+    "name": "Lytham St Annes Road Runners",
+    "shortName": "LSA",
+    "logo": "lytham.svg"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/2004/clubs.json
+++ b/src/data/2004/clubs.json
@@ -11,7 +11,7 @@
   },
   {
     "id": "lytham",
-    "name": "Lytham St Annes Road Runners",
+    "name": "Lytham St Annes RR",
     "shortName": "LSA",
     "logo": "lytham.svg"
   },
@@ -28,13 +28,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/2004/clubs.json
+++ b/src/data/2004/clubs.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": "blackpool-fylde",
+    "name": "Blackpool & Fylde AC",
+    "shortName": "BFA"
+  },
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "lytham",
+    "name": "Lytham St Annes Road Runners",
+    "shortName": "LSA",
+    "logo": "lytham.svg"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/2005/clubs.json
+++ b/src/data/2005/clubs.json
@@ -11,7 +11,7 @@
   },
   {
     "id": "lytham",
-    "name": "Lytham St Annes Road Runners",
+    "name": "Lytham St Annes RR",
     "shortName": "LSA",
     "logo": "lytham.svg"
   },
@@ -28,13 +28,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/2005/clubs.json
+++ b/src/data/2005/clubs.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": "blackpool-fylde",
+    "name": "Blackpool & Fylde AC",
+    "shortName": "BFA"
+  },
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "lytham",
+    "name": "Lytham St Annes Road Runners",
+    "shortName": "LSA",
+    "logo": "lytham.svg"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/2006/clubs.json
+++ b/src/data/2006/clubs.json
@@ -11,7 +11,7 @@
   },
   {
     "id": "lytham",
-    "name": "Lytham St Annes Road Runners",
+    "name": "Lytham St Annes RR",
     "shortName": "LSA",
     "logo": "lytham.svg"
   },
@@ -28,13 +28,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/2006/clubs.json
+++ b/src/data/2006/clubs.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": "blackpool-fylde",
+    "name": "Blackpool & Fylde AC",
+    "shortName": "BFA"
+  },
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "lytham",
+    "name": "Lytham St Annes Road Runners",
+    "shortName": "LSA",
+    "logo": "lytham.svg"
+  },
+  {
+    "id": "north-fylde",
+    "name": "North Fylde AC",
+    "shortName": "NFA"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/2007/clubs.json
+++ b/src/data/2007/clubs.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "blackpool",
+    "name": "Blackpool, Wyre & Fylde AC",
+    "shortName": "BWF",
+    "logo": "blackpool.svg"
+  },
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "lytham",
+    "name": "Lytham St Annes Road Runners",
+    "shortName": "LSA",
+    "logo": "lytham.svg"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/2007/clubs.json
+++ b/src/data/2007/clubs.json
@@ -12,7 +12,7 @@
   },
   {
     "id": "lytham",
-    "name": "Lytham St Annes Road Runners",
+    "name": "Lytham St Annes RR",
     "shortName": "LSA",
     "logo": "lytham.svg"
   },
@@ -24,13 +24,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/2008/clubs.json
+++ b/src/data/2008/clubs.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "blackpool",
+    "name": "Blackpool, Wyre & Fylde AC",
+    "shortName": "BWF",
+    "logo": "blackpool.svg"
+  },
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "lytham",
+    "name": "Lytham St Annes Road Runners",
+    "shortName": "LSA",
+    "logo": "lytham.svg"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/2008/clubs.json
+++ b/src/data/2008/clubs.json
@@ -12,7 +12,7 @@
   },
   {
     "id": "lytham",
-    "name": "Lytham St Annes Road Runners",
+    "name": "Lytham St Annes RR",
     "shortName": "LSA",
     "logo": "lytham.svg"
   },
@@ -24,13 +24,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/2009/clubs.json
+++ b/src/data/2009/clubs.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "blackpool",
+    "name": "Blackpool, Wyre & Fylde AC",
+    "shortName": "BWF",
+    "logo": "blackpool.svg"
+  },
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "lytham",
+    "name": "Lytham St Annes Road Runners",
+    "shortName": "LSA",
+    "logo": "lytham.svg"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/2009/clubs.json
+++ b/src/data/2009/clubs.json
@@ -12,7 +12,7 @@
   },
   {
     "id": "lytham",
-    "name": "Lytham St Annes Road Runners",
+    "name": "Lytham St Annes RR",
     "shortName": "LSA",
     "logo": "lytham.svg"
   },
@@ -24,13 +24,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/2010/clubs.json
+++ b/src/data/2010/clubs.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "blackpool",
+    "name": "Blackpool, Wyre & Fylde AC",
+    "shortName": "BWF",
+    "logo": "blackpool.svg"
+  },
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "lytham",
+    "name": "Lytham St Annes Road Runners",
+    "shortName": "LSA",
+    "logo": "lytham.svg"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/2010/clubs.json
+++ b/src/data/2010/clubs.json
@@ -12,7 +12,7 @@
   },
   {
     "id": "lytham",
-    "name": "Lytham St Annes Road Runners",
+    "name": "Lytham St Annes RR",
     "shortName": "LSA",
     "logo": "lytham.svg"
   },
@@ -24,13 +24,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }

--- a/src/data/2011/clubs.json
+++ b/src/data/2011/clubs.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "blackpool",
+    "name": "Blackpool, Wyre & Fylde AC",
+    "shortName": "BWF",
+    "logo": "blackpool.svg"
+  },
+  {
+    "id": "chorley-ac",
+    "name": "Chorley AC",
+    "shortName": "CAC"
+  },
+  {
+    "id": "lytham",
+    "name": "Lytham St Annes Road Runners",
+    "shortName": "LSA",
+    "logo": "lytham.svg"
+  },
+  {
+    "id": "preston",
+    "name": "Preston Harriers",
+    "shortName": "PH",
+    "logo": "preston.svg"
+  },
+  {
+    "id": "red-rose",
+    "name": "Red Rose Road Runners",
+    "shortName": "RR",
+    "logo": "red-rose.svg"
+  },
+  {
+    "id": "wesham",
+    "name": "Wesham Road Runners",
+    "shortName": "WRR",
+    "logo": "wesham.svg"
+  }
+]

--- a/src/data/2011/clubs.json
+++ b/src/data/2011/clubs.json
@@ -12,7 +12,7 @@
   },
   {
     "id": "lytham",
-    "name": "Lytham St Annes Road Runners",
+    "name": "Lytham St Annes RR",
     "shortName": "LSA",
     "logo": "lytham.svg"
   },
@@ -24,13 +24,13 @@
   },
   {
     "id": "red-rose",
-    "name": "Red Rose Road Runners",
+    "name": "Red Rose RR",
     "shortName": "RR",
     "logo": "red-rose.svg"
   },
   {
     "id": "wesham",
-    "name": "Wesham Road Runners",
+    "name": "Wesham RR",
     "shortName": "WRR",
     "logo": "wesham.svg"
   }


### PR DESCRIPTION
## Summary

- Adds `clubs.json` for all years from 1985 to 2011, covering the history of the competition before the existing 2012 baseline
- Introduces historical club IDs not present in modern data: `chorley-ac` (Chorley AC — distinct from the current `chorley`/Chorley A&TC), `springfields` (Springfields AC), `north-fylde` (North Fylde AC), and `blackpool-fylde` (Blackpool & Fylde AC, predecessor to the current `blackpool`)
- Club membership per year reflects the provided historical records (1985, 1988, 1992, 1993, 1995, 2000, 2003, 2007 as anchor points; intermediate years interpolated accordingly)

## Reviewer notes

- `chorley-ac` and `chorley` are intentionally separate IDs — Chorley AC and Chorley A&TC are different clubs
- Clubs without a confirmed logo file omit the `logo` field (the type allows this for historical entries)
- The 2003 year uses `blackpool-fylde` for Blackpool & Fylde AC; the 2007 year uses `blackpool` for Blackpool, Wyre & Fylde AC (the modern club)

🤖 Generated with [Claude Code](https://claude.com/claude-code)