### PR TITLE
fix: expand abbreviated names in 2018 red-rose team results

### DIFF
--- a/src/data/2018/road-gp/results/red-rose-teams.json
+++ b/src/data/2018/road-gp/results/red-rose-teams.json
@@ -11,43 +11,43 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  5,
-                                                                 "name":  "J. Greenwood"
+                                                                 "name":  "Joe Greenwood"
                                                              },
                                                              {
                                                                  "position":  7,
-                                                                 "name":  "C. McCarthy"
+                                                                 "name":  "Christopher McCarthy"
                                                              },
                                                              {
                                                                  "position":  9,
-                                                                 "name":  "A. Draper"
+                                                                 "name":  "Andrew Draper"
                                                              },
                                                              {
                                                                  "position":  14,
-                                                                 "name":  "E. Abbott"
+                                                                 "name":  "Elizabeth Abbott"
                                                              },
                                                              {
                                                                  "position":  19,
-                                                                 "name":  "A. Leivers"
+                                                                 "name":  "Alistair Leivers"
                                                              },
                                                              {
                                                                  "position":  23,
-                                                                 "name":  "T. Howarth"
+                                                                 "name":  "Thomas Howarth"
                                                              },
                                                              {
                                                                  "position":  30,
-                                                                 "name":  "P. Veevers"
+                                                                 "name":  "Paul Veevers"
                                                              },
                                                              {
                                                                  "position":  32,
-                                                                 "name":  "N. Tate"
+                                                                 "name":  "Neil Tate"
                                                              },
                                                              {
                                                                  "position":  34,
-                                                                 "name":  "C. Carrdus"
+                                                                 "name":  "Catherine Carrdus"
                                                              },
                                                              {
                                                                  "position":  54,
-                                                                 "name":  "J. Goorney"
+                                                                 "name":  "Joanna Goorney"
                                                              }
                                                          ]
                                          },
@@ -59,43 +59,43 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  1,
-                                                                 "name":  "R. Danson"
+                                                                 "name":  "Robert Danson"
                                                              },
                                                              {
                                                                  "position":  3,
-                                                                 "name":  "G. Booth"
+                                                                 "name":  "Gareth Booth"
                                                              },
                                                              {
                                                                  "position":  6,
-                                                                 "name":  "S. Littler"
+                                                                 "name":  "Steve Littler"
                                                              },
                                                              {
                                                                  "position":  12,
-                                                                 "name":  "D. Taylor"
+                                                                 "name":  "David Taylor"
                                                              },
                                                              {
                                                                  "position":  17,
-                                                                 "name":  "U. Datavs"
+                                                                 "name":  "Ugis Datavs"
                                                              },
                                                              {
                                                                  "position":  22,
-                                                                 "name":  "S. Abbott"
+                                                                 "name":  "Stephen Abbott"
                                                              },
                                                              {
                                                                  "position":  27,
-                                                                 "name":  "L. Barlow"
+                                                                 "name":  "Lee Barlow"
                                                              },
                                                              {
                                                                  "position":  44,
-                                                                 "name":  "C. Groome"
+                                                                 "name":  "Carl Groome"
                                                              },
                                                              {
                                                                  "position":  46,
-                                                                 "name":  "M. Chamberlain"
+                                                                 "name":  "Matty Chamberlain"
                                                              },
                                                              {
                                                                  "position":  56,
-                                                                 "name":  "N. Gregson"
+                                                                 "name":  "Neil Gregson"
                                                              }
                                                          ]
                                          },
@@ -107,43 +107,43 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  2,
-                                                                 "name":  "R. Affleck"
+                                                                 "name":  "Rob Affleck"
                                                              },
                                                              {
                                                                  "position":  15,
-                                                                 "name":  "D. Watson"
+                                                                 "name":  "Dave Watson"
                                                              },
                                                              {
                                                                  "position":  20,
-                                                                 "name":  "L. Foley"
+                                                                 "name":  "Lee Foley"
                                                              },
                                                              {
                                                                  "position":  25,
-                                                                 "name":  "N. Hilditch"
+                                                                 "name":  "Nathan Hilditch"
                                                              },
                                                              {
                                                                  "position":  26,
-                                                                 "name":  "A. Whaley"
+                                                                 "name":  "Andy Whaley"
                                                              },
                                                              {
                                                                  "position":  28,
-                                                                 "name":  "S. Robinson"
+                                                                 "name":  "Simon Robinson"
                                                              },
                                                              {
                                                                  "position":  29,
-                                                                 "name":  "M. Lee"
+                                                                 "name":  "Mark Lee"
                                                              },
                                                              {
                                                                  "position":  37,
-                                                                 "name":  "N. McDonald"
+                                                                 "name":  "Neil McDonald"
                                                              },
                                                              {
                                                                  "position":  39,
-                                                                 "name":  "C. Wales"
+                                                                 "name":  "Chris Wales"
                                                              },
                                                              {
                                                                  "position":  41,
-                                                                 "name":  "D. Potter"
+                                                                 "name":  "Douglas Potter"
                                                              }
                                                          ]
                                          },
@@ -155,43 +155,43 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  4,
-                                                                 "name":  "S. Croft"
+                                                                 "name":  "Simon Croft"
                                                              },
                                                              {
                                                                  "position":  11,
-                                                                 "name":  "M. Holmes"
+                                                                 "name":  "Matt Holmes"
                                                              },
                                                              {
                                                                  "position":  18,
-                                                                 "name":  "D. Anderson"
+                                                                 "name":  "Duncan Anderson"
                                                              },
                                                              {
                                                                  "position":  21,
-                                                                 "name":  "D. Hughes"
+                                                                 "name":  "Daniel Hughes"
                                                              },
                                                              {
                                                                  "position":  38,
-                                                                 "name":  "B. Wheeler"
+                                                                 "name":  "Barry Wheeler"
                                                              },
                                                              {
                                                                  "position":  40,
-                                                                 "name":  "P. Duffell"
+                                                                 "name":  "Paul Duffell"
                                                              },
                                                              {
                                                                  "position":  42,
-                                                                 "name":  "F. Nightingale"
+                                                                 "name":  "Frank Nightingale"
                                                              },
                                                              {
                                                                  "position":  51,
-                                                                 "name":  "J. Naylor"
+                                                                 "name":  "John Naylor"
                                                              },
                                                              {
                                                                  "position":  55,
-                                                                 "name":  "M. Hall"
+                                                                 "name":  "Michael Hall"
                                                              },
                                                              {
                                                                  "position":  58,
-                                                                 "name":  "G. Corcoran"
+                                                                 "name":  "Gary Corcoran"
                                                              }
                                                          ]
                                          },
@@ -203,43 +203,43 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  10,
-                                                                 "name":  "T. Belcher"
+                                                                 "name":  "Tom Belcher"
                                                              },
                                                              {
                                                                  "position":  13,
-                                                                 "name":  "R. Walsh"
+                                                                 "name":  "Robert Walsh"
                                                              },
                                                              {
                                                                  "position":  16,
-                                                                 "name":  "G. Norris"
+                                                                 "name":  "George Norris"
                                                              },
                                                              {
                                                                  "position":  36,
-                                                                 "name":  "R. Sciacca"
+                                                                 "name":  "Ryan Sciacca"
                                                              },
                                                              {
                                                                  "position":  43,
-                                                                 "name":  "J. Mattock"
+                                                                 "name":  "Jonathan Mattock"
                                                              },
                                                              {
                                                                  "position":  47,
-                                                                 "name":  "M. Quinn"
+                                                                 "name":  "Martin Quinn"
                                                              },
                                                              {
                                                                  "position":  50,
-                                                                 "name":  "G. Yardley"
+                                                                 "name":  "Graham Yardley"
                                                              },
                                                              {
                                                                  "position":  62,
-                                                                 "name":  "M. Bond"
+                                                                 "name":  "Mark Bond"
                                                              },
                                                              {
                                                                  "position":  67,
-                                                                 "name":  "P. Wareing"
+                                                                 "name":  "Paul Wareing"
                                                              },
                                                              {
                                                                  "position":  74,
-                                                                 "name":  "W. Crook"
+                                                                 "name":  "Warren Crook"
                                                              }
                                                          ]
                                          },
@@ -251,43 +251,43 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  8,
-                                                                 "name":  "P. Leybourne"
+                                                                 "name":  "Philip Leybourne"
                                                              },
                                                              {
                                                                  "position":  33,
-                                                                 "name":  "I. Dawson"
+                                                                 "name":  "Ian Dawson"
                                                              },
                                                              {
                                                                  "position":  45,
-                                                                 "name":  "P. Sparrow"
+                                                                 "name":  "Paul Sparrow"
                                                              },
                                                              {
                                                                  "position":  48,
-                                                                 "name":  "J. Rogers"
+                                                                 "name":  "Jessica Rogers"
                                                              },
                                                              {
                                                                  "position":  53,
-                                                                 "name":  "P. Beech"
+                                                                 "name":  "Paul Beech"
                                                              },
                                                              {
                                                                  "position":  57,
-                                                                 "name":  "S. Dunn"
+                                                                 "name":  "Steve Dunn"
                                                              },
                                                              {
                                                                  "position":  82,
-                                                                 "name":  "B. Wright"
+                                                                 "name":  "Bev Wright"
                                                              },
                                                              {
                                                                  "position":  83,
-                                                                 "name":  "M. Warner"
+                                                                 "name":  "Mark Warner"
                                                              },
                                                              {
                                                                  "position":  99,
-                                                                 "name":  "P. Plummer"
+                                                                 "name":  "Paul Plummer"
                                                              },
                                                              {
                                                                  "position":  101,
-                                                                 "name":  "C. Rawcliffe"
+                                                                 "name":  "Chris Rawcliffe"
                                                              }
                                                          ]
                                          },
@@ -299,43 +299,43 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  24,
-                                                                 "name":  "J. Greenaway"
+                                                                 "name":  "James Greenaway"
                                                              },
                                                              {
                                                                  "position":  31,
-                                                                 "name":  "D. Barras"
+                                                                 "name":  "David Barras"
                                                              },
                                                              {
                                                                  "position":  35,
-                                                                 "name":  "J. Tyldesley"
+                                                                 "name":  "Joseph Tyldesley"
                                                              },
                                                              {
                                                                  "position":  75,
-                                                                 "name":  "P. Dixon"
+                                                                 "name":  "Paul Dixon"
                                                              },
                                                              {
                                                                  "position":  155,
-                                                                 "name":  "S. Thompson"
+                                                                 "name":  "Steve Thompson"
                                                              },
                                                              {
                                                                  "position":  167,
-                                                                 "name":  "S. Burgess"
+                                                                 "name":  "Steve Burgess"
                                                              },
                                                              {
                                                                  "position":  199,
-                                                                 "name":  "J. Cruse"
+                                                                 "name":  "Julie Cruse"
                                                              },
                                                              {
                                                                  "position":  204,
-                                                                 "name":  "K. Chadwick"
+                                                                 "name":  "Kieron Chadwick"
                                                              },
                                                              {
                                                                  "position":  207,
-                                                                 "name":  "S. Barton"
+                                                                 "name":  "Sarah Barton"
                                                              },
                                                              {
                                                                  "position":  214,
-                                                                 "name":  "L. Batty"
+                                                                 "name":  "Leanne Batty"
                                                              }
                                                          ]
                                          }
@@ -352,23 +352,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  1,
-                                                                 "name":  "E. Abbott"
+                                                                 "name":  "Elizabeth Abbott"
                                                              },
                                                              {
                                                                  "position":  2,
-                                                                 "name":  "C. Carrdus"
+                                                                 "name":  "Catherine Carrdus"
                                                              },
                                                              {
                                                                  "position":  4,
-                                                                 "name":  "J. Goorney"
+                                                                 "name":  "Joanna Goorney"
                                                              },
                                                              {
                                                                  "position":  6,
-                                                                 "name":  "M. Koth"
+                                                                 "name":  "Melanie Koth"
                                                              },
                                                              {
                                                                  "position":  21,
-                                                                 "name":  "H. Haigh"
+                                                                 "name":  "Heidi Haigh"
                                                              }
                                                          ]
                                          },
@@ -380,23 +380,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  3,
-                                                                 "name":  "J. Rogers"
+                                                                 "name":  "Jessica Rogers"
                                                              },
                                                              {
                                                                  "position":  8,
-                                                                 "name":  "B. Wright"
+                                                                 "name":  "Bev Wright"
                                                              },
                                                              {
                                                                  "position":  17,
-                                                                 "name":  "M. Tickle"
+                                                                 "name":  "Michelle Tickle"
                                                              },
                                                              {
                                                                  "position":  19,
-                                                                 "name":  "N. Unsworth"
+                                                                 "name":  "Nicola Unsworth"
                                                              },
                                                              {
                                                                  "position":  20,
-                                                                 "name":  "K. Dunford"
+                                                                 "name":  "Karen Dunford"
                                                              }
                                                          ]
                                          },
@@ -408,23 +408,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  7,
-                                                                 "name":  "N. Hughes"
+                                                                 "name":  "Nicola Hughes"
                                                              },
                                                              {
                                                                  "position":  9,
-                                                                 "name":  "H. McCusker"
+                                                                 "name":  "Hannah McCusker"
                                                              },
                                                              {
                                                                  "position":  14,
-                                                                 "name":  "S. Edwards"
+                                                                 "name":  "Samantha Edwards"
                                                              },
                                                              {
                                                                  "position":  18,
-                                                                 "name":  "L. Houghton"
+                                                                 "name":  "Laura Houghton"
                                                              },
                                                              {
                                                                  "position":  28,
-                                                                 "name":  "N. Moore"
+                                                                 "name":  "Natalie Moore"
                                                              }
                                                          ]
                                          },
@@ -436,23 +436,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  5,
-                                                                 "name":  "S. Bailey"
+                                                                 "name":  "Susan Bailey"
                                                              },
                                                              {
                                                                  "position":  11,
-                                                                 "name":  "J. Wren"
+                                                                 "name":  "Jenny Wren"
                                                              },
                                                              {
                                                                  "position":  12,
-                                                                 "name":  "E. Hargreaves"
+                                                                 "name":  "Emma Hargreaves"
                                                              },
                                                              {
                                                                  "position":  27,
-                                                                 "name":  "V. Sherrington"
+                                                                 "name":  "Vicki Sherrington"
                                                              },
                                                              {
                                                                  "position":  30,
-                                                                 "name":  "D. Parkes"
+                                                                 "name":  "Dolly Parkes"
                                                              }
                                                          ]
                                          },
@@ -464,23 +464,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  10,
-                                                                 "name":  "H. Lawrenson"
+                                                                 "name":  "Helen Lawrenson"
                                                              },
                                                              {
                                                                  "position":  13,
-                                                                 "name":  "C. Sullivan"
+                                                                 "name":  "Carmel Sullivan"
                                                              },
                                                              {
                                                                  "position":  22,
-                                                                 "name":  "T. Hulme"
+                                                                 "name":  "Tracey Hulme"
                                                              },
                                                              {
                                                                  "position":  32,
-                                                                 "name":  "G. Owen"
+                                                                 "name":  "Gemma Owen"
                                                              },
                                                              {
                                                                  "position":  34,
-                                                                 "name":  "M. Danson"
+                                                                 "name":  "Maureen Danson"
                                                              }
                                                          ]
                                          },
@@ -492,23 +492,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  15,
-                                                                 "name":  "S. Jeffrey"
+                                                                 "name":  "Sarah Jeffrey"
                                                              },
                                                              {
                                                                  "position":  16,
-                                                                 "name":  "A. Fairhurst"
+                                                                 "name":  "Annette Fairhurst"
                                                              },
                                                              {
                                                                  "position":  25,
-                                                                 "name":  "L. Dickinson"
+                                                                 "name":  "Lara Dickinson"
                                                              },
                                                              {
                                                                  "position":  44,
-                                                                 "name":  "J. Barrow"
+                                                                 "name":  "Janet Barrow"
                                                              },
                                                              {
                                                                  "position":  99,
-                                                                 "name":  "A. Cain"
+                                                                 "name":  "Alison Cain"
                                                              }
                                                          ]
                                          },
@@ -520,23 +520,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  43,
-                                                                 "name":  "J. Cruse"
+                                                                 "name":  "Julie Cruse"
                                                              },
                                                              {
                                                                  "position":  47,
-                                                                 "name":  "S. Barton"
+                                                                 "name":  "Sarah Barton"
                                                              },
                                                              {
                                                                  "position":  52,
-                                                                 "name":  "L. Batty"
+                                                                 "name":  "Leanne Batty"
                                                              },
                                                              {
                                                                  "position":  53,
-                                                                 "name":  "D. Saunders"
+                                                                 "name":  "Dawn Saunders"
                                                              },
                                                              {
                                                                  "position":  58,
-                                                                 "name":  "Z. Byrne"
+                                                                 "name":  "Zara Byrne"
                                                              }
                                                          ]
                                          }
@@ -553,27 +553,27 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  1,
-                                                                 "name":  "R. Affleck"
+                                                                 "name":  "Rob Affleck"
                                                              },
                                                              {
                                                                  "position":  7,
-                                                                 "name":  "D. Watson"
+                                                                 "name":  "Dave Watson"
                                                              },
                                                              {
                                                                  "position":  10,
-                                                                 "name":  "A. Whaley"
+                                                                 "name":  "Andy Whaley"
                                                              },
                                                              {
                                                                  "position":  12,
-                                                                 "name":  "M. Lee"
+                                                                 "name":  "Mark Lee"
                                                              },
                                                              {
                                                                  "position":  14,
-                                                                 "name":  "N. McDonald"
+                                                                 "name":  "Neil McDonald"
                                                              },
                                                              {
                                                                  "position":  15,
-                                                                 "name":  "C. Wales"
+                                                                 "name":  "Chris Wales"
                                                              }
                                                          ]
                                          },
@@ -585,27 +585,27 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  2,
-                                                                 "name":  "G. Booth"
+                                                                 "name":  "Gareth Booth"
                                                              },
                                                              {
                                                                  "position":  3,
-                                                                 "name":  "S. Littler"
+                                                                 "name":  "Steve Littler"
                                                              },
                                                              {
                                                                  "position":  9,
-                                                                 "name":  "S. Abbott"
+                                                                 "name":  "Stephen Abbott"
                                                              },
                                                              {
                                                                  "position":  11,
-                                                                 "name":  "L. Barlow"
+                                                                 "name":  "Lee Barlow"
                                                              },
                                                              {
                                                                  "position":  19,
-                                                                 "name":  "C. Groome"
+                                                                 "name":  "Carl Groome"
                                                              },
                                                              {
                                                                  "position":  21,
-                                                                 "name":  "M. Chamberlain"
+                                                                 "name":  "Matty Chamberlain"
                                                              }
                                                          ]
                                          },
@@ -617,27 +617,27 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  8,
-                                                                 "name":  "D. Anderson"
+                                                                 "name":  "Duncan Anderson"
                                                              },
                                                              {
                                                                  "position":  16,
-                                                                 "name":  "P. Duffell"
+                                                                 "name":  "Paul Duffell"
                                                              },
                                                              {
                                                                  "position":  17,
-                                                                 "name":  "F. Nightingale"
+                                                                 "name":  "Frank Nightingale"
                                                              },
                                                              {
                                                                  "position":  27,
-                                                                 "name":  "M. Hall"
+                                                                 "name":  "Michael Hall"
                                                              },
                                                              {
                                                                  "position":  29,
-                                                                 "name":  "G. Corcoran"
+                                                                 "name":  "Gary Corcoran"
                                                              },
                                                              {
                                                                  "position":  30,
-                                                                 "name":  "K. Addison"
+                                                                 "name":  "Kenneth Addison"
                                                              }
                                                          ]
                                          },
@@ -649,27 +649,27 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  5,
-                                                                 "name":  "R. Walsh"
+                                                                 "name":  "Robert Walsh"
                                                              },
                                                              {
                                                                  "position":  18,
-                                                                 "name":  "J. Mattock"
+                                                                 "name":  "Jonathan Mattock"
                                                              },
                                                              {
                                                                  "position":  22,
-                                                                 "name":  "M. Quinn"
+                                                                 "name":  "Martin Quinn"
                                                              },
                                                              {
                                                                  "position":  23,
-                                                                 "name":  "G. Yardley"
+                                                                 "name":  "Graham Yardley"
                                                              },
                                                              {
                                                                  "position":  35,
-                                                                 "name":  "P. Wareing"
+                                                                 "name":  "Paul Wareing"
                                                              },
                                                              {
                                                                  "position":  41,
-                                                                 "name":  "W. Crook"
+                                                                 "name":  "Warren Crook"
                                                              }
                                                          ]
                                          },
@@ -681,27 +681,27 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  6,
-                                                                 "name":  "E. Abbott"
+                                                                 "name":  "Elizabeth Abbott"
                                                              },
                                                              {
                                                                  "position":  13,
-                                                                 "name":  "C. Carrdus"
+                                                                 "name":  "Catherine Carrdus"
                                                              },
                                                              {
                                                                  "position":  26,
-                                                                 "name":  "J. Goorney"
+                                                                 "name":  "Joanna Goorney"
                                                              },
                                                              {
                                                                  "position":  36,
-                                                                 "name":  "D. Ames"
+                                                                 "name":  "Darran Ames"
                                                              },
                                                              {
                                                                  "position":  44,
-                                                                 "name":  "M. Koth"
+                                                                 "name":  "Melanie Koth"
                                                              },
                                                              {
                                                                  "position":  47,
-                                                                 "name":  "I. Tate"
+                                                                 "name":  "Ian Tate"
                                                              }
                                                          ]
                                          },
@@ -713,27 +713,27 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  4,
-                                                                 "name":  "P. Leybourne"
+                                                                 "name":  "Philip Leybourne"
                                                              },
                                                              {
                                                                  "position":  20,
-                                                                 "name":  "P. Sparrow"
+                                                                 "name":  "Paul Sparrow"
                                                              },
                                                              {
                                                                  "position":  25,
-                                                                 "name":  "P. Beech"
+                                                                 "name":  "Paul Beech"
                                                              },
                                                              {
                                                                  "position":  28,
-                                                                 "name":  "S. Dunn"
+                                                                 "name":  "Steve Dunn"
                                                              },
                                                              {
                                                                  "position":  48,
-                                                                 "name":  "B. Wright"
+                                                                 "name":  "Bev Wright"
                                                              },
                                                              {
                                                                  "position":  59,
-                                                                 "name":  "P. Plummer"
+                                                                 "name":  "Paul Plummer"
                                                              }
                                                          ]
                                          },
@@ -745,27 +745,27 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  42,
-                                                                 "name":  "P. Dixon"
+                                                                 "name":  "Paul Dixon"
                                                              },
                                                              {
                                                                  "position":  98,
-                                                                 "name":  "S. Thompson"
+                                                                 "name":  "Steve Thompson"
                                                              },
                                                              {
                                                                  "position":  107,
-                                                                 "name":  "S. Burgess"
+                                                                 "name":  "Steve Burgess"
                                                              },
                                                              {
                                                                  "position":  133,
-                                                                 "name":  "J. Cruse"
+                                                                 "name":  "Julie Cruse"
                                                              },
                                                              {
                                                                  "position":  138,
-                                                                 "name":  "K. Chadwick"
+                                                                 "name":  "Kieron Chadwick"
                                                              },
                                                              {
                                                                  "position":  140,
-                                                                 "name":  "S. Barton"
+                                                                 "name":  "Sarah Barton"
                                                              }
                                                          ]
                                          }
@@ -782,23 +782,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  1,
-                                                                 "name":  "C. Carrdus"
+                                                                 "name":  "Catherine Carrdus"
                                                              },
                                                              {
                                                                  "position":  2,
-                                                                 "name":  "J. Goorney"
+                                                                 "name":  "Joanna Goorney"
                                                              },
                                                              {
                                                                  "position":  3,
-                                                                 "name":  "M. Koth"
+                                                                 "name":  "Melanie Koth"
                                                              },
                                                              {
                                                                  "position":  10,
-                                                                 "name":  "H. Haigh"
+                                                                 "name":  "Heidi Haigh"
                                                              },
                                                              {
                                                                  "position":  22,
-                                                                 "name":  "J. Rolfe"
+                                                                 "name":  "Julia Rolfe"
                                                              }
                                                          ]
                                          },
@@ -810,23 +810,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  4,
-                                                                 "name":  "B. Wright"
+                                                                 "name":  "Bev Wright"
                                                              },
                                                              {
                                                                  "position":  7,
-                                                                 "name":  "M. Tickle"
+                                                                 "name":  "Michelle Tickle"
                                                              },
                                                              {
                                                                  "position":  8,
-                                                                 "name":  "N. Unsworth"
+                                                                 "name":  "Nicola Unsworth"
                                                              },
                                                              {
                                                                  "position":  9,
-                                                                 "name":  "K. Dunford"
+                                                                 "name":  "Karen Dunford"
                                                              },
                                                              {
                                                                  "position":  13,
-                                                                 "name":  "N. Tanner"
+                                                                 "name":  "Natalie Tanner"
                                                              }
                                                          ]
                                          },
@@ -838,23 +838,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  5,
-                                                                 "name":  "H. Lawrenson"
+                                                                 "name":  "Helen Lawrenson"
                                                              },
                                                              {
                                                                  "position":  6,
-                                                                 "name":  "C. Sullivan"
+                                                                 "name":  "Carmel Sullivan"
                                                              },
                                                              {
                                                                  "position":  11,
-                                                                 "name":  "T. Hulme"
+                                                                 "name":  "Tracey Hulme"
                                                              },
                                                              {
                                                                  "position":  18,
-                                                                 "name":  "M. Danson"
+                                                                 "name":  "Maureen Danson"
                                                              },
                                                              {
                                                                  "position":  19,
-                                                                 "name":  "S. Leonard"
+                                                                 "name":  "Suzanne Leonard"
                                                              }
                                                          ]
                                          },
@@ -866,23 +866,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  15,
-                                                                 "name":  "A. Croft"
+                                                                 "name":  "Alicia Croft"
                                                              },
                                                              {
                                                                  "position":  17,
-                                                                 "name":  "A. Cleave"
+                                                                 "name":  "Ann Cleave"
                                                              },
                                                              {
                                                                  "position":  20,
-                                                                 "name":  "J. Gouldthorpe"
+                                                                 "name":  "Joan Gouldthorpe"
                                                              },
                                                              {
                                                                  "position":  27,
-                                                                 "name":  "C. Douglass"
+                                                                 "name":  "Carol Douglass"
                                                              },
                                                              {
                                                                  "position":  32,
-                                                                 "name":  "K. White"
+                                                                 "name":  "Kelly White"
                                                              }
                                                          ]
                                          },
@@ -894,23 +894,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  24,
-                                                                 "name":  "J. Cruse"
+                                                                 "name":  "Julie Cruse"
                                                              },
                                                              {
                                                                  "position":  28,
-                                                                 "name":  "L. Batty"
+                                                                 "name":  "Leanne Batty"
                                                              },
                                                              {
                                                                  "position":  29,
-                                                                 "name":  "D. Saunders"
+                                                                 "name":  "Dawn Saunders"
                                                              },
                                                              {
                                                                  "position":  33,
-                                                                 "name":  "V. Wrigley"
+                                                                 "name":  "Victoria Wrigley"
                                                              },
                                                              {
                                                                  "position":  36,
-                                                                 "name":  "D. Cardwell"
+                                                                 "name":  "Deborah Cardwell"
                                                              }
                                                          ]
                                          },
@@ -922,23 +922,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  14,
-                                                                 "name":  "V. Sherrington"
+                                                                 "name":  "Vicki Sherrington"
                                                              },
                                                              {
                                                                  "position":  26,
-                                                                 "name":  "J. Tyrer"
+                                                                 "name":  "Julie Tyrer"
                                                              },
                                                              {
                                                                  "position":  43,
-                                                                 "name":  "S. Wickham"
+                                                                 "name":  "Sue Wickham"
                                                              },
                                                              {
                                                                  "position":  44,
-                                                                 "name":  "M. Kirkby"
+                                                                 "name":  "Maureen Kirkby"
                                                              },
                                                              {
                                                                  "position":  55,
-                                                                 "name":  "S. Clubb"
+                                                                 "name":  "Sarah Clubb"
                                                              }
                                                          ]
                                          },
@@ -950,15 +950,15 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  12,
-                                                                 "name":  "L. Dickinson"
+                                                                 "name":  "Lara Dickinson"
                                                              },
                                                              {
                                                                  "position":  25,
-                                                                 "name":  "J. Barrow"
+                                                                 "name":  "Janet Barrow"
                                                              },
                                                              {
                                                                  "position":  59,
-                                                                 "name":  "A. Cain"
+                                                                 "name":  "Alison Cain"
                                                              }
                                                          ]
                                          }
@@ -975,19 +975,19 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  2,
-                                                                 "name":  "D. Watson"
+                                                                 "name":  "Dave Watson"
                                                              },
                                                              {
                                                                  "position":  3,
-                                                                 "name":  "M. Lee"
+                                                                 "name":  "Mark Lee"
                                                              },
                                                              {
                                                                  "position":  4,
-                                                                 "name":  "N. McDonald"
+                                                                 "name":  "Neil McDonald"
                                                              },
                                                              {
                                                                  "position":  7,
-                                                                 "name":  "W. Johnstone"
+                                                                 "name":  "William Johnstone"
                                                              }
                                                          ]
                                          },
@@ -999,19 +999,19 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  5,
-                                                                 "name":  "F. Nightingale"
+                                                                 "name":  "Frank Nightingale"
                                                              },
                                                              {
                                                                  "position":  8,
-                                                                 "name":  "M. Hall"
+                                                                 "name":  "Michael Hall"
                                                              },
                                                              {
                                                                  "position":  9,
-                                                                 "name":  "K. Addison"
+                                                                 "name":  "Kenneth Addison"
                                                              },
                                                              {
                                                                  "position":  14,
-                                                                 "name":  "J. Allen"
+                                                                 "name":  "John Allen"
                                                              }
                                                          ]
                                          },
@@ -1023,19 +1023,19 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  1,
-                                                                 "name":  "P. Leybourne"
+                                                                 "name":  "Philip Leybourne"
                                                              },
                                                              {
                                                                  "position":  6,
-                                                                 "name":  "P. Sparrow"
+                                                                 "name":  "Paul Sparrow"
                                                              },
                                                              {
                                                                  "position":  20,
-                                                                 "name":  "B. Wright"
+                                                                 "name":  "Bev Wright"
                                                              },
                                                              {
                                                                  "position":  26,
-                                                                 "name":  "B. Willoughby"
+                                                                 "name":  "Brandon Willoughby"
                                                              }
                                                          ]
                                          },
@@ -1047,19 +1047,19 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  10,
-                                                                 "name":  "N. Shepherd"
+                                                                 "name":  "Nigel Shepherd"
                                                              },
                                                              {
                                                                  "position":  16,
-                                                                 "name":  "J. Collier"
+                                                                 "name":  "John Collier"
                                                              },
                                                              {
                                                                  "position":  23,
-                                                                 "name":  "C. Sullivan"
+                                                                 "name":  "Carmel Sullivan"
                                                              },
                                                              {
                                                                  "position":  33,
-                                                                 "name":  "S. Browne"
+                                                                 "name":  "Stephen Browne"
                                                              }
                                                          ]
                                          },
@@ -1071,19 +1071,19 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  13,
-                                                                 "name":  "P. Wareing"
+                                                                 "name":  "Paul Wareing"
                                                              },
                                                              {
                                                                  "position":  17,
-                                                                 "name":  "W. Crook"
+                                                                 "name":  "Warren Crook"
                                                              },
                                                              {
                                                                  "position":  29,
-                                                                 "name":  "D. North"
+                                                                 "name":  "David North"
                                                              },
                                                              {
                                                                  "position":  37,
-                                                                 "name":  "S. Baker"
+                                                                 "name":  "Stephen Baker"
                                                              }
                                                          ]
                                          },
@@ -1095,19 +1095,19 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  21,
-                                                                 "name":  "J. Bertenshaw"
+                                                                 "name":  "John Bertenshaw"
                                                              },
                                                              {
                                                                  "position":  27,
-                                                                 "name":  "T. Hellings"
+                                                                 "name":  "Terry Hellings"
                                                              },
                                                              {
                                                                  "position":  51,
-                                                                 "name":  "I. Balshaw"
+                                                                 "name":  "Ian Balshaw"
                                                              },
                                                              {
                                                                  "position":  61,
-                                                                 "name":  "S. Tate"
+                                                                 "name":  "Steve Tate"
                                                              }
                                                          ]
                                          },
@@ -1119,19 +1119,19 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  46,
-                                                                 "name":  "S. Thompson"
+                                                                 "name":  "Steve Thompson"
                                                              },
                                                              {
                                                                  "position":  50,
-                                                                 "name":  "S. Burgess"
+                                                                 "name":  "Steve Burgess"
                                                              },
                                                              {
                                                                  "position":  67,
-                                                                 "name":  "J. Cruse"
+                                                                 "name":  "Julie Cruse"
                                                              },
                                                              {
                                                                  "position":  79,
-                                                                 "name":  "A. Whitlam"
+                                                                 "name":  "Andy Whitlam"
                                                              }
                                                          ]
                                          }
@@ -1148,15 +1148,15 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  3,
-                                                                 "name":  "K. Beardzley"
+                                                                 "name":  "Kenneth Beardzley"
                                                              },
                                                              {
                                                                  "position":  5,
-                                                                 "name":  "C. Hogarth"
+                                                                 "name":  "Carl Hogarth"
                                                              },
                                                              {
                                                                  "position":  10,
-                                                                 "name":  "A. Appleby"
+                                                                 "name":  "Alan Appleby"
                                                              }
                                                          ]
                                          },
@@ -1168,15 +1168,15 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  2,
-                                                                 "name":  "N. Shepherd"
+                                                                 "name":  "Nigel Shepherd"
                                                              },
                                                              {
                                                                  "position":  4,
-                                                                 "name":  "J. Collier"
+                                                                 "name":  "John Collier"
                                                              },
                                                              {
                                                                  "position":  12,
-                                                                 "name":  "P. Leaver"
+                                                                 "name":  "Philip Leaver"
                                                              }
                                                          ]
                                          },
@@ -1188,15 +1188,15 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  1,
-                                                                 "name":  "K. Addison"
+                                                                 "name":  "Kenneth Addison"
                                                              },
                                                              {
                                                                  "position":  9,
-                                                                 "name":  "R. Taylor"
+                                                                 "name":  "Ray Taylor"
                                                              },
                                                              {
                                                                  "position":  13,
-                                                                 "name":  "D. Hooton"
+                                                                 "name":  "David Hooton"
                                                              }
                                                          ]
                                          },
@@ -1208,15 +1208,15 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  6,
-                                                                 "name":  "J. Bertenshaw"
+                                                                 "name":  "John Bertenshaw"
                                                              },
                                                              {
                                                                  "position":  8,
-                                                                 "name":  "T. Hellings"
+                                                                 "name":  "Terry Hellings"
                                                              },
                                                              {
                                                                  "position":  23,
-                                                                 "name":  "S. Tate"
+                                                                 "name":  "Steve Tate"
                                                              }
                                                          ]
                                          },
@@ -1228,15 +1228,15 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  7,
-                                                                 "name":  "B. Willoughby"
+                                                                 "name":  "Brandon Willoughby"
                                                              },
                                                              {
                                                                  "position":  11,
-                                                                 "name":  "R. Smallbone"
+                                                                 "name":  "Reg Smallbone"
                                                              },
                                                              {
                                                                  "position":  20,
-                                                                 "name":  "D. Twizell"
+                                                                 "name":  "David Twizell"
                                                              }
                                                          ]
                                          },
@@ -1248,15 +1248,15 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  15,
-                                                                 "name":  "A. Lowe"
+                                                                 "name":  "Andrew Lowe"
                                                              },
                                                              {
                                                                  "position":  28,
-                                                                 "name":  "S. Thomas"
+                                                                 "name":  "Steve Thomas"
                                                              },
                                                              {
                                                                  "position":  32,
-                                                                 "name":  "S. Wilde"
+                                                                 "name":  "Steven Wilde"
                                                              }
                                                          ]
                                          },
@@ -1268,15 +1268,15 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  34,
-                                                                 "name":  "A. Whitlam"
+                                                                 "name":  "Andy Whitlam"
                                                              },
                                                              {
                                                                  "position":  40,
-                                                                 "name":  "A. Norris"
+                                                                 "name":  "Angela Norris"
                                                              },
                                                              {
                                                                  "position":  45,
-                                                                 "name":  "C. Fletcher"
+                                                                 "name":  "Catherine Fletcher"
                                                              }
                                                          ]
                                          }


### PR DESCRIPTION
## Summary

Expand all abbreviated runner names in the 2018 Red Rose road race team results JSON file.

## Changes

- **229 abbreviated names expanded to full names**
- Names matched by surname, first initial, and club affiliation
- All team scorers now display full names instead of initials

## Examples

- 'M. Hall' → 'Michael Hall' (red-rose)
- 'P. Leybourne' → 'Philip Leybourne' (blackpool)
- 'N. Tate' → 'Neil Tate' (lytham)
- 'J. Greenwood' → 'Joe Greenwood' (lytham)
- 'C. Carrdus' → 'Catherine Carrdus' (lytham)

## Context

This follows the completion of the 2018 Red Rose race data correction, which included:
- Correcting all runner clubs (were incorrectly marked as "Guest")
- Extracting accurate finish times from Excel source
- Normalizing all categories and sex values

With the full CSV now complete and accurate, this allows team results to display the same full runner names as the individual race results.