### PR TITLE
feat: redesign individual history page with tabbed table layout

### DIFF
--- a/docs/superpowers/plans/2026-05-17-individual-history-redesign.md
+++ b/docs/superpowers/plans/2026-05-17-individual-history-redesign.md
@@ -1,0 +1,683 @@
+# Individual History Page Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the per-year card layout on the individual history page with a two-level tabbed (Male / Female / Overall → age category) table showing years as rows and 1st / 2nd / 3rd positions as columns.
+
+**Architecture:** Add a pure `pivotIndividualAwardsByCategory` function to `results.ts` that reshapes year-keyed award data into category-keyed table data. Both history pages (`road-gp` and `fell`) call this function and pass the result to a rewritten `AwardsHistoryIndividuals` component that renders two-level tabs and a table per category. Tab state is managed by an inline `<script>` using data attributes.
+
+**Tech Stack:** Astro v6, TypeScript (strict), Tailwind CSS v4, DaisyUI v5, Vitest
+
+---
+
+### Task 1: Add types and pivot function to `results.ts`
+
+**Files:**
+- Modify: `src/lib/results.ts` (append to end of file)
+
+- [ ] **Step 1: Add the new interfaces and function**
+
+Append to the end of `src/lib/results.ts`:
+
+```ts
+// ---- Individual history pivot ----
+
+export interface YearlyResolvedIndividual {
+  year: number;
+  categories: Array<{
+    id: string;
+    name: string;
+    sex: 'M' | 'F' | null;
+    awards: Array<{
+      position: number;
+      name: string;
+      clubName: string;
+      runnerUrl?: string;
+    }>;
+  }>;
+}
+
+export interface CategoryHistoryEntry {
+  name: string;
+  clubName: string;
+  runnerUrl?: string;
+}
+
+export interface CategoryHistoryRow {
+  year: number;
+  positions: {
+    1: CategoryHistoryEntry | null;
+    2: CategoryHistoryEntry | null;
+    3: CategoryHistoryEntry | null;
+  };
+}
+
+export interface CategoryHistoryData {
+  id: string;
+  name: string;
+  sex: 'M' | 'F' | null;
+  rows: CategoryHistoryRow[];
+}
+
+export function pivotIndividualAwardsByCategory(
+  yearlyData: YearlyResolvedIndividual[]
+): CategoryHistoryData[] {
+  const categoryMap = new Map<string, { name: string; sex: 'M' | 'F' | null }>();
+  for (const yearly of yearlyData) {
+    for (const cat of yearly.categories) {
+      if (!categoryMap.has(cat.id)) {
+        categoryMap.set(cat.id, { name: cat.name, sex: cat.sex });
+      }
+    }
+  }
+
+  return Array.from(categoryMap.entries()).map(([id, meta]) => {
+    const rows = yearlyData
+      .filter(yearly => yearly.categories.some(c => c.id === id))
+      .map(yearly => {
+        const cat = yearly.categories.find(c => c.id === id)!;
+        const findPos = (pos: number) => cat.awards.find(a => a.position === pos);
+        const mapEntry = (a: ReturnType<typeof findPos>): CategoryHistoryEntry | null =>
+          a ? { name: a.name, clubName: a.clubName, runnerUrl: a.runnerUrl } : null;
+        return {
+          year: yearly.year,
+          positions: {
+            1: mapEntry(findPos(1)),
+            2: mapEntry(findPos(2)),
+            3: mapEntry(findPos(3)),
+          },
+        };
+      });
+    return { id, name: meta.name, sex: meta.sex, rows };
+  });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/lib/results.ts
+git commit -m "feat: add pivotIndividualAwardsByCategory to results.ts"
+```
+
+---
+
+### Task 2: Test `pivotIndividualAwardsByCategory`
+
+**Files:**
+- Modify: `tests/lib/results.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/lib/results.test.ts` (add to the imports line at the top):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { parseResultsCsv, parseTeamResultsPath, parseTeamStandingsPath, parseIndividualStandingsPath, pivotIndividualAwardsByCategory } from '../../src/lib/results';
+```
+
+Then append the following `describe` block to `tests/lib/results.test.ts`:
+
+```ts
+describe('pivotIndividualAwardsByCategory', () => {
+  it('returns empty array for empty input', () => {
+    expect(pivotIndividualAwardsByCategory([])).toEqual([]);
+  });
+
+  it('returns one category entry for a single year with one category', () => {
+    const input = [{
+      year: 2024,
+      categories: [{
+        id: 'sen-m',
+        name: 'Senior Men',
+        sex: 'M' as const,
+        awards: [
+          { position: 1, name: 'A. Smith', clubName: 'Wesham' },
+          { position: 2, name: 'B. Jones', clubName: 'Preston' },
+        ],
+      }],
+    }];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('sen-m');
+    expect(result[0].name).toBe('Senior Men');
+    expect(result[0].sex).toBe('M');
+    expect(result[0].rows).toHaveLength(1);
+    expect(result[0].rows[0].year).toBe(2024);
+    expect(result[0].rows[0].positions[1]).toEqual({ name: 'A. Smith', clubName: 'Wesham', runnerUrl: undefined });
+    expect(result[0].rows[0].positions[2]).toEqual({ name: 'B. Jones', clubName: 'Preston', runnerUrl: undefined });
+    expect(result[0].rows[0].positions[3]).toBeNull();
+  });
+
+  it('omits years that have no entry for a category', () => {
+    const input = [
+      {
+        year: 2024,
+        categories: [{ id: 'sen-m', name: 'Senior Men', sex: 'M' as const, awards: [{ position: 1, name: 'A', clubName: 'X' }] }],
+      },
+      {
+        year: 2023,
+        categories: [], // no sen-m this year
+      },
+      {
+        year: 2022,
+        categories: [{ id: 'sen-m', name: 'Senior Men', sex: 'M' as const, awards: [{ position: 1, name: 'B', clubName: 'Y' }] }],
+      },
+    ];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result[0].rows).toHaveLength(2);
+    expect(result[0].rows.map(r => r.year)).toEqual([2024, 2022]);
+  });
+
+  it('preserves the input year order (caller is responsible for sorting)', () => {
+    const input = [
+      { year: 2025, categories: [{ id: 'sen-f', name: 'Senior Women', sex: 'F' as const, awards: [{ position: 1, name: 'C', clubName: 'Z' }] }] },
+      { year: 2024, categories: [{ id: 'sen-f', name: 'Senior Women', sex: 'F' as const, awards: [{ position: 1, name: 'D', clubName: 'W' }] }] },
+    ];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result[0].rows[0].year).toBe(2025);
+    expect(result[0].rows[1].year).toBe(2024);
+  });
+
+  it('returns null for positions not present in the data', () => {
+    const input = [{
+      year: 2024,
+      categories: [{
+        id: 'v40-m', name: 'V40 Men', sex: 'M' as const,
+        awards: [{ position: 1, name: 'E', clubName: 'Q' }],
+      }],
+    }];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result[0].rows[0].positions[2]).toBeNull();
+    expect(result[0].rows[0].positions[3]).toBeNull();
+  });
+
+  it('propagates runnerUrl when present', () => {
+    const input = [{
+      year: 2024,
+      categories: [{
+        id: 'sen-m', name: 'Senior Men', sex: 'M' as const,
+        awards: [{ position: 1, name: 'F', clubName: 'R', runnerUrl: '/runners/f-surname' }],
+      }],
+    }];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result[0].rows[0].positions[1]?.runnerUrl).toBe('/runners/f-surname');
+  });
+
+  it('collects all categories across all years', () => {
+    const input = [
+      { year: 2024, categories: [{ id: 'sen-m', name: 'Senior Men', sex: 'M' as const, awards: [] }] },
+      { year: 2023, categories: [{ id: 'v40-f', name: 'V40 Women', sex: 'F' as const, awards: [] }] },
+    ];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result).toHaveLength(2);
+    expect(result.map(c => c.id)).toContain('sen-m');
+    expect(result.map(c => c.id)).toContain('v40-f');
+  });
+
+  it('propagates null sex for overall categories', () => {
+    const input = [{
+      year: 2024,
+      categories: [{ id: 'overall', name: 'Overall', sex: null, awards: [] }],
+    }];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result[0].sex).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | tail -30
+```
+
+Expected: failures on `pivotIndividualAwardsByCategory` (function not yet exported / tests newly added). If they pass already, check that the import in step 1 was correct.
+
+- [ ] **Step 3: Run tests to verify they pass (function already added in Task 1)**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | tail -30
+```
+
+Expected: all `pivotIndividualAwardsByCategory` tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/lib/results.test.ts
+git commit -m "test: add pivotIndividualAwardsByCategory tests"
+```
+
+---
+
+### Task 3: Rewrite `AwardsHistoryIndividuals.astro`
+
+**Files:**
+- Modify: `src/components/AwardsHistoryIndividuals.astro`
+
+- [ ] **Step 1: Replace the entire file content**
+
+```astro
+---
+import type { CategoryHistoryData } from '../lib/results';
+
+interface Props {
+  categories: CategoryHistoryData[];
+}
+
+const { categories } = Astro.props;
+
+const groups = [
+  { key: 'M',       label: 'Male',    cats: categories.filter(c => c.sex === 'M') },
+  { key: 'F',       label: 'Female',  cats: categories.filter(c => c.sex === 'F') },
+  { key: 'overall', label: 'Overall', cats: categories.filter(c => c.sex === null) },
+].filter(g => g.cats.length > 0);
+---
+
+{groups.length === 0 ? (
+  <p class="text-base-content/60">No individual awards recorded.</p>
+) : (
+  <div>
+    <div role="tablist" class="tabs tabs-border mb-2">
+      {groups.map((group, i) => (
+        <button
+          role="tab"
+          class={`tab${i === 0 ? ' tab-active' : ''}`}
+          data-top-tab={group.key}
+        >
+          {group.label}
+        </button>
+      ))}
+    </div>
+
+    {groups.map((group, i) => (
+      <div data-top-panel={group.key} class={i > 0 ? 'hidden' : ''}>
+        {group.cats.length > 1 && (
+          <div role="tablist" class="tabs tabs-border mb-4">
+            {group.cats.map((cat, j) => (
+              <button
+                role="tab"
+                class={`tab${j === 0 ? ' tab-active' : ''}`}
+                data-sub-tab={cat.id}
+                data-group={group.key}
+              >
+                {cat.name}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {group.cats.map((cat, j) => (
+          <div
+            data-sub-panel={cat.id}
+            data-group={group.key}
+            class={j > 0 ? 'hidden' : ''}
+          >
+            {cat.rows.length === 0 ? (
+              <p class="text-base-content/60">No awards recorded.</p>
+            ) : (
+              <div class="overflow-x-auto">
+                <table class="table table-sm w-full">
+                  <caption class="sr-only">{cat.name} award winners by year</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Year</th>
+                      <th scope="col">1st</th>
+                      <th scope="col">2nd</th>
+                      <th scope="col">3rd</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {cat.rows.map(row => (
+                      <tr class="hover">
+                        <td class="font-semibold">{row.year}</td>
+                        {([1, 2, 3] as const).map(pos => {
+                          const entry = row.positions[pos];
+                          return (
+                            <td class="text-sm">
+                              {entry ? (
+                                <span>
+                                  {entry.runnerUrl ? (
+                                    <a href={entry.runnerUrl} class="link link-hover font-medium">{entry.name}</a>
+                                  ) : (
+                                    <span class="font-medium">{entry.name}</span>
+                                  )}
+                                  <span class="text-base-content/50 ml-1">({entry.clubName})</span>
+                                </span>
+                              ) : <span>—</span>}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    ))}
+  </div>
+)}
+
+<script>
+  document.querySelectorAll<HTMLButtonElement>('[data-top-tab]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const key = btn.dataset.topTab!;
+      document.querySelectorAll('[data-top-tab]').forEach(t => t.classList.remove('tab-active'));
+      btn.classList.add('tab-active');
+      document.querySelectorAll('[data-top-panel]').forEach(p => p.classList.add('hidden'));
+      document.querySelector(`[data-top-panel="${key}"]`)?.classList.remove('hidden');
+    });
+  });
+
+  document.querySelectorAll<HTMLButtonElement>('[data-sub-tab]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const catId = btn.dataset.subTab!;
+      const group = btn.dataset.group!;
+      document.querySelectorAll(`[data-sub-tab][data-group="${group}"]`).forEach(t => t.classList.remove('tab-active'));
+      btn.classList.add('tab-active');
+      document.querySelectorAll(`[data-sub-panel][data-group="${group}"]`).forEach(p => p.classList.add('hidden'));
+      document.querySelector(`[data-sub-panel="${catId}"][data-group="${group}"]`)?.classList.remove('hidden');
+    });
+  });
+</script>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/AwardsHistoryIndividuals.astro
+git commit -m "feat: rewrite AwardsHistoryIndividuals with tabbed table layout"
+```
+
+---
+
+### Task 4: Update road-gp history page
+
+**Files:**
+- Modify: `src/pages/road-gp/history/[type].astro`
+
+- [ ] **Step 1: Replace the individuals section of the page**
+
+Replace the entire file with:
+
+```astro
+---
+import Layout from '../../../components/Layout.astro';
+import AwardsHistoryTeams from '../../../components/AwardsHistoryTeams.astro';
+import AwardsHistoryIndividuals from '../../../components/AwardsHistoryIndividuals.astro';
+import { getAllAwardsByYear, pivotIndividualAwardsByCategory } from '../../../lib/results';
+import { buildRunnerUrlMap } from '../../../lib/runners';
+import type { TeamCategory, CategoryHistoryData } from '../../../lib/types';
+
+export function getStaticPaths() {
+  return [
+    { params: { type: 'teams' } },
+    { params: { type: 'individuals' } },
+  ];
+}
+
+const series = 'road-gp';
+const { type } = Astro.params as { type: 'teams' | 'individuals' };
+
+const allYearlyAwards = getAllAwardsByYear(series);
+
+const pageTitle = type === 'teams' ? 'Road Grand Prix Team Winners' : 'Road Grand Prix Individual Winners';
+
+// Prepare team data
+let allCategories: TeamCategory[] = [];
+let yearlyTeamData: Array<{ year: number; categoryWinners: Record<string, string | null> }> = [];
+
+if (type === 'teams') {
+  const categoryMap = new Map<string, TeamCategory>();
+  allYearlyAwards.forEach(yearly => {
+    yearly.config.teamCategories?.forEach(cat => {
+      if (!categoryMap.has(cat.id)) {
+        categoryMap.set(cat.id, cat);
+      }
+    });
+  });
+  allCategories = Array.from(categoryMap.values());
+
+  yearlyTeamData = allYearlyAwards.map(yearly => {
+    const categoryWinners: Record<string, string | null> = {};
+    allCategories.forEach(cat => {
+      const award = yearly.awards.teamAwards.find(ta => ta.category === cat.id);
+      if (award) {
+        const clubName = yearly.clubs.find(c => c.id === award.club)?.name ?? award.club;
+        categoryWinners[cat.id] = clubName;
+      } else {
+        categoryWinners[cat.id] = null;
+      }
+    });
+    return { year: yearly.year, categoryWinners };
+  });
+}
+
+// Prepare individual data
+let categoryData: CategoryHistoryData[] = [];
+
+if (type === 'individuals') {
+  const yearlyResolved = allYearlyAwards.map(yearly => {
+    const runnerUrlMap = buildRunnerUrlMap(yearly.year, series);
+    return {
+      year: yearly.year,
+      categories: yearly.awards.individualAwards.map(ia => {
+        const configCat = yearly.config.individualCategories?.find(c => c.id === ia.category);
+        return {
+          id: ia.category,
+          name: configCat?.name ?? ia.category,
+          sex: configCat?.sex ?? null,
+          awards: ia.awards.map(a => ({
+            position: a.position,
+            name: a.name,
+            clubName: yearly.clubs.find(c => c.id === a.club)?.name ?? a.club ?? '',
+            runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
+          })),
+        };
+      }),
+    };
+  });
+  categoryData = pivotIndividualAwardsByCategory(yearlyResolved);
+}
+---
+
+<Layout title={pageTitle}>
+  <div class="container mx-auto px-4 py-6">
+    <div class="mb-6">
+      <a href="/road-gp" class="btn btn-sm btn-ghost">← Back</a>
+    </div>
+    <h1 class="text-3xl font-bold mb-6">{pageTitle}</h1>
+    {type === 'teams' ? (
+      <AwardsHistoryTeams
+        series={series}
+        yearlyData={yearlyTeamData}
+        allCategories={allCategories}
+      />
+    ) : (
+      <AwardsHistoryIndividuals categories={categoryData} />
+    )}
+  </div>
+</Layout>
+```
+
+Note: `CategoryHistoryData` is imported from `'../../../lib/types'` — but it's defined in `results.ts`. Update the import to `'../../../lib/results'`:
+
+```ts
+import type { TeamCategory } from '../../../lib/types';
+import { getAllAwardsByYear, pivotIndividualAwardsByCategory } from '../../../lib/results';
+import type { CategoryHistoryData } from '../../../lib/results';
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/pages/road-gp/history/[type].astro
+git commit -m "feat: update road-gp history page to use pivoted individual data"
+```
+
+---
+
+### Task 5: Update fell history page
+
+**Files:**
+- Modify: `src/pages/fell/history/[type].astro`
+
+- [ ] **Step 1: Read the current fell history page**
+
+Read `src/pages/fell/history/[type].astro` to confirm its structure matches the road-gp version.
+
+- [ ] **Step 2: Apply the same changes as Task 4**
+
+Replace the file with the same content as the road-gp version from Task 4, changing only:
+- `const series = 'road-gp';` → `const series = 'fell';`
+- `pageTitle` values: `'Fell Championship Team Winners'` and `'Fell Championship Individual Winners'`
+- `<a href="/road-gp"` → `<a href="/fell"`
+- All three import paths: `'../../../components/...'` → `'../../../components/...'` (same depth, no change needed)
+- All three import paths from lib: `'../../../lib/...'` (same depth, no change needed)
+
+The full file content to write:
+
+```astro
+---
+import Layout from '../../../components/Layout.astro';
+import AwardsHistoryTeams from '../../../components/AwardsHistoryTeams.astro';
+import AwardsHistoryIndividuals from '../../../components/AwardsHistoryIndividuals.astro';
+import { getAllAwardsByYear, pivotIndividualAwardsByCategory } from '../../../lib/results';
+import { buildRunnerUrlMap } from '../../../lib/runners';
+import type { TeamCategory } from '../../../lib/types';
+import type { CategoryHistoryData } from '../../../lib/results';
+
+export function getStaticPaths() {
+  return [
+    { params: { type: 'teams' } },
+    { params: { type: 'individuals' } },
+  ];
+}
+
+const series = 'fell';
+const { type } = Astro.params as { type: 'teams' | 'individuals' };
+
+const allYearlyAwards = getAllAwardsByYear(series);
+
+const pageTitle = type === 'teams' ? 'Fell Championship Team Winners' : 'Fell Championship Individual Winners';
+
+// Prepare team data
+let allCategories: TeamCategory[] = [];
+let yearlyTeamData: Array<{ year: number; categoryWinners: Record<string, string | null> }> = [];
+
+if (type === 'teams') {
+  const categoryMap = new Map<string, TeamCategory>();
+  allYearlyAwards.forEach(yearly => {
+    yearly.config.teamCategories?.forEach(cat => {
+      if (!categoryMap.has(cat.id)) {
+        categoryMap.set(cat.id, cat);
+      }
+    });
+  });
+  allCategories = Array.from(categoryMap.values());
+
+  yearlyTeamData = allYearlyAwards.map(yearly => {
+    const categoryWinners: Record<string, string | null> = {};
+    allCategories.forEach(cat => {
+      const award = yearly.awards.teamAwards.find(ta => ta.category === cat.id);
+      if (award) {
+        const clubName = yearly.clubs.find(c => c.id === award.club)?.name ?? award.club;
+        categoryWinners[cat.id] = clubName;
+      } else {
+        categoryWinners[cat.id] = null;
+      }
+    });
+    return { year: yearly.year, categoryWinners };
+  });
+}
+
+// Prepare individual data
+let categoryData: CategoryHistoryData[] = [];
+
+if (type === 'individuals') {
+  const yearlyResolved = allYearlyAwards.map(yearly => {
+    const runnerUrlMap = buildRunnerUrlMap(yearly.year, series);
+    return {
+      year: yearly.year,
+      categories: yearly.awards.individualAwards.map(ia => {
+        const configCat = yearly.config.individualCategories?.find(c => c.id === ia.category);
+        return {
+          id: ia.category,
+          name: configCat?.name ?? ia.category,
+          sex: configCat?.sex ?? null,
+          awards: ia.awards.map(a => ({
+            position: a.position,
+            name: a.name,
+            clubName: yearly.clubs.find(c => c.id === a.club)?.name ?? a.club ?? '',
+            runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
+          })),
+        };
+      }),
+    };
+  });
+  categoryData = pivotIndividualAwardsByCategory(yearlyResolved);
+}
+---
+
+<Layout title={pageTitle}>
+  <div class="container mx-auto px-4 py-6">
+    <div class="mb-6">
+      <a href="/fell" class="btn btn-sm btn-ghost">← Back</a>
+    </div>
+    <h1 class="text-3xl font-bold mb-6">{pageTitle}</h1>
+    {type === 'teams' ? (
+      <AwardsHistoryTeams
+        series={series}
+        yearlyData={yearlyTeamData}
+        allCategories={allCategories}
+      />
+    ) : (
+      <AwardsHistoryIndividuals categories={categoryData} />
+    )}
+  </div>
+</Layout>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/fell/history/[type].astro
+git commit -m "feat: update fell history page to use pivoted individual data"
+```
+
+---
+
+### Task 6: Build verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run unit tests**
+
+```bash
+npm test 2>&1 | tail -20
+```
+
+Expected: all tests PASS, no failures.
+
+- [ ] **Step 2: Run build**
+
+```bash
+npm run build 2>&1 | tail -40
+```
+
+Expected: build completes with no TypeScript errors. If you see type errors, the most likely causes are:
+- `CategoryHistoryData` imported from wrong path — must be `'../../../lib/results'`, not `'../../../lib/types'`
+- `series` prop still being passed to `AwardsHistoryIndividuals` — the new component does not accept a `series` prop; remove it
+
+- [ ] **Step 3: Commit if build is clean**
+
+If the build passes without errors, no additional commit is needed (all changes are already committed). If you made fixes, commit them:
+
+```bash
+git add -p
+git commit -m "fix: resolve build errors in individual history pages"
+```

--- a/docs/superpowers/specs/2026-05-17-individual-history-redesign.md
+++ b/docs/superpowers/specs/2026-05-17-individual-history-redesign.md
@@ -1,0 +1,90 @@
+# Individual History Page Redesign
+
+**Date:** 2026-05-17  
+**Series:** Road GP and Fell Championship  
+**Page:** `/road-gp/history/individuals` and `/fell/history/individuals`
+
+## Problem
+
+The current individual history page groups award winners by year (one card per year). This makes it hard to compare who won a specific category across different years — you have to scroll through every year card and mentally filter. The team history page (`/road-gp/history/teams`) solves this well with a table where years are rows and categories are columns.
+
+## Goal
+
+Redesign the individual history page to use the same year-as-rows pattern, making it easy to see "who won Senior Men each year" at a glance.
+
+## Design
+
+### Data Shape
+
+The page (`[type].astro`) pivots the existing year-keyed data into a category-first structure before passing it to the component:
+
+```ts
+interface CategoryHistoryData {
+  id: string;
+  name: string;
+  sex: 'M' | 'F' | null;  // from config.individualCategories[].sex; null = Overall
+  rows: Array<{
+    year: number;
+    positions: {
+      1: { name: string; clubName: string; runnerUrl?: string } | null;
+      2: { name: string; clubName: string; runnerUrl?: string } | null;
+      3: { name: string; clubName: string; runnerUrl?: string } | null;
+    };
+  }>;
+}
+```
+
+- All categories across all years are included (union of all `individualCategories` from all yearly configs)
+- `rows` only includes years that have at least one award entry for that category (years with no entry are omitted entirely)
+- `rows` are ordered newest year first
+- Positions 1, 2, 3 are fixed columns — not derived from data. If a position wasn't awarded in a given year, the value is `null` (renders as `—`)
+
+### Tab Structure
+
+Two-level tab navigation:
+
+**Top-level tabs:** Male | Female | Overall  
+Derived from the `sex` field on `individualCategories`:
+- `"M"` → Male tab
+- `"F"` → Female tab  
+- `null` / absent → Overall tab
+- Tabs are only rendered if at least one category belongs to that group
+
+**Sub-tabs:** One tab per category within the active top-level group  
+(e.g. Male → Overall, Senior, V40, V45, V50, V55, V60, V65, V70, V75)
+
+Tab state managed by a small inline `<script>` (plain JS, class toggling). DaisyUI radio-based tabs don't compose cleanly across two levels. The first top tab and its first sub-tab are active on page load.
+
+### Table
+
+Each category panel renders a table:
+
+| Year | 1st | 2nd | 3rd |
+|------|-----|-----|-----|
+| 2025 | L. Minns (Blackpool) | R. Danson (Preston) | S. Evans (Preston) |
+| 2024 | … | … | — |
+
+- Columns: Year (left-aligned, bold), 1st, 2nd, 3rd (fixed headings)
+- Cell content: "Name (Club)" — runner name links to profile page when `runnerUrl` is available
+- Missing position: `—`
+- Years with no award entry for this category are omitted from the table entirely
+- Matches the visual style of `AwardsHistoryTeams` (DaisyUI `table table-sm`, `hover` rows)
+
+## Files Changed
+
+### Modified
+- `src/components/AwardsHistoryIndividuals.astro` — replace card-per-year layout with tabbed table layout; new props interface using `CategoryHistoryData[]`
+- `src/pages/road-gp/history/[type].astro` — pivot individual data from year-keyed to category-keyed before passing to component
+- `src/pages/fell/history/[type].astro` — same pivot as road-gp
+
+### No changes needed
+- `AwardsHistoryTeams.astro` — unchanged
+- Data files (`awards.json`, `config.json`) — unchanged
+- `results.ts` / `runners.ts` — unchanged
+
+## Edge Cases
+
+- **Category appears in only one year:** Still gets a tab and a single-row table
+- **No awards for a series:** Page renders with empty state (existing behaviour)
+- **Top-level group has no categories:** That top tab is not rendered
+- **Position 4+ in awards data:** Ignored — only positions 1, 2, 3 are shown

--- a/src/components/AwardsHistoryIndividuals.astro
+++ b/src/components/AwardsHistoryIndividuals.astro
@@ -1,83 +1,125 @@
 ---
-import type { Series, IndividualCategory } from '../lib/types';
-
-interface ResolvedAwardEntry {
-  position: number;
-  name: string;
-  clubName: string;
-  ageCategory?: string;
-  runnerUrl?: string;
-}
-
-interface ResolvedCategory {
-  categoryName: string;
-  awards: ResolvedAwardEntry[];
-}
-
-interface YearlyIndividualAwards {
-  year: number;
-  categories: ResolvedCategory[];
-}
+import type { CategoryHistoryData } from '../lib/results';
 
 interface Props {
-  series: Series;
-  yearlyData: YearlyIndividualAwards[];
+  categories: CategoryHistoryData[];
 }
 
-const { yearlyData } = Astro.props;
+const { categories } = Astro.props;
 
-function positionLabel(pos: number): string {
-  if (pos === 1) return '🥇';
-  if (pos === 2) return '🥈';
-  if (pos === 3) return '🥉';
-  const mod10 = pos % 10;
-  const mod100 = pos % 100;
-  const suffix =
-    mod10 === 1 && mod100 !== 11 ? 'st' :
-    mod10 === 2 && mod100 !== 12 ? 'nd' :
-    mod10 === 3 && mod100 !== 13 ? 'rd' : 'th';
-  return `${pos}${suffix}`;
-}
+const groups = [
+  { key: 'M',       label: 'Male',    cats: categories.filter(c => c.sex === 'M') },
+  { key: 'F',       label: 'Female',  cats: categories.filter(c => c.sex === 'F') },
+  { key: 'overall', label: 'Overall', cats: categories.filter(c => c.sex === null) },
+].filter(g => g.cats.length > 0);
 ---
 
-<div class="space-y-6">
-  {yearlyData.map(yearly => (
-    <div class="card bg-base-200">
-      <div class="card-body p-6">
-        <h2 class="card-title text-2xl mb-4">{yearly.year}</h2>
+{groups.length === 0 ? (
+  <p class="text-base-content/60">No individual awards recorded.</p>
+) : (
+  <div>
+    <div role="tablist" class="tabs tabs-border mb-2">
+      {groups.map((group, i) => (
+        <button
+          role="tab"
+          class={`tab${i === 0 ? ' tab-active' : ''}`}
+          data-top-tab={group.key}
+        >
+          {group.label}
+        </button>
+      ))}
+    </div>
 
-        {yearly.categories.length === 0 ? (
-          <p class="text-base-content/60">No individual awards</p>
-        ) : (
-          <div class="space-y-4">
-            {yearly.categories.map(cat => (
-              <div class="bg-base-100 rounded-lg p-4">
-                <p class="text-sm font-semibold text-base-content/70 mb-3">{cat.categoryName}</p>
-                <div class="space-y-2">
-                  {cat.awards.map(award => (
-                    <div class="flex items-baseline gap-3 text-sm">
-                      <span class="w-6 shrink-0 text-lg">{positionLabel(award.position)}</span>
-                      <div class="flex-1 min-w-0">
-                        {award.runnerUrl ? (
-                          <a href={award.runnerUrl} class="font-medium link link-hover">
-                            {award.name}
-                          </a>
-                        ) : (
-                          <span class="font-medium">{award.name}</span>
-                        )}
-                      </div>
-                      <span class="text-base-content/50 text-xs shrink-0">{award.clubName}</span>
-                      {award.ageCategory && (
-                        <span class="text-base-content/50 text-xs shrink-0">{award.ageCategory}</span>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
+    {groups.map((group, i) => (
+      <div data-top-panel={group.key} class={i > 0 ? 'hidden' : ''}>
+        {group.cats.length > 1 && (
+          <div role="tablist" class="tabs tabs-border mb-4">
+            {group.cats.map((cat, j) => (
+              <button
+                role="tab"
+                class={`tab${j === 0 ? ' tab-active' : ''}`}
+                data-sub-tab={cat.id}
+                data-group={group.key}
+              >
+                {cat.name}
+              </button>
             ))}
           </div>
         )}
+
+        {group.cats.map((cat, j) => (
+          <div
+            data-sub-panel={cat.id}
+            data-group={group.key}
+            class={j > 0 ? 'hidden' : ''}
+          >
+            {cat.rows.length === 0 ? (
+              <p class="text-base-content/60">No awards recorded.</p>
+            ) : (
+              <div class="overflow-x-auto">
+                <table class="table table-sm w-full">
+                  <caption class="sr-only">{cat.name} award winners by year</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Year</th>
+                      <th scope="col">1st</th>
+                      <th scope="col">2nd</th>
+                      <th scope="col">3rd</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {cat.rows.map(row => (
+                      <tr class="hover">
+                        <td class="font-semibold">{row.year}</td>
+                        {([1, 2, 3] as const).map(pos => {
+                          const entry = row.positions[pos];
+                          return (
+                            <td class="text-sm">
+                              {entry ? (
+                                <span>
+                                  {entry.runnerUrl ? (
+                                    <a href={entry.runnerUrl} class="link link-hover font-medium">{entry.name}</a>
+                                  ) : (
+                                    <span class="font-medium">{entry.name}</span>
+                                  )}
+                                  <span class="text-base-content/50 ml-1">({entry.clubName})</span>
+                                </span>
+                              ) : <span>—</span>}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        ))}
       </div>
-    </div>
-  ))}
-</div>
+    ))}
+  </div>
+)}
+
+<script>
+  document.querySelectorAll<HTMLButtonElement>('[data-top-tab]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const key = btn.dataset.topTab!;
+      document.querySelectorAll('[data-top-tab]').forEach(t => t.classList.remove('tab-active'));
+      btn.classList.add('tab-active');
+      document.querySelectorAll('[data-top-panel]').forEach(p => p.classList.add('hidden'));
+      document.querySelector(`[data-top-panel="${key}"]`)?.classList.remove('hidden');
+    });
+  });
+
+  document.querySelectorAll<HTMLButtonElement>('[data-sub-tab]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const catId = btn.dataset.subTab!;
+      const group = btn.dataset.group!;
+      document.querySelectorAll(`[data-sub-tab][data-group="${group}"]`).forEach(t => t.classList.remove('tab-active'));
+      btn.classList.add('tab-active');
+      document.querySelectorAll(`[data-sub-panel][data-group="${group}"]`).forEach(p => p.classList.add('hidden'));
+      document.querySelector(`[data-sub-panel="${catId}"][data-group="${group}"]`)?.classList.remove('hidden');
+    });
+  });
+</script>

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -323,3 +323,75 @@ export function getAllAwardsByYear(series: Series): YearlyAwardsData[] {
   // Sort by year descending (newest first)
   return awardsList.sort((a, b) => b.year - a.year);
 }
+
+// ---- Individual history pivot ----
+
+export interface YearlyResolvedIndividual {
+  year: number;
+  categories: Array<{
+    id: string;
+    name: string;
+    sex: 'M' | 'F' | null;
+    awards: Array<{
+      position: number;
+      name: string;
+      clubName: string;
+      runnerUrl?: string;
+    }>;
+  }>;
+}
+
+export interface CategoryHistoryEntry {
+  name: string;
+  clubName: string;
+  runnerUrl?: string;
+}
+
+export interface CategoryHistoryRow {
+  year: number;
+  positions: {
+    1: CategoryHistoryEntry | null;
+    2: CategoryHistoryEntry | null;
+    3: CategoryHistoryEntry | null;
+  };
+}
+
+export interface CategoryHistoryData {
+  id: string;
+  name: string;
+  sex: 'M' | 'F' | null;
+  rows: CategoryHistoryRow[];
+}
+
+export function pivotIndividualAwardsByCategory(
+  yearlyData: YearlyResolvedIndividual[]
+): CategoryHistoryData[] {
+  const categoryMap = new Map<string, { name: string; sex: 'M' | 'F' | null }>();
+  for (const yearly of yearlyData) {
+    for (const cat of yearly.categories) {
+      if (!categoryMap.has(cat.id)) {
+        categoryMap.set(cat.id, { name: cat.name, sex: cat.sex });
+      }
+    }
+  }
+
+  return Array.from(categoryMap.entries()).map(([id, meta]) => {
+    const rows = yearlyData
+      .filter(yearly => yearly.categories.some(c => c.id === id))
+      .map(yearly => {
+        const cat = yearly.categories.find(c => c.id === id)!;
+        const findPos = (pos: number) => cat.awards.find(a => a.position === pos);
+        const mapEntry = (a: ReturnType<typeof findPos>): CategoryHistoryEntry | null =>
+          a ? { name: a.name, clubName: a.clubName, runnerUrl: a.runnerUrl } : null;
+        return {
+          year: yearly.year,
+          positions: {
+            1: mapEntry(findPos(1)),
+            2: mapEntry(findPos(2)),
+            3: mapEntry(findPos(3)),
+          },
+        };
+      });
+    return { id, name: meta.name, sex: meta.sex, rows };
+  });
+}

--- a/src/pages/fell/history/[type].astro
+++ b/src/pages/fell/history/[type].astro
@@ -2,9 +2,10 @@
 import Layout from '../../../components/Layout.astro';
 import AwardsHistoryTeams from '../../../components/AwardsHistoryTeams.astro';
 import AwardsHistoryIndividuals from '../../../components/AwardsHistoryIndividuals.astro';
-import { getAllAwardsByYear } from '../../../lib/results';
+import { getAllAwardsByYear, pivotIndividualAwardsByCategory } from '../../../lib/results';
 import { buildRunnerUrlMap } from '../../../lib/runners';
 import type { TeamCategory } from '../../../lib/types';
+import type { CategoryHistoryData } from '../../../lib/results';
 
 export function getStaticPaths() {
   return [
@@ -37,7 +38,6 @@ if (type === 'teams') {
 
   yearlyTeamData = allYearlyAwards.map(yearly => {
     const categoryWinners: Record<string, string | null> = {};
-
     allCategories.forEach(cat => {
       const award = yearly.awards.teamAwards.find(ta => ta.category === cat.id);
       if (award) {
@@ -47,35 +47,35 @@ if (type === 'teams') {
         categoryWinners[cat.id] = null;
       }
     });
-
     return { year: yearly.year, categoryWinners };
   });
 }
 
 // Prepare individual data
-let yearlyIndividualData: Array<{ year: number; categories: Array<{ categoryName: string; awards: Array<{ position: number; name: string; clubName: string; ageCategory: string; runnerUrl?: string }> }> }> = [];
+let categoryData: CategoryHistoryData[] = [];
 
 if (type === 'individuals') {
-  yearlyIndividualData = allYearlyAwards.map(yearly => {
+  const yearlyResolved = allYearlyAwards.map(yearly => {
     const runnerUrlMap = buildRunnerUrlMap(yearly.year, series);
-
-    const categories = yearly.awards.individualAwards.map(ia => {
-      const cat = yearly.config.individualCategories?.find(c => c.id === ia.category);
-
-      return {
-        categoryName: cat?.name ?? ia.category,
-        awards: ia.awards.map(a => ({
-          position: a.position,
-          name: a.name,
-          clubName: yearly.clubs.find(c => c.id === a.club)?.name ?? a.club,
-          ageCategory: a.category,
-          runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
-        })),
-      };
-    });
-
-    return { year: yearly.year, categories };
+    return {
+      year: yearly.year,
+      categories: yearly.awards.individualAwards.map(ia => {
+        const configCat = yearly.config.individualCategories?.find(c => c.id === ia.category);
+        return {
+          id: ia.category,
+          name: configCat?.name ?? ia.category,
+          sex: configCat?.sex ?? null,
+          awards: ia.awards.map(a => ({
+            position: a.position,
+            name: a.name,
+            clubName: yearly.clubs.find(c => c.id === a.club)?.name ?? a.club ?? '',
+            runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
+          })),
+        };
+      }),
+    };
   });
+  categoryData = pivotIndividualAwardsByCategory(yearlyResolved);
 }
 ---
 
@@ -92,10 +92,7 @@ if (type === 'individuals') {
         allCategories={allCategories}
       />
     ) : (
-      <AwardsHistoryIndividuals
-        series={series}
-        yearlyData={yearlyIndividualData}
-      />
+      <AwardsHistoryIndividuals categories={categoryData} />
     )}
   </div>
 </Layout>

--- a/src/pages/road-gp/history/[type].astro
+++ b/src/pages/road-gp/history/[type].astro
@@ -2,9 +2,10 @@
 import Layout from '../../../components/Layout.astro';
 import AwardsHistoryTeams from '../../../components/AwardsHistoryTeams.astro';
 import AwardsHistoryIndividuals from '../../../components/AwardsHistoryIndividuals.astro';
-import { getAllAwardsByYear } from '../../../lib/results';
+import { getAllAwardsByYear, pivotIndividualAwardsByCategory } from '../../../lib/results';
 import { buildRunnerUrlMap } from '../../../lib/runners';
 import type { TeamCategory } from '../../../lib/types';
+import type { CategoryHistoryData } from '../../../lib/results';
 
 export function getStaticPaths() {
   return [
@@ -37,7 +38,6 @@ if (type === 'teams') {
 
   yearlyTeamData = allYearlyAwards.map(yearly => {
     const categoryWinners: Record<string, string | null> = {};
-
     allCategories.forEach(cat => {
       const award = yearly.awards.teamAwards.find(ta => ta.category === cat.id);
       if (award) {
@@ -47,35 +47,35 @@ if (type === 'teams') {
         categoryWinners[cat.id] = null;
       }
     });
-
     return { year: yearly.year, categoryWinners };
   });
 }
 
 // Prepare individual data
-let yearlyIndividualData: Array<{ year: number; categories: Array<{ categoryName: string; awards: Array<{ position: number; name: string; clubName: string; ageCategory: string; runnerUrl?: string }> }> }> = [];
+let categoryData: CategoryHistoryData[] = [];
 
 if (type === 'individuals') {
-  yearlyIndividualData = allYearlyAwards.map(yearly => {
+  const yearlyResolved = allYearlyAwards.map(yearly => {
     const runnerUrlMap = buildRunnerUrlMap(yearly.year, series);
-
-    const categories = yearly.awards.individualAwards.map(ia => {
-      const cat = yearly.config.individualCategories?.find(c => c.id === ia.category);
-
-      return {
-        categoryName: cat?.name ?? ia.category,
-        awards: ia.awards.map(a => ({
-          position: a.position,
-          name: a.name,
-          clubName: yearly.clubs.find(c => c.id === a.club)?.name ?? a.club,
-          ageCategory: a.category,
-          runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
-        })),
-      };
-    });
-
-    return { year: yearly.year, categories };
+    return {
+      year: yearly.year,
+      categories: yearly.awards.individualAwards.map(ia => {
+        const configCat = yearly.config.individualCategories?.find(c => c.id === ia.category);
+        return {
+          id: ia.category,
+          name: configCat?.name ?? ia.category,
+          sex: configCat?.sex ?? null,
+          awards: ia.awards.map(a => ({
+            position: a.position,
+            name: a.name,
+            clubName: yearly.clubs.find(c => c.id === a.club)?.name ?? a.club ?? '',
+            runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
+          })),
+        };
+      }),
+    };
   });
+  categoryData = pivotIndividualAwardsByCategory(yearlyResolved);
 }
 ---
 
@@ -92,10 +92,7 @@ if (type === 'individuals') {
         allCategories={allCategories}
       />
     ) : (
-      <AwardsHistoryIndividuals
-        series={series}
-        yearlyData={yearlyIndividualData}
-      />
+      <AwardsHistoryIndividuals categories={categoryData} />
     )}
   </div>
 </Layout>

--- a/tests/lib/results.test.ts
+++ b/tests/lib/results.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseResultsCsv, parseTeamResultsPath, parseTeamStandingsPath, parseIndividualStandingsPath } from '../../src/lib/results';
+import { parseResultsCsv, parseTeamResultsPath, parseTeamStandingsPath, parseIndividualStandingsPath, pivotIndividualAwardsByCategory } from '../../src/lib/results';
 
 describe('parseResultsCsv', () => {
   const sample = [
@@ -164,5 +164,111 @@ describe('parseIndividualStandingsPath', () => {
   it('returns null for an individual results path', () => {
     expect(parseIndividualStandingsPath('../data/2026/fell/results/race-1.csv'))
       .toBeNull();
+  });
+});
+
+describe('pivotIndividualAwardsByCategory', () => {
+  it('returns empty array for empty input', () => {
+    expect(pivotIndividualAwardsByCategory([])).toEqual([]);
+  });
+
+  it('returns one category entry for a single year with one category', () => {
+    const input = [{
+      year: 2024,
+      categories: [{
+        id: 'sen-m',
+        name: 'Senior Men',
+        sex: 'M' as const,
+        awards: [
+          { position: 1, name: 'A. Smith', clubName: 'Wesham' },
+          { position: 2, name: 'B. Jones', clubName: 'Preston' },
+        ],
+      }],
+    }];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('sen-m');
+    expect(result[0].name).toBe('Senior Men');
+    expect(result[0].sex).toBe('M');
+    expect(result[0].rows).toHaveLength(1);
+    expect(result[0].rows[0].year).toBe(2024);
+    expect(result[0].rows[0].positions[1]).toEqual({ name: 'A. Smith', clubName: 'Wesham', runnerUrl: undefined });
+    expect(result[0].rows[0].positions[2]).toEqual({ name: 'B. Jones', clubName: 'Preston', runnerUrl: undefined });
+    expect(result[0].rows[0].positions[3]).toBeNull();
+  });
+
+  it('omits years that have no entry for a category', () => {
+    const input = [
+      {
+        year: 2024,
+        categories: [{ id: 'sen-m', name: 'Senior Men', sex: 'M' as const, awards: [{ position: 1, name: 'A', clubName: 'X' }] }],
+      },
+      {
+        year: 2023,
+        categories: [], // no sen-m this year
+      },
+      {
+        year: 2022,
+        categories: [{ id: 'sen-m', name: 'Senior Men', sex: 'M' as const, awards: [{ position: 1, name: 'B', clubName: 'Y' }] }],
+      },
+    ];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result[0].rows).toHaveLength(2);
+    expect(result[0].rows.map(r => r.year)).toEqual([2024, 2022]);
+  });
+
+  it('preserves the input year order (caller is responsible for sorting)', () => {
+    const input = [
+      { year: 2025, categories: [{ id: 'sen-f', name: 'Senior Women', sex: 'F' as const, awards: [{ position: 1, name: 'C', clubName: 'Z' }] }] },
+      { year: 2024, categories: [{ id: 'sen-f', name: 'Senior Women', sex: 'F' as const, awards: [{ position: 1, name: 'D', clubName: 'W' }] }] },
+    ];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result[0].rows[0].year).toBe(2025);
+    expect(result[0].rows[1].year).toBe(2024);
+  });
+
+  it('returns null for positions not present in the data', () => {
+    const input = [{
+      year: 2024,
+      categories: [{
+        id: 'v40-m', name: 'V40 Men', sex: 'M' as const,
+        awards: [{ position: 1, name: 'E', clubName: 'Q' }],
+      }],
+    }];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result[0].rows[0].positions[2]).toBeNull();
+    expect(result[0].rows[0].positions[3]).toBeNull();
+  });
+
+  it('propagates runnerUrl when present', () => {
+    const input = [{
+      year: 2024,
+      categories: [{
+        id: 'sen-m', name: 'Senior Men', sex: 'M' as const,
+        awards: [{ position: 1, name: 'F', clubName: 'R', runnerUrl: '/runners/f-surname' }],
+      }],
+    }];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result[0].rows[0].positions[1]?.runnerUrl).toBe('/runners/f-surname');
+  });
+
+  it('collects all categories across all years', () => {
+    const input = [
+      { year: 2024, categories: [{ id: 'sen-m', name: 'Senior Men', sex: 'M' as const, awards: [] }] },
+      { year: 2023, categories: [{ id: 'v40-f', name: 'V40 Women', sex: 'F' as const, awards: [] }] },
+    ];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result).toHaveLength(2);
+    expect(result.map(c => c.id)).toContain('sen-m');
+    expect(result.map(c => c.id)).toContain('v40-f');
+  });
+
+  it('propagates null sex for overall categories', () => {
+    const input = [{
+      year: 2024,
+      categories: [{ id: 'overall', name: 'Overall', sex: null, awards: [] }],
+    }];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result[0].sex).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Replaces the per-year card layout on `/road-gp/history/individuals` and `/fell/history/individuals` with a two-level tabbed table — **Male / Female / Overall** top tabs, age-category sub-tabs, and a **Year | 1st | 2nd | 3rd** table per category
- Adds `pivotIndividualAwardsByCategory` pure function to `results.ts` (with 8 unit tests) that reshapes year-keyed award data into category-keyed table rows
- Keeps the team history page unchanged

## Test Plan

- [ ] All 52 unit tests pass (`npm test`)
- [ ] Build succeeds with no TypeScript errors (`npm run build`)
- [ ] `/road-gp/history/individuals` shows Male / Female / Overall top tabs with age sub-tabs and a year-by-year table per category
- [ ] `/fell/history/individuals` shows the same layout
- [ ] `/road-gp/history/teams` is unaffected
- [ ] Runner profile links work when present
- [ ] `—` shown for positions not awarded in a given year

🤖 Generated with [Claude Code](https://claude.com/claude-code)