### PR TITLE
fix: expand abbreviated names in 2014 Lytham team results

### DIFF
--- a/src/data/2014/road-gp/results/lytham-teams.json
+++ b/src/data/2014/road-gp/results/lytham-teams.json
@@ -223,7 +223,7 @@
                                                              },
                                                              {
                                                                  "position":  47,
-                                                                 "name":  "O.Hirst"
+                                                                 "name":  "Oliver Hirst"
                                                              },
                                                              {
                                                                  "position":  66,
@@ -271,11 +271,11 @@
                                                              },
                                                              {
                                                                  "position":  72,
-                                                                 "name":  "B.Beckett"
+                                                                 "name":  "BillBeckett"
                                                              },
                                                              {
                                                                  "position":  73,
-                                                                 "name":  "K.Johnson"
+                                                                 "name":  "Keith Johnson"
                                                              },
                                                              {
                                                                  "position":  90,
@@ -593,7 +593,7 @@
                                                              },
                                                              {
                                                                  "position":  42,
-                                                                 "name":  "B.Beckett"
+                                                                 "name":  "Bill Beckett"
                                                              },
                                                              {
                                                                  "position":  54,
@@ -774,7 +774,7 @@
                                                              },
                                                              {
                                                                  "position":  40,
-                                                                 "name":  "T.Orrell"
+                                                                 "name":  "Ted Orrell"
                                                              },
                                                              {
                                                                  "position":  45,
@@ -823,7 +823,7 @@
                                                              },
                                                              {
                                                                  "position":  12,
-                                                                 "name":  "R.Massey"
+                                                                 "name":  "Bob Massey"
                                                              }
                                                          ]
                                          },
@@ -895,7 +895,7 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  14,
-                                                                 "name":  "T.Orrell"
+                                                                 "name":  "Ted Orrell"
                                                              },
                                                              {
                                                                  "position":  16,

--- a/src/data/2014/road-gp/results/lytham-teams.json
+++ b/src/data/2014/road-gp/results/lytham-teams.json
@@ -123,27 +123,27 @@
                                                              },
                                                              {
                                                                  "position":  28,
-                                                                 "name":  "K.Addison"
+                                                                 "name":  "Ken Addison"
                                                              },
                                                              {
                                                                  "position":  34,
-                                                                 "name":  "A.Murphy"
+                                                                 "name":  "Anthony Murphy"
                                                              },
                                                              {
                                                                  "position":  39,
-                                                                 "name":  "S.Cann"
+                                                                 "name":  "Stuart Cann"
                                                              },
                                                              {
                                                                  "position":  40,
-                                                                 "name":  "S.Whitney"
+                                                                 "name":  "Steven Whitney"
                                                              },
                                                              {
                                                                  "position":  48,
-                                                                 "name":  "J.Allen"
+                                                                 "name":  "John Allen"
                                                              },
                                                              {
                                                                  "position":  49,
-                                                                 "name":  "A.Durkin"
+                                                                 "name":  "Anthony Durkin"
                                                              }
                                                          ]
                                          },
@@ -416,23 +416,23 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  16,
-                                                                 "name":  "J.Needham"
+                                                                 "name":  "Janine Needham"
                                                              },
                                                              {
                                                                  "position":  29,
-                                                                 "name":  "P.Plowman"
+                                                                 "name":  "Paula Plowman"
                                                              },
                                                              {
                                                                  "position":  37,
-                                                                 "name":  "C.Douglas"
+                                                                 "name":  "Carol Douglas"
                                                              },
                                                              {
                                                                  "position":  43,
-                                                                 "name":  "J.Gouldthorpe"
+                                                                 "name":  "Joan Gouldthorpe"
                                                              },
                                                              {
                                                                  "position":  44,
-                                                                 "name":  "J.Fairclough"
+                                                                 "name":  "Jenny Fairclough"
                                                              }
                                                          ]
                                          }
@@ -513,27 +513,27 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  14,
-                                                                 "name":  "K.Addison"
+                                                                 "name":  "Ken Addison"
                                                              },
                                                              {
                                                                  "position":  17,
-                                                                 "name":  "A.Murphy"
+                                                                 "name":  "Anthony Murphy"
                                                              },
                                                              {
                                                                  "position":  20,
-                                                                 "name":  "S.Cann"
+                                                                 "name":  "Stuart Cann"
                                                              },
                                                              {
                                                                  "position":  21,
-                                                                 "name":  "S.Whitney"
+                                                                 "name":  "Steven Whitney"
                                                              },
                                                              {
                                                                  "position":  25,
-                                                                 "name":  "J.Allen"
+                                                                 "name":  "John Allen"
                                                              },
                                                              {
                                                                  "position":  31,
-                                                                 "name":  "D.Brinton"
+                                                                 "name":  "David Brinton"
                                                              }
                                                          ]
                                          },
@@ -694,19 +694,19 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  4,
-                                                                 "name":  "K.Addison"
+                                                                 "name":  "Ken Addison"
                                                              },
                                                              {
                                                                  "position":  8,
-                                                                 "name":  "S.Cann"
+                                                                 "name":  "Stuart Cann"
                                                              },
                                                              {
                                                                  "position":  10,
-                                                                 "name":  "J.Allen"
+                                                                 "name":  "John Allen"
                                                              },
                                                              {
                                                                  "position":  14,
-                                                                 "name":  "F.Nightingale"
+                                                                 "name":  "Frank Nightingale"
                                                              }
                                                          ]
                                          },
@@ -835,15 +835,15 @@
                                              "scorers":  [
                                                              {
                                                                  "position":  5,
-                                                                 "name":  "D.Hooton"
+                                                                 "name":  "Dave Hooton"
                                                              },
                                                              {
                                                                  "position":  13,
-                                                                 "name":  "N.Marshall"
+                                                                 "name":  "Neil Marshall"
                                                              },
                                                              {
                                                                  "position":  15,
-                                                                 "name":  "C.Douglas"
+                                                                 "name":  "Carol Douglas"
                                                              }
                                                          ]
                                          },


### PR DESCRIPTION
## Summary

Expand all abbreviated runner names in the 2014 Lytham road race team results JSON file.

## Changes

- **31 abbreviated names expanded to full names across multiple passes**
- Names matched by surname, first initial, and club affiliation
- All successfully matched team scorers now display full names instead of initials

## Name Expansions

First pass (27 names):
- K.Addison → Ken Addison (red-rose)
- A.Murphy → Anthony Murphy (red-rose)
- S.Cann → Stuart Cann (red-rose)
- S.Whitney → Steven Whitney (red-rose)
- J.Allen → John Allen (red-rose)
- A.Durkin → Anthony Durkin (red-rose)
- D.Hooton → Dave Hooton (red-rose)
- N.Marshall → Neil Marshall (red-rose)
- C.Douglas → Carol Douglas (red-rose)

Second pass (additional 4+ names):
- O.Hirst → Oliver Hirst
- B.Beckett → Bill Beckett
- K.Johnson → Keith Johnson
- T.Orrell → Ted Orrell

## Context

The 2014 Lytham race results CSV is now complete with accurate runner data. This PR updates the team results JSON to display the same full runner names as the individual results, improving consistency and readability of the team scoring display.