### PR TITLE
feat: add awards history timeline pages

### DIFF
--- a/docs/superpowers/plans/2026-05-16-awards-history-timeline.md
+++ b/docs/superpowers/plans/2026-05-16-awards-history-timeline.md
@@ -1,0 +1,611 @@
+# Awards History Timeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create dedicated history pages showing award winners across all years for Road GP and Fell Championship series without requiring navigation to individual year pages.
+
+**Architecture:** Build four static pages using dynamic routing (`[series]/[type]`), reusing award resolution logic from existing year pages. Load all awards files at build time via `import.meta.glob`, aggregate by series, and render in two layouts (tabular for teams, cards for individuals). Navigation links guide users to history pages from series index pages.
+
+**Tech Stack:** Astro (static generation), TypeScript, TailwindCSS + DaisyUI, existing types and data loading patterns from `src/lib/results.ts`.
+
+---
+
+## File Structure
+
+**New files:**
+- `src/components/AwardsHistoryTeams.astro` — Renders tabular team awards history
+- `src/components/AwardsHistoryIndividuals.astro` — Renders chronological year cards with individual awards
+- `src/pages/history/[series]/[type].astro` — Dynamic page router for four history pages
+
+**Modified files:**
+- `src/lib/results.ts` — Add helper functions to load and aggregate awards across all years
+- `src/pages/road-gp/[year]/index.astro` — Add navigation link to history pages
+- `src/pages/fell/[year]/index.astro` — Add navigation link to history pages
+
+---
+
+## Task 1: Add Award Aggregation Helpers to `src/lib/results.ts`
+
+**Files:**
+- Modify: `src/lib/results.ts:1-90` (add new functions after existing imports and globs)
+
+- [ ] **Step 1: Add new import.meta.glob calls for awards data**
+
+Open `src/lib/results.ts` and locate the existing `import.meta.glob` declarations (around line 76-85). After the existing `roadAwardsFiles` and `fellAwardsFiles` globs, these are already defined, so we'll use them to build aggregation functions.
+
+No code changes needed here — the globs already exist.
+
+- [ ] **Step 2: Add getAllAwardsByYear helper function**
+
+Add this function after the existing helper functions in `src/lib/results.ts`:
+
+```typescript
+interface YearlyAwardsData {
+  year: number;
+  awards: SeriesAwards;
+  clubs: Club[];
+  config: SeriesConfig;
+}
+
+export function getAllAwardsByYear(series: Series): YearlyAwardsData[] {
+  const awardsFiles = awardsFilesForSeries(series);
+  const awardsList: YearlyAwardsData[] = [];
+
+  Object.keys(awardsFiles).forEach(path => {
+    const match = path.match(/\/data\/(\d+)\//);
+    if (!match) return;
+    
+    const year = parseInt(match[1], 10);
+    const awards = awardsFiles[path].default;
+    const clubs = getClubs(year);
+    const config = getSeriesConfig(year, series);
+    
+    awardsList.push({ year, awards, clubs, config });
+  });
+
+  // Sort by year descending (newest first)
+  return awardsList.sort((a, b) => b.year - a.year);
+}
+```
+
+- [ ] **Step 3: Run npm test to ensure no TypeScript errors**
+
+```bash
+npm test
+```
+
+Expected: All tests pass or fail in pre-existing ways (no new errors introduced).
+
+- [ ] **Step 4: Run npm run build to check that globs work correctly**
+
+```bash
+npm run build
+```
+
+Expected: Build completes successfully; no "glob not found" or import errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/results.ts
+git commit -m "feat: add getAllAwardsByYear helper for aggregating awards by year"
+```
+
+---
+
+## Task 2: Create AwardsHistoryTeams Component
+
+**Files:**
+- Create: `src/components/AwardsHistoryTeams.astro`
+
+- [ ] **Step 1: Create the component file with props interface**
+
+Create `src/components/AwardsHistoryTeams.astro` with the following content:
+
+```astro
+---
+import type { Series, TeamCategory, Club } from '../lib/types';
+
+interface YearlyTeamAwards {
+  year: number;
+  categoryWinners: Record<string, string | null>; // categoryId → clubName or null
+}
+
+interface Props {
+  series: Series;
+  yearlyData: YearlyTeamAwards[];
+  allCategories: TeamCategory[];
+}
+
+const { yearlyData, allCategories } = Astro.props;
+---
+
+<div class="overflow-x-auto">
+  <table class="table table-sm w-full">
+    <thead>
+      <tr>
+        <th class="text-base">Year</th>
+        {allCategories.map(cat => (
+          <th class="text-center text-sm">{cat.name}</th>
+        ))}
+      </tr>
+    </thead>
+    <tbody>
+      {yearlyData.map(yearly => (
+        <tr class="hover">
+          <td class="font-semibold">{yearly.year}</td>
+          {allCategories.map(cat => (
+            <td class="text-center text-sm">
+              {yearly.categoryWinners[cat.id] ?? '—'}
+            </td>
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  </table>
+</div>
+```
+
+- [ ] **Step 2: Verify component syntax with npm run build**
+
+```bash
+npm run build
+```
+
+Expected: Build completes successfully; no Astro syntax errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/AwardsHistoryTeams.astro
+git commit -m "feat: create AwardsHistoryTeams component with tabular layout"
+```
+
+---
+
+## Task 3: Create AwardsHistoryIndividuals Component
+
+**Files:**
+- Create: `src/components/AwardsHistoryIndividuals.astro`
+
+- [ ] **Step 1: Create the component file with award resolution logic**
+
+Create `src/components/AwardsHistoryIndividuals.astro`:
+
+```astro
+---
+import type { Series, IndividualCategory } from '../lib/types';
+
+interface ResolvedAwardEntry {
+  position: number;
+  name: string;
+  clubName: string;
+  ageCategory?: string;
+  runnerUrl?: string;
+}
+
+interface ResolvedCategory {
+  categoryName: string;
+  awards: ResolvedAwardEntry[];
+}
+
+interface YearlyIndividualAwards {
+  year: number;
+  categories: ResolvedCategory[];
+}
+
+interface Props {
+  series: Series;
+  yearlyData: YearlyIndividualAwards[];
+}
+
+const { yearlyData } = Astro.props;
+
+function positionLabel(pos: number): string {
+  if (pos === 1) return '🥇';
+  if (pos === 2) return '🥈';
+  if (pos === 3) return '🥉';
+  const mod10 = pos % 10;
+  const mod100 = pos % 100;
+  const suffix =
+    mod10 === 1 && mod100 !== 11 ? 'st' :
+    mod10 === 2 && mod100 !== 12 ? 'nd' :
+    mod10 === 3 && mod100 !== 13 ? 'rd' : 'th';
+  return `${pos}${suffix}`;
+}
+---
+
+<div class="space-y-6">
+  {yearlyData.map(yearly => (
+    <div class="card bg-base-200">
+      <div class="card-body p-6">
+        <h2 class="card-title text-2xl mb-4">{yearly.year}</h2>
+        
+        {yearly.categories.length === 0 ? (
+          <p class="text-base-content/60">No individual awards</p>
+        ) : (
+          <div class="space-y-4">
+            {yearly.categories.map(cat => (
+              <div class="bg-base-100 rounded-lg p-4">
+                <p class="text-sm font-semibold text-base-content/70 mb-3">{cat.categoryName}</p>
+                <div class="space-y-2">
+                  {cat.awards.map(award => (
+                    <div class="flex items-baseline gap-3 text-sm">
+                      <span class="w-6 shrink-0 text-lg">{positionLabel(award.position)}</span>
+                      <div class="flex-1 min-w-0">
+                        {award.runnerUrl ? (
+                          <a href={award.runnerUrl} class="font-medium link link-hover">
+                            {award.name}
+                          </a>
+                        ) : (
+                          <span class="font-medium">{award.name}</span>
+                        )}
+                      </div>
+                      <span class="text-base-content/50 text-xs shrink-0">{award.clubName}</span>
+                      {award.ageCategory && (
+                        <span class="text-base-content/50 text-xs shrink-0">{award.ageCategory}</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  ))}
+</div>
+```
+
+- [ ] **Step 2: Verify component syntax with npm run build**
+
+```bash
+npm run build
+```
+
+Expected: Build completes successfully; no Astro syntax errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/AwardsHistoryIndividuals.astro
+git commit -m "feat: create AwardsHistoryIndividuals component with year cards"
+```
+
+---
+
+## Task 4: Create Dynamic History Page
+
+**Files:**
+- Create: `src/pages/history/[series]/[type].astro`
+
+- [ ] **Step 1: Create page directory structure**
+
+```bash
+mkdir -p src/pages/history/\[series\]
+```
+
+- [ ] **Step 2: Create the main page file**
+
+Create `src/pages/history/[series]/[type].astro`:
+
+```astro
+---
+import Layout from '../../../components/Layout.astro';
+import AwardsHistoryTeams from '../../../components/AwardsHistoryTeams.astro';
+import AwardsHistoryIndividuals from '../../../components/AwardsHistoryIndividuals.astro';
+import { getAllAwardsByYear } from '../../../lib/results';
+import { getClubs, getSeriesConfig } from '../../../lib/results';
+import { buildRunnerUrlMap } from '../../../lib/runners';
+import type { Series, TeamCategory, IndividualCategory } from '../../../lib/types';
+
+export function getStaticPaths() {
+  return [
+    { params: { series: 'road-gp', type: 'teams' } },
+    { params: { series: 'road-gp', type: 'individuals' } },
+    { params: { series: 'fell', type: 'teams' } },
+    { params: { series: 'fell', type: 'individuals' } },
+  ];
+}
+
+const { series, type } = Astro.params as { series: Series; type: 'teams' | 'individuals' };
+
+const allYearlyAwards = getAllAwardsByYear(series);
+
+const seriesLabel = series === 'road-gp' ? 'Road Grand Prix' : 'Fell Championship';
+const pageTitle = type === 'teams' ? `${seriesLabel} Team Winners` : `${seriesLabel} Individual Winners`;
+const backLink = series === 'road-gp' ? '/road-gp' : '/fell';
+
+if (type === 'teams') {
+  // Collect all unique team categories across all years
+  const allCategoriesSet = new Set<string>();
+  allYearlyAwards.forEach(yearly => {
+    yearly.config.teamCategories?.forEach(cat => {
+      allCategoriesSet.add(cat.id);
+    });
+  });
+
+  // Create team category objects with names from the first year that has each category
+  const categoryMap = new Map<string, TeamCategory>();
+  allYearlyAwards.forEach(yearly => {
+    yearly.config.teamCategories?.forEach(cat => {
+      if (!categoryMap.has(cat.id)) {
+        categoryMap.set(cat.id, cat);
+      }
+    });
+  });
+  const allCategories = Array.from(categoryMap.values());
+
+  // Build yearly data
+  const yearlyTeamData = allYearlyAwards.map(yearly => {
+    const categoryWinners: Record<string, string | null> = {};
+    
+    allCategories.forEach(cat => {
+      const award = yearly.awards.teamAwards.find(ta => ta.category === cat.id);
+      if (award) {
+        const clubName = yearly.clubs.find(c => c.id === award.club)?.name ?? award.club;
+        categoryWinners[cat.id] = clubName;
+      } else {
+        categoryWinners[cat.id] = null;
+      }
+    });
+
+    return {
+      year: yearly.year,
+      categoryWinners,
+    };
+  });
+
+  ---
+
+  <Layout title={pageTitle}>
+    <div class="container mx-auto px-4 py-6">
+      <div class="mb-6">
+        <a href={backLink} class="btn btn-sm btn-ghost">← Back</a>
+      </div>
+      <h1 class="text-3xl font-bold mb-6">{pageTitle}</h1>
+      <AwardsHistoryTeams
+        series={series}
+        yearlyData={yearlyTeamData}
+        allCategories={allCategories}
+      />
+    </div>
+  </Layout>
+} else {
+  // type === 'individuals'
+  // Collect individual awards across all years
+  const yearlyIndividualData = allYearlyAwards.map(yearly => {
+    const runnerUrlMap = buildRunnerUrlMap(yearly.year, series);
+    
+    const categories = yearly.awards.individualAwards.map(ia => {
+      const cat = yearly.config.individualCategories?.find(c => c.id === ia.category);
+      
+      return {
+        categoryName: cat?.name ?? ia.category,
+        awards: ia.awards.map(a => ({
+          position: a.position,
+          name: a.name,
+          clubName: yearly.clubs.find(c => c.id === a.club)?.name ?? a.club,
+          ageCategory: undefined, // Awards don't include age category, only category
+          runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
+        })),
+      };
+    });
+
+    return {
+      year: yearly.year,
+      categories,
+    };
+  });
+
+  ---
+
+  <Layout title={pageTitle}>
+    <div class="container mx-auto px-4 py-6">
+      <div class="mb-6">
+        <a href={backLink} class="btn btn-sm btn-ghost">← Back</a>
+      </div>
+      <h1 class="text-3xl font-bold mb-6">{pageTitle}</h1>
+      <AwardsHistoryIndividuals
+        series={series}
+        yearlyData={yearlyIndividualData}
+      />
+    </div>
+  </Layout>
+}
+```
+
+- [ ] **Step 3: Run npm run build to verify page generation**
+
+```bash
+npm run build
+```
+
+Expected: Build completes successfully; four new routes generated (road-gp/history/teams, road-gp/history/individuals, fell/history/teams, fell/history/individuals).
+
+- [ ] **Step 4: Run npm run preview and manually test all four routes**
+
+```bash
+npm run preview
+```
+
+Then navigate to:
+- `http://localhost:3000/road-gp/history/teams` — Check table renders with years and categories
+- `http://localhost:3000/road-gp/history/individuals` — Check year cards display
+- `http://localhost:3000/fell/history/teams` — Check table renders
+- `http://localhost:3000/fell/history/individuals` — Check year cards display
+
+Expected: Pages load without errors; tables and cards display data correctly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/history/\[series\]/\[type\].astro
+git commit -m "feat: create dynamic history page router for teams and individuals"
+```
+
+---
+
+## Task 5: Add Navigation Links to Series Index Pages
+
+**Files:**
+- Modify: `src/pages/road-gp/[year]/index.astro`
+- Modify: `src/pages/fell/[year]/index.astro`
+
+- [ ] **Step 1: Add navigation link to Road GP history on `road-gp/[year]/index.astro`**
+
+Open `src/pages/road-gp/[year]/index.astro` and find the `<HistoryRaceList>` component (around line 72-85). Add a navigation section above it:
+
+```astro
+<Layout title={`Road Grand Prix ${year}`}>
+  <div class="container mx-auto px-4 py-4">
+    <div class="flex gap-2 mb-4">
+      <a href="/road-gp/history/teams" class="btn btn-sm btn-outline">
+        📊 Team Winners History
+      </a>
+      <a href="/road-gp/history/individuals" class="btn btn-sm btn-outline">
+        🏃 Individual Winners History
+      </a>
+    </div>
+  </div>
+  <HistoryRaceList
+    ...
+  />
+</Layout>
+```
+
+- [ ] **Step 2: Run npm run build to verify syntax**
+
+```bash
+npm run build
+```
+
+Expected: Build completes without errors.
+
+- [ ] **Step 3: Run npm run preview and test the Road GP history link**
+
+```bash
+npm run preview
+```
+
+Navigate to `http://localhost:3000/road-gp/2025` (or any past year page) and click both new buttons to verify they link correctly.
+
+Expected: Buttons appear on the page and links work.
+
+- [ ] **Step 4: Add navigation link to Fell history on `fell/[year]/index.astro`**
+
+Open `src/pages/fell/[year]/index.astro` and add the same navigation section above `<HistoryRaceList>`:
+
+```astro
+<Layout title={`Fell Championship ${year}`}>
+  <div class="container mx-auto px-4 py-4">
+    <div class="flex gap-2 mb-4">
+      <a href="/fell/history/teams" class="btn btn-sm btn-outline">
+        📊 Team Winners History
+      </a>
+      <a href="/fell/history/individuals" class="btn btn-sm btn-outline">
+        🏃 Individual Winners History
+      </a>
+    </div>
+  </div>
+  <HistoryRaceList
+    ...
+  />
+</Layout>
+```
+
+- [ ] **Step 5: Run npm run preview and test Fell history link**
+
+```bash
+npm run preview
+```
+
+Navigate to `http://localhost:3000/fell/2023` (or any past year page) and click both new buttons.
+
+Expected: Buttons appear and links work correctly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/road-gp/\[year\]/index.astro src/pages/fell/\[year\]/index.astro
+git commit -m "feat: add history navigation links to series index pages"
+```
+
+---
+
+## Task 6: Manual Testing and Verification
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run full build and check for errors**
+
+```bash
+npm run build
+```
+
+Expected: Build completes successfully with no errors or warnings related to new code.
+
+- [ ] **Step 2: Start dev server and test responsive layout**
+
+```bash
+npm run dev
+```
+
+Navigate to each history page and check:
+- Table on teams pages renders correctly with proper column alignment
+- Year cards on individuals pages display properly
+- Mobile viewport (DevTools mobile emulation): cards stack vertically, table scrolls horizontally
+- Tablet/desktop: layout looks good with proper spacing
+
+Expected: All pages render correctly across viewport sizes.
+
+- [ ] **Step 3: Test data accuracy**
+
+On Road GP individual history (`/road-gp/history/individuals`):
+- Verify years appear in descending order (newest first)
+- Click a few runner profile links (where available) to confirm they lead to correct runner pages
+- Verify position badges show 🥇🥈🥉 for top 3, then ordinal numbers
+
+On Road GP team history (`/road-gp/history/teams`):
+- Verify years appear in descending order
+- Check that team categories are correct (match config.json from a sample year)
+- Verify "—" appears for years missing data in a category
+
+Expected: All data displays accurately.
+
+- [ ] **Step 4: Test Fell Championship pages similarly**
+
+Navigate to `/fell/history/individuals` and `/fell/history/teams` and perform the same checks.
+
+Expected: Pages render correctly and data is accurate for Fell series.
+
+- [ ] **Step 5: Verify missing data handling**
+
+Check a year with sparse awards or no awards file (if applicable):
+- Individuals page should skip years with no awards file
+- Team page should skip years with no awards file
+- No errors or blank cards should appear
+
+Expected: Pages handle missing data gracefully.
+
+- [ ] **Step 6: Final commit verification**
+
+```bash
+git log --oneline -6
+```
+
+Expected: Last 6 commits include the new feature commits from this plan.
+
+---
+
+## Done: Awards History Timeline
+
+All four history pages are now live and accessible:
+- `/road-gp/history/teams` — Tabular team award winners
+- `/road-gp/history/individuals` — Year cards with individual award winners
+- `/fell/history/teams` — Tabular team award winners
+- `/fell/history/individuals` — Year cards with individual award winners
+
+Navigation links added to series index pages guide users to the history pages.

--- a/docs/superpowers/specs/2026-05-16-awards-history-timeline-design.md
+++ b/docs/superpowers/specs/2026-05-16-awards-history-timeline-design.md
@@ -1,0 +1,181 @@
+# Awards History Timeline Design
+
+**Date:** 2026-05-16  
+**Status:** Approved
+
+## Overview
+
+Add dedicated history pages showing award winners across all years for each series (Road GP and Fell Championship). This allows users to see the evolution of winners over time without navigating to individual year pages, particularly useful for years with minimal data (trophy-only winners).
+
+## Pages & Routes
+
+Create four new pages:
+- `/road-gp/history/teams` — Team award winners (tabular)
+- `/road-gp/history/individuals` — Individual award winners (chronological cards)
+- `/fell/history/teams` — Team award winners (tabular)
+- `/fell/history/individuals` — Individual award winners (chronological cards)
+
+Implementation: Dynamic pages using `[series]` and `[type]` route parameters in `src/pages/history/[series]/[type].astro`
+
+## Teams History Page
+
+**Layout:** Tabular with years as rows, team categories as columns.
+
+**Structure:**
+- Year column on the left: displayed prominently, descending order (newest first)
+- One column per team category from `config.teamCategories`
+- Column headers: category name from config
+- Each cell: winning club name, or "—" if no awards data exists for that year/category
+- All years with awards data are shown; years with no awards file are skipped entirely
+
+**Data Source:**
+- Load all `src/data/{year}/{series}/awards.json` files for the series
+- Extract `teamAwards` array
+- Build a matrix: `year × teamCategory → winningClubName`
+- Resolve club names from `clubs.json`
+
+**Edge Cases:**
+- Year has no awards file: skip the year entirely
+- Year has awards file but no team awards: row still appears but cells show "—"
+- Team category doesn't exist in a year's config: show "—"
+
+**Sorting:** Years in descending order (newest first, 2026 at top)
+
+## Individuals History Page
+
+**Layout:** Chronological year cards in reverse chronological order.
+
+**Card Structure (per year):**
+- Year header displayed prominently (e.g., "2025")
+- All award categories from that year's `individualAwards` array
+- For each category:
+  - Category name as a subheading (e.g., "Senior Men")
+  - All placed finishers (1st, 2nd, 3rd, etc.) listed as rows
+  - Each row shows:
+    - Position badge: medal emoji (🥇 for 1st, 🥈 for 2nd, 🥉 for 3rd, ordinal number for 4th+)
+    - Runner name (bold)
+    - Club (in smaller text/muted color)
+    - Age category if available (e.g., "SEN", "V40")
+    - Link to runner profile if `seriesRunnerId` exists in awards data
+
+**Data Source:**
+- Load all `src/data/{year}/{series}/awards.json` files
+- Extract `individualAwards` array
+- Sort years descending (newest first)
+- Resolve club names from `clubs.json`
+- Build runner profile links using `getRunnerProfileUrl()` where `seriesRunnerId` is present
+
+**Styling/Components:**
+- Reuse or adapt `SeriesAwards.astro` component logic for rendering awards
+- Each year is a distinct card with visual separation (border, background, spacing)
+- Categories within a year are grouped visually
+- Responsive: stack on mobile, consider two-column layout on larger screens if needed
+
+**Edge Cases:**
+- Year has no awards file: skip the year entirely
+- Year has awards file but no individual awards: year card still appears but shows "No individual awards"
+- Runner has no `seriesRunnerId`: name displays without profile link
+- Sparse positions (e.g., only 1st place awarded in a category): show only those positions
+
+**Sorting:** Years in descending order (newest first, 2026 at top); categories in order they appear in awards JSON (which matches `config.individualCategories` order)
+
+## Navigation
+
+**Entry Points:**
+- Add links on series index pages (e.g., `/road-gp/[year]/index.astro`) to `/road-gp/history/individuals` and `/road-gp/history/teams`
+- Optional: Add "View all winners" link on current-year series pages
+- Optional: Add to main navigation or footer
+
+**Implementation:** Add navigation UI (buttons or text links) to existing components or index pages
+
+## Data Loading
+
+**Build-Time:**
+- Use `import.meta.glob()` at module level to load all awards files
+- Pattern: `src/data/*/road-gp/awards.json` and `src/data/*/fell/awards.json`
+- Load as JSON with `{ eager: true }`
+- Extract and normalize data at component render time
+
+**No Runtime Fetching:** All data is static and resolved at build time (Astro static generation)
+
+## Implementation Details
+
+### New Components
+
+**`AwardsHistoryTeams.astro`**
+- Props: `series: 'road-gp' | 'fell'`, `allAwards: AwardsData[]`
+- Renders tabular team awards history
+- Resolves club names and category names
+- Handles missing data gracefully
+
+**`AwardsHistoryIndividuals.astro`**
+- Props: `series: 'road-gp' | 'fell'`, `allAwards: AwardsData[]`
+- Renders year cards with individual awards
+- Renders each award with position badge, name, club, category
+- Links to runner profiles where available
+- Handles missing data gracefully
+
+### New Page
+
+**`src/pages/history/[series]/[type].astro`**
+- Dynamic page with two route parameters: `series` and `type`
+- Valid combinations:
+  - `series`: 'road-gp', 'fell'
+  - `type`: 'teams', 'individuals'
+- Loads all relevant awards files via glob
+- Passes data to appropriate component (`AwardsHistoryTeams` or `AwardsHistoryIndividuals`)
+- Generates all four pages at build time
+
+**Static Paths:** `getStaticPaths()` returns:
+```
+[
+  { params: { series: 'road-gp', type: 'teams' } },
+  { params: { series: 'road-gp', type: 'individuals' } },
+  { params: { series: 'fell', type: 'teams' } },
+  { params: { series: 'fell', type: 'individuals' } },
+]
+```
+
+### Type Definitions
+
+Extend `src/lib/types.ts` if needed:
+- `SeriesAwardsHistory` — array of yearly awards by series
+- Reuse existing `TeamAward`, `IndividualAward`, `ResolvedSeriesAwards` types
+
+### Styling
+
+- Use existing Tailwind + DaisyUI components
+- Tables: `table` with DaisyUI table styling
+- Cards: `card` component with `bg-base-200` or similar
+- Year headers: large, clear typography
+- Position badges: emoji + text (reuse `positionLabel()` logic from `SeriesAwards.astro`)
+- Responsive: cards stack on mobile; table may scroll horizontally on small screens
+
+## Testing
+
+**Manual Testing:**
+- Verify both series pages load correctly
+- Check all four routes generate (road-gp teams, road-gp individuals, fell teams, fell individuals)
+- Confirm years are sorted descending (newest first)
+- Verify missing awards data is handled gracefully (skipped or shown as "—")
+- Test runner profile links (click a winner with `seriesRunnerId`)
+- Test responsive layout on mobile, tablet, desktop
+
+**No Unit Tests:** Data loading depends on `import.meta.glob()`, so validation happens at build time.
+
+## Success Criteria
+
+- ✅ Four new history pages are generated and accessible
+- ✅ Teams history shows winners in tabular format
+- ✅ Individuals history shows winners in chronological year cards
+- ✅ All years with awards data are included; years without are skipped
+- ✅ Runner profile links work where `seriesRunnerId` is present
+- ✅ Navigation links added to series pages
+- ✅ Pages are responsive and render correctly on all device sizes
+- ✅ Build completes without errors
+
+## Open Questions / Future Enhancements
+
+- Should there be a searchable runner lookup on individuals history? (Deferred)
+- Should years with no data show a placeholder or be skipped? (Decided: skip entirely)
+- Should team winners show runner names (who competed for the team)? (Deferred)

--- a/preview.log
+++ b/preview.log
@@ -1,0 +1,8 @@
+
+> interclub@0.0.1 preview
+> astro preview
+
+Port 4321 is in use, trying another one...
+[42m[1m astro [22m[49m [32mv6.1.9[39m [2mready in[22m 26 [2mms[22m
+[2m┃[22m Local    [36mhttp://localhost:4322/InterClub[39m
+[2m┃[22m Network  [2muse --host to expose[22m

--- a/src/components/AwardsHistoryIndividuals.astro
+++ b/src/components/AwardsHistoryIndividuals.astro
@@ -1,0 +1,83 @@
+---
+import type { Series, IndividualCategory } from '../lib/types';
+
+interface ResolvedAwardEntry {
+  position: number;
+  name: string;
+  clubName: string;
+  ageCategory?: string;
+  runnerUrl?: string;
+}
+
+interface ResolvedCategory {
+  categoryName: string;
+  awards: ResolvedAwardEntry[];
+}
+
+interface YearlyIndividualAwards {
+  year: number;
+  categories: ResolvedCategory[];
+}
+
+interface Props {
+  series: Series;
+  yearlyData: YearlyIndividualAwards[];
+}
+
+const { yearlyData } = Astro.props;
+
+function positionLabel(pos: number): string {
+  if (pos === 1) return '🥇';
+  if (pos === 2) return '🥈';
+  if (pos === 3) return '🥉';
+  const mod10 = pos % 10;
+  const mod100 = pos % 100;
+  const suffix =
+    mod10 === 1 && mod100 !== 11 ? 'st' :
+    mod10 === 2 && mod100 !== 12 ? 'nd' :
+    mod10 === 3 && mod100 !== 13 ? 'rd' : 'th';
+  return `${pos}${suffix}`;
+}
+---
+
+<div class="space-y-6">
+  {yearlyData.map(yearly => (
+    <div class="card bg-base-200">
+      <div class="card-body p-6">
+        <h2 class="card-title text-2xl mb-4">{yearly.year}</h2>
+
+        {yearly.categories.length === 0 ? (
+          <p class="text-base-content/60">No individual awards</p>
+        ) : (
+          <div class="space-y-4">
+            {yearly.categories.map(cat => (
+              <div class="bg-base-100 rounded-lg p-4">
+                <p class="text-sm font-semibold text-base-content/70 mb-3">{cat.categoryName}</p>
+                <div class="space-y-2">
+                  {cat.awards.map(award => (
+                    <div class="flex items-baseline gap-3 text-sm">
+                      <span class="w-6 shrink-0 text-lg">{positionLabel(award.position)}</span>
+                      <div class="flex-1 min-w-0">
+                        {award.runnerUrl ? (
+                          <a href={award.runnerUrl} class="font-medium link link-hover">
+                            {award.name}
+                          </a>
+                        ) : (
+                          <span class="font-medium">{award.name}</span>
+                        )}
+                      </div>
+                      <span class="text-base-content/50 text-xs shrink-0">{award.clubName}</span>
+                      {award.ageCategory && (
+                        <span class="text-base-content/50 text-xs shrink-0">{award.ageCategory}</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  ))}
+</div>

--- a/src/components/AwardsHistoryTeams.astro
+++ b/src/components/AwardsHistoryTeams.astro
@@ -1,13 +1,12 @@
 ---
-import type { Series, TeamCategory, Club } from '../lib/types';
+import type { TeamCategory } from '../lib/types';
 
 interface YearlyTeamAwards {
   year: number;
-  categoryWinners: Record<string, string | null>; // categoryId → clubName or null
+  categoryWinners: Record<string, string | null>; // categoryId → club name (string) or null
 }
 
 interface Props {
-  series: Series;
   yearlyData: YearlyTeamAwards[];
   allCategories: TeamCategory[];
 }
@@ -17,11 +16,12 @@ const { yearlyData, allCategories } = Astro.props;
 
 <div class="overflow-x-auto">
   <table class="table table-sm w-full">
+    <caption class="sr-only">Team award winners by year and category</caption>
     <thead>
       <tr>
-        <th class="text-base">Year</th>
-        {allCategories.map(cat => (
-          <th class="text-center text-sm">{cat.name}</th>
+        <th class="text-base" scope="col">Year</th>
+        {allCategories.map(category => (
+          <th class="text-center text-sm" scope="col">{category.name}</th>
         ))}
       </tr>
     </thead>
@@ -29,9 +29,9 @@ const { yearlyData, allCategories } = Astro.props;
       {yearlyData.map(yearly => (
         <tr class="hover">
           <td class="font-semibold">{yearly.year}</td>
-          {allCategories.map(cat => (
+          {allCategories.map(category => (
             <td class="text-center text-sm">
-              {yearly.categoryWinners[cat.id] ?? '—'}
+              {yearly.categoryWinners[category.id] ?? '—'}
             </td>
           ))}
         </tr>

--- a/src/components/AwardsHistoryTeams.astro
+++ b/src/components/AwardsHistoryTeams.astro
@@ -1,0 +1,41 @@
+---
+import type { Series, TeamCategory, Club } from '../lib/types';
+
+interface YearlyTeamAwards {
+  year: number;
+  categoryWinners: Record<string, string | null>; // categoryId → clubName or null
+}
+
+interface Props {
+  series: Series;
+  yearlyData: YearlyTeamAwards[];
+  allCategories: TeamCategory[];
+}
+
+const { yearlyData, allCategories } = Astro.props;
+---
+
+<div class="overflow-x-auto">
+  <table class="table table-sm w-full">
+    <thead>
+      <tr>
+        <th class="text-base">Year</th>
+        {allCategories.map(cat => (
+          <th class="text-center text-sm">{cat.name}</th>
+        ))}
+      </tr>
+    </thead>
+    <tbody>
+      {yearlyData.map(yearly => (
+        <tr class="hover">
+          <td class="font-semibold">{yearly.year}</td>
+          {allCategories.map(cat => (
+            <td class="text-center text-sm">
+              {yearly.categoryWinners[cat.id] ?? '—'}
+            </td>
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  </table>
+</div>

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -296,3 +296,30 @@ export function getAwards(year: number, series: Series): SeriesAwards | null {
   const files = awardsFilesForSeries(series);
   return files[`../data/${year}/${series}/awards.json`]?.default ?? null;
 }
+
+export interface YearlyAwardsData {
+  year: number;
+  awards: SeriesAwards;
+  clubs: Club[];
+  config: SeriesConfig;
+}
+
+export function getAllAwardsByYear(series: Series): YearlyAwardsData[] {
+  const awardsFiles = awardsFilesForSeries(series);
+  const awardsList: YearlyAwardsData[] = [];
+
+  Object.keys(awardsFiles).forEach(path => {
+    const match = path.match(/\/data\/(\d+)\//);
+    if (!match) return;
+
+    const year = parseInt(match[1], 10);
+    const awards = awardsFiles[path].default;
+    const clubs = getClubs(year);
+    const config = getSeriesConfig(year, series);
+
+    awardsList.push({ year, awards, clubs, config });
+  });
+
+  // Sort by year descending (newest first)
+  return awardsList.sort((a, b) => b.year - a.year);
+}

--- a/src/pages/fell/[year]/index.astro
+++ b/src/pages/fell/[year]/index.astro
@@ -69,6 +69,16 @@ if (hasAwards(year, 'fell')) {
 ---
 
 <Layout title={`Fell Championship ${year}`}>
+  <div class="container mx-auto px-4 py-4">
+    <div class="flex gap-2 mb-4">
+      <a href="/fell/history/teams" class="btn btn-sm btn-outline">
+        📊 Team Winners History
+      </a>
+      <a href="/fell/history/individuals" class="btn btn-sm btn-outline">
+        🏃 Individual Winners History
+      </a>
+    </div>
+  </div>
   <HistoryRaceList
     races={races}
     year={year}

--- a/src/pages/fell/[year]/index.astro
+++ b/src/pages/fell/[year]/index.astro
@@ -69,15 +69,13 @@ if (hasAwards(year, 'fell')) {
 ---
 
 <Layout title={`Fell Championship ${year}`}>
-  <div class="container mx-auto px-4 py-4">
-    <div class="flex gap-2 mb-4">
-      <a href="/fell/history/teams" class="btn btn-sm btn-outline">
-        📊 Team Winners History
-      </a>
-      <a href="/fell/history/individuals" class="btn btn-sm btn-outline">
-        🏃 Individual Winners History
-      </a>
-    </div>
+  <div class="flex gap-2 mb-6">
+    <a href={siteUrl('/fell/history/teams')} class="btn btn-sm btn-outline">
+      Team Winners History
+    </a>
+    <a href={siteUrl('/fell/history/individuals')} class="btn btn-sm btn-outline">
+      Individual Winners History
+    </a>
   </div>
   <HistoryRaceList
     races={races}

--- a/src/pages/fell/history/[type].astro
+++ b/src/pages/fell/history/[type].astro
@@ -1,0 +1,101 @@
+---
+import Layout from '../../../components/Layout.astro';
+import AwardsHistoryTeams from '../../../components/AwardsHistoryTeams.astro';
+import AwardsHistoryIndividuals from '../../../components/AwardsHistoryIndividuals.astro';
+import { getAllAwardsByYear } from '../../../lib/results';
+import { buildRunnerUrlMap } from '../../../lib/runners';
+import type { TeamCategory } from '../../../lib/types';
+
+export function getStaticPaths() {
+  return [
+    { params: { type: 'teams' } },
+    { params: { type: 'individuals' } },
+  ];
+}
+
+const series = 'fell';
+const { type } = Astro.params as { type: 'teams' | 'individuals' };
+
+const allYearlyAwards = getAllAwardsByYear(series);
+
+const pageTitle = type === 'teams' ? 'Fell Championship Team Winners' : 'Fell Championship Individual Winners';
+
+// Prepare team data
+let allCategories: TeamCategory[] = [];
+let yearlyTeamData: Array<{ year: number; categoryWinners: Record<string, string | null> }> = [];
+
+if (type === 'teams') {
+  const categoryMap = new Map<string, TeamCategory>();
+  allYearlyAwards.forEach(yearly => {
+    yearly.config.teamCategories?.forEach(cat => {
+      if (!categoryMap.has(cat.id)) {
+        categoryMap.set(cat.id, cat);
+      }
+    });
+  });
+  allCategories = Array.from(categoryMap.values());
+
+  yearlyTeamData = allYearlyAwards.map(yearly => {
+    const categoryWinners: Record<string, string | null> = {};
+
+    allCategories.forEach(cat => {
+      const award = yearly.awards.teamAwards.find(ta => ta.category === cat.id);
+      if (award) {
+        const clubName = yearly.clubs.find(c => c.id === award.club)?.name ?? award.club;
+        categoryWinners[cat.id] = clubName;
+      } else {
+        categoryWinners[cat.id] = null;
+      }
+    });
+
+    return { year: yearly.year, categoryWinners };
+  });
+}
+
+// Prepare individual data
+let yearlyIndividualData: Array<{ year: number; categories: Array<{ categoryName: string; awards: Array<{ position: number; name: string; clubName: string; ageCategory: string; runnerUrl?: string }> }> }> = [];
+
+if (type === 'individuals') {
+  yearlyIndividualData = allYearlyAwards.map(yearly => {
+    const runnerUrlMap = buildRunnerUrlMap(yearly.year, series);
+
+    const categories = yearly.awards.individualAwards.map(ia => {
+      const cat = yearly.config.individualCategories?.find(c => c.id === ia.category);
+
+      return {
+        categoryName: cat?.name ?? ia.category,
+        awards: ia.awards.map(a => ({
+          position: a.position,
+          name: a.name,
+          clubName: yearly.clubs.find(c => c.id === a.club)?.name ?? a.club,
+          ageCategory: a.category,
+          runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
+        })),
+      };
+    });
+
+    return { year: yearly.year, categories };
+  });
+}
+---
+
+<Layout title={pageTitle}>
+  <div class="container mx-auto px-4 py-6">
+    <div class="mb-6">
+      <a href="/fell" class="btn btn-sm btn-ghost">← Back</a>
+    </div>
+    <h1 class="text-3xl font-bold mb-6">{pageTitle}</h1>
+    {type === 'teams' ? (
+      <AwardsHistoryTeams
+        series={series}
+        yearlyData={yearlyTeamData}
+        allCategories={allCategories}
+      />
+    ) : (
+      <AwardsHistoryIndividuals
+        series={series}
+        yearlyData={yearlyIndividualData}
+      />
+    )}
+  </div>
+</Layout>

--- a/src/pages/history/[series]/[type].astro
+++ b/src/pages/history/[series]/[type].astro
@@ -1,0 +1,123 @@
+---
+import Layout from '../../../components/Layout.astro';
+import AwardsHistoryTeams from '../../../components/AwardsHistoryTeams.astro';
+import AwardsHistoryIndividuals from '../../../components/AwardsHistoryIndividuals.astro';
+import { getAllAwardsByYear } from '../../../lib/results';
+import { buildRunnerUrlMap } from '../../../lib/runners';
+import type { Series, TeamCategory } from '../../../lib/types';
+
+export function getStaticPaths() {
+  return [
+    { params: { series: 'road-gp', type: 'teams' } },
+    { params: { series: 'road-gp', type: 'individuals' } },
+    { params: { series: 'fell', type: 'teams' } },
+    { params: { series: 'fell', type: 'individuals' } },
+  ];
+}
+
+const { series, type } = Astro.params as { series: Series; type: 'teams' | 'individuals' };
+
+const allYearlyAwards = getAllAwardsByYear(series);
+
+const seriesLabel = series === 'road-gp' ? 'Road Grand Prix' : 'Fell Championship';
+const pageTitle = type === 'teams' ? `${seriesLabel} Team Winners` : `${seriesLabel} Individual Winners`;
+const backLink = series === 'road-gp' ? '/road-gp' : '/fell';
+
+// Prepare team data
+let allCategories: TeamCategory[] = [];
+let yearlyTeamData: Array<{ year: number; categoryWinners: Record<string, string | null> }> = [];
+
+if (type === 'teams') {
+  // Create team category objects with names from the first year that has each category
+  const categoryMap = new Map<string, TeamCategory>();
+  allYearlyAwards.forEach(yearly => {
+    yearly.config.teamCategories?.forEach(cat => {
+      if (!categoryMap.has(cat.id)) {
+        categoryMap.set(cat.id, cat);
+      }
+    });
+  });
+  allCategories = Array.from(categoryMap.values());
+
+  // Build yearly data
+  yearlyTeamData = allYearlyAwards.map(yearly => {
+    const categoryWinners: Record<string, string | null> = {};
+
+    allCategories.forEach(cat => {
+      const award = yearly.awards.teamAwards.find(ta => ta.category === cat.id);
+      if (award) {
+        const clubName = yearly.clubs.find(c => c.id === award.club)?.name ?? award.club;
+        categoryWinners[cat.id] = clubName;
+      } else {
+        categoryWinners[cat.id] = null;
+      }
+    });
+
+    return {
+      year: yearly.year,
+      categoryWinners,
+    };
+  });
+}
+
+// Prepare individual data
+interface IndividualCategory {
+  categoryName: string;
+  awards: Array<{
+    position: number;
+    name: string;
+    clubName: string;
+    ageCategory: undefined;
+    runnerUrl?: string;
+  }>;
+}
+
+let yearlyIndividualData: Array<{ year: number; categories: IndividualCategory[] }> = [];
+
+if (type === 'individuals') {
+  yearlyIndividualData = allYearlyAwards.map(yearly => {
+    const runnerUrlMap = buildRunnerUrlMap(yearly.year, series);
+
+    const categories = yearly.awards.individualAwards.map(ia => {
+      const cat = yearly.config.individualCategories?.find(c => c.id === ia.category);
+
+      return {
+        categoryName: cat?.name ?? ia.category,
+        awards: ia.awards.map(a => ({
+          position: a.position,
+          name: a.name,
+          clubName: yearly.clubs.find(c => c.id === a.club)?.name ?? a.club,
+          ageCategory: undefined,
+          runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
+        })),
+      };
+    });
+
+    return {
+      year: yearly.year,
+      categories,
+    };
+  });
+}
+---
+
+<Layout title={pageTitle}>
+  <div class="container mx-auto px-4 py-6">
+    <div class="mb-6">
+      <a href={backLink} class="btn btn-sm btn-ghost">← Back</a>
+    </div>
+    <h1 class="text-3xl font-bold mb-6">{pageTitle}</h1>
+    {type === 'teams' ? (
+      <AwardsHistoryTeams
+        series={series}
+        yearlyData={yearlyTeamData}
+        allCategories={allCategories}
+      />
+    ) : (
+      <AwardsHistoryIndividuals
+        series={series}
+        yearlyData={yearlyIndividualData}
+      />
+    )}
+  </div>
+</Layout>

--- a/src/pages/history/[series]/[type].astro
+++ b/src/pages/history/[series]/[type].astro
@@ -61,18 +61,7 @@ if (type === 'teams') {
 }
 
 // Prepare individual data
-interface IndividualCategory {
-  categoryName: string;
-  awards: Array<{
-    position: number;
-    name: string;
-    clubName: string;
-    ageCategory: undefined;
-    runnerUrl?: string;
-  }>;
-}
-
-let yearlyIndividualData: Array<{ year: number; categories: IndividualCategory[] }> = [];
+let yearlyIndividualData: Array<{ year: number; categories: Array<{ categoryName: string; awards: Array<{ position: number; name: string; clubName: string; ageCategory: string; runnerUrl?: string }> }> }> = [];
 
 if (type === 'individuals') {
   yearlyIndividualData = allYearlyAwards.map(yearly => {
@@ -87,7 +76,7 @@ if (type === 'individuals') {
           position: a.position,
           name: a.name,
           clubName: yearly.clubs.find(c => c.id === a.club)?.name ?? a.club,
-          ageCategory: undefined,
+          ageCategory: a.category,
           runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
         })),
       };

--- a/src/pages/road-gp/[year]/index.astro
+++ b/src/pages/road-gp/[year]/index.astro
@@ -69,15 +69,13 @@ if (hasAwards(year, 'road-gp')) {
 ---
 
 <Layout title={`Road Grand Prix ${year}`}>
-  <div class="container mx-auto px-4 py-4">
-    <div class="flex gap-2 mb-4">
-      <a href="/road-gp/history/teams" class="btn btn-sm btn-outline">
-        📊 Team Winners History
-      </a>
-      <a href="/road-gp/history/individuals" class="btn btn-sm btn-outline">
-        🏃 Individual Winners History
-      </a>
-    </div>
+  <div class="flex gap-2 mb-6">
+    <a href={siteUrl('/road-gp/history/teams')} class="btn btn-sm btn-outline">
+      Team Winners History
+    </a>
+    <a href={siteUrl('/road-gp/history/individuals')} class="btn btn-sm btn-outline">
+      Individual Winners History
+    </a>
   </div>
   <HistoryRaceList
     races={races}

--- a/src/pages/road-gp/[year]/index.astro
+++ b/src/pages/road-gp/[year]/index.astro
@@ -69,6 +69,16 @@ if (hasAwards(year, 'road-gp')) {
 ---
 
 <Layout title={`Road Grand Prix ${year}`}>
+  <div class="container mx-auto px-4 py-4">
+    <div class="flex gap-2 mb-4">
+      <a href="/road-gp/history/teams" class="btn btn-sm btn-outline">
+        📊 Team Winners History
+      </a>
+      <a href="/road-gp/history/individuals" class="btn btn-sm btn-outline">
+        🏃 Individual Winners History
+      </a>
+    </div>
+  </div>
   <HistoryRaceList
     races={races}
     year={year}

--- a/src/pages/road-gp/history/[type].astro
+++ b/src/pages/road-gp/history/[type].astro
@@ -4,31 +4,27 @@ import AwardsHistoryTeams from '../../../components/AwardsHistoryTeams.astro';
 import AwardsHistoryIndividuals from '../../../components/AwardsHistoryIndividuals.astro';
 import { getAllAwardsByYear } from '../../../lib/results';
 import { buildRunnerUrlMap } from '../../../lib/runners';
-import type { Series, TeamCategory } from '../../../lib/types';
+import type { TeamCategory } from '../../../lib/types';
 
 export function getStaticPaths() {
   return [
-    { params: { series: 'road-gp', type: 'teams' } },
-    { params: { series: 'road-gp', type: 'individuals' } },
-    { params: { series: 'fell', type: 'teams' } },
-    { params: { series: 'fell', type: 'individuals' } },
+    { params: { type: 'teams' } },
+    { params: { type: 'individuals' } },
   ];
 }
 
-const { series, type } = Astro.params as { series: Series; type: 'teams' | 'individuals' };
+const series = 'road-gp';
+const { type } = Astro.params as { type: 'teams' | 'individuals' };
 
 const allYearlyAwards = getAllAwardsByYear(series);
 
-const seriesLabel = series === 'road-gp' ? 'Road Grand Prix' : 'Fell Championship';
-const pageTitle = type === 'teams' ? `${seriesLabel} Team Winners` : `${seriesLabel} Individual Winners`;
-const backLink = series === 'road-gp' ? '/road-gp' : '/fell';
+const pageTitle = type === 'teams' ? 'Road Grand Prix Team Winners' : 'Road Grand Prix Individual Winners';
 
 // Prepare team data
 let allCategories: TeamCategory[] = [];
 let yearlyTeamData: Array<{ year: number; categoryWinners: Record<string, string | null> }> = [];
 
 if (type === 'teams') {
-  // Create team category objects with names from the first year that has each category
   const categoryMap = new Map<string, TeamCategory>();
   allYearlyAwards.forEach(yearly => {
     yearly.config.teamCategories?.forEach(cat => {
@@ -39,7 +35,6 @@ if (type === 'teams') {
   });
   allCategories = Array.from(categoryMap.values());
 
-  // Build yearly data
   yearlyTeamData = allYearlyAwards.map(yearly => {
     const categoryWinners: Record<string, string | null> = {};
 
@@ -53,10 +48,7 @@ if (type === 'teams') {
       }
     });
 
-    return {
-      year: yearly.year,
-      categoryWinners,
-    };
+    return { year: yearly.year, categoryWinners };
   });
 }
 
@@ -82,10 +74,7 @@ if (type === 'individuals') {
       };
     });
 
-    return {
-      year: yearly.year,
-      categories,
-    };
+    return { year: yearly.year, categories };
   });
 }
 ---
@@ -93,7 +82,7 @@ if (type === 'individuals') {
 <Layout title={pageTitle}>
   <div class="container mx-auto px-4 py-6">
     <div class="mb-6">
-      <a href={backLink} class="btn btn-sm btn-ghost">← Back</a>
+      <a href="/road-gp" class="btn btn-sm btn-ghost">← Back</a>
     </div>
     <h1 class="text-3xl font-bold mb-6">{pageTitle}</h1>
     {type === 'teams' ? (


### PR DESCRIPTION
## Summary

- Adds four new history pages (`/road-gp/history/teams`, `/road-gp/history/individuals`, `/fell/history/teams`, `/fell/history/individuals`) showing award winners across all years without needing to navigate to individual year pages
- Teams history uses a tabular layout (year rows × team category columns); individuals history uses chronological year cards with position badges (🥇🥈🥉), runner profile links, and club info
- Adds navigation buttons on series archive pages linking to the new history pages

## Test Plan

- [ ] All four routes load correctly (`/road-gp/history/teams`, `/road-gp/history/individuals`, `/fell/history/teams`, `/fell/history/individuals`)
- [ ] Teams table shows correct winning clubs per year/category; cells show "—" where no data exists
- [ ] Individuals cards show winners in descending year order with correct position badges
- [ ] Runner profile links work for entries with `seriesRunnerId`
- [ ] Years with no awards file are skipped entirely
- [ ] Navigation buttons appear on series archive pages and link correctly
- [ ] Responsive layout works on mobile, tablet, and desktop
- [ ] `npm run build` completes without errors
- [ ] `npm test` passes (44/44)