### PR TITLE
fix(data): rename id to ageCategory on individual award entries in historical road-gp awards

### DIFF
--- a/src/data/2017/road-gp/awards.json
+++ b/src/data/2017/road-gp/awards.json
@@ -7,61 +7,61 @@
           "position": 1,
           "name": "C. Carrdus",
           "club": "lytham",
-          "id": "V45"
+          "ageCategory": "V45"
         },
         {
           "position": 2,
           "name": "J. Rogers",
           "club": "blackpool",
-          "id": "JUN"
+          "ageCategory": "JUN"
         },
         {
           "position": 3,
           "name": "J. Goorney",
           "club": "lytham",
-          "id": "V45"
+          "ageCategory": "V45"
         },
         {
           "position": 4,
           "name": "C. Davies",
           "club": "red-rose",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 5,
           "name": "M. Hook",
           "club": "lytham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 6,
           "name": "H. Lawrenson",
           "club": "wesham",
-          "id": "V45"
+          "ageCategory": "V45"
         },
         {
           "position": 7,
           "name": "C. Sullivan",
           "club": "wesham",
-          "id": "V50"
+          "ageCategory": "V50"
         },
         {
           "position": 8,
           "name": "B. Wright",
           "club": "blackpool",
-          "id": "V55"
+          "ageCategory": "V55"
         },
         {
           "position": 9,
           "name": "H. Morris",
           "club": "chorley",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 10,
           "name": "M. Tickle",
           "club": "blackpool",
-          "id": "V40"
+          "ageCategory": "V40"
         }
       ]
     },
@@ -72,61 +72,61 @@
           "position": 1,
           "name": "R. Danson",
           "club": "wesham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 2,
           "name": "R. Affleck",
           "club": "preston",
-          "id": "V45"
+          "ageCategory": "V45"
         },
         {
           "position": 3,
           "name": "G. Pennington",
           "club": "preston",
-          "id": "V45"
+          "ageCategory": "V45"
         },
         {
           "position": 4,
           "name": "S. Croft",
           "club": "red-rose",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 5,
           "name": "C. McCarthy",
           "club": "lytham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 6,
           "name": "T. Donnely",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 7,
           "name": "P. Leybourne",
           "club": "blackpool",
-          "id": "V50"
+          "ageCategory": "V50"
         },
         {
           "position": 8,
           "name": "J. Greenwood",
           "club": "lytham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 9,
           "name": "R. Smith",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 10,
           "name": "J. Mulvany",
           "club": "wesham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         }
       ]
     },

--- a/src/data/2018/road-gp/awards.json
+++ b/src/data/2018/road-gp/awards.json
@@ -7,61 +7,61 @@
           "position": 1,
           "name": "T. Robinson",
           "club": "wesham",
-          "id": "V35"
+          "ageCategory": "V35"
         },
         {
           "position": 2,
           "name": "E. Abbott",
           "club": "lytham",
-          "id": "V35"
+          "ageCategory": "V35"
         },
         {
           "position": 3,
           "name": "C. Carrdus",
           "club": "lytham",
-          "id": "V45"
+          "ageCategory": "V45"
         },
         {
           "position": 4,
           "name": "J. Rogers",
           "club": "blackpool",
-          "id": "JUN"
+          "ageCategory": "JUN"
         },
         {
           "position": 5,
           "name": "J. Goorney",
           "club": "lytham",
-          "id": "V45"
+          "ageCategory": "V45"
         },
         {
           "position": 6,
           "name": "B. Wright",
           "club": "blackpool",
-          "id": "V55"
+          "ageCategory": "V55"
         },
         {
           "position": 7,
           "name": "M. Koth",
           "club": "lytham",
-          "id": "V40"
+          "ageCategory": "V40"
         },
         {
           "position": 8,
           "name": "H. Lawrenson",
           "club": "wesham",
-          "id": "V45"
+          "ageCategory": "V45"
         },
         {
           "position": 9,
           "name": "J. Wren",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 10,
           "name": "H. Lees",
           "club": "chorley",
-          "id": "SEN"
+          "ageCategory": "SEN"
         }
       ]
     },
@@ -72,61 +72,61 @@
           "position": 1,
           "name": "R. Danson",
           "club": "wesham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 2,
           "name": "R. Affleck",
           "club": "preston",
-          "id": "V45"
+          "ageCategory": "V45"
         },
         {
           "position": 3,
           "name": "S. Croft",
           "club": "red-rose",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 4,
           "name": "P. Leybourne",
           "club": "blackpool",
-          "id": "V50"
+          "ageCategory": "V50"
         },
         {
           "position": 5,
           "name": "S. Swarbrick",
           "club": "wesham",
-          "id": "V45"
+          "ageCategory": "V45"
         },
         {
           "position": 6,
           "name": "J. Greenwood",
           "club": "lytham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 7,
           "name": "A. Draper",
           "club": "lytham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 8,
           "name": "K. Hodgson",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 9,
           "name": "T. Belcher",
           "club": "chorley",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 10,
           "name": "K. Lee",
           "club": "lytham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         }
       ]
     },

--- a/src/data/2019/road-gp/awards.json
+++ b/src/data/2019/road-gp/awards.json
@@ -7,19 +7,19 @@
           "position": 1,
           "name": "L. Abbott",
           "club": "lytham",
-          "id": "V35"
+          "ageCategory": "V35"
         },
         {
           "position": 2,
           "name": "C. Carrdus",
           "club": "lytham",
-          "id": "V45"
+          "ageCategory": "V45"
         },
         {
           "position": 3,
           "name": "K. Klunder",
           "club": "chorley",
-          "id": "V35"
+          "ageCategory": "V35"
         }
       ]
     },
@@ -30,19 +30,19 @@
           "position": 1,
           "name": "R. Danson",
           "club": "wesham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 2,
           "name": "D. Rigby",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 3,
           "name": "L. Minns",
           "club": "blackpool",
-          "id": "SEN"
+          "ageCategory": "SEN"
         }
       ]
     },

--- a/src/data/2022/road-gp/awards.json
+++ b/src/data/2022/road-gp/awards.json
@@ -7,19 +7,19 @@
           "position": 1,
           "name": "S. Pilkington",
           "club": "red-rose",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 2,
           "name": "M. Koth",
           "club": "lytham",
-          "id": "V45"
+          "ageCategory": "V45"
         },
         {
           "position": 3,
           "name": "J. Goorney",
           "club": "lytham",
-          "id": "V50"
+          "ageCategory": "V50"
         }
       ]
     },
@@ -30,19 +30,19 @@
           "position": 1,
           "name": "R. Danson",
           "club": "wesham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 2,
           "name": "S. Evans",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 3,
           "name": "R. McKelvie",
           "club": "lytham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         }
       ]
     },

--- a/src/data/2023/road-gp/awards.json
+++ b/src/data/2023/road-gp/awards.json
@@ -8,19 +8,19 @@
           "position": 1,
           "name": "S. Pilkington",
           "club": "red-rose",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 2,
           "name": "C. Gregory",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 3,
           "name": "M. Chadwick",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         }
       ]
     },
@@ -31,19 +31,19 @@
           "position": 1,
           "name": "R. Danson",
           "club": "wesham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 2,
           "name": "S. Evans",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 3,
           "name": "W. Wilkinson",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         }
       ]
     },

--- a/src/data/2024/road-gp/awards.json
+++ b/src/data/2024/road-gp/awards.json
@@ -8,19 +8,19 @@
           "position": 1,
           "name": "J. Robinson",
           "club": "preston",
-          "id": "V35"
+          "ageCategory": "V35"
         },
         {
           "position": 2,
           "name": "M. Chadwick",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 3,
           "name": "S. Pilkington",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         }
       ]
     },
@@ -31,19 +31,19 @@
           "position": 1,
           "name": "R. Danson",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 2,
           "name": "M. Toft",
           "club": "lytham",
-          "id": "SEN"
+          "ageCategory": "SEN"
         },
         {
           "position": 3,
           "name": "P. Brown",
           "club": "preston",
-          "id": "SEN"
+          "ageCategory": "SEN"
         }
       ]
     },

--- a/src/data/2025/road-gp/awards.json
+++ b/src/data/2025/road-gp/awards.json
@@ -15,21 +15,21 @@
                                                     "position":  1,
                                                     "name":  "Katie Littlefair",
                                                     "club":  "preston",
-                                                    "id":  "SEN",
+                                                    "ageCategory": "SEN",
                                                     "seriesRunnerId":  164
                                                 },
                                                 {
                                                     "position":  2,
                                                     "name":  "Emma Watson",
                                                     "club":  "preston",
-                                                    "id":  "V35",
+                                                    "ageCategory": "V35",
                                                     "seriesRunnerId":  185
                                                 },
                                                 {
                                                     "position":  3,
                                                     "name":  "Cass Chisholm",
                                                     "club":  "lytham",
-                                                    "id":  "V40",
+                                                    "ageCategory": "V40",
                                                     "seriesRunnerId":  497
                                                 }
                                             ]
@@ -41,21 +41,21 @@
                                                     "position":  1,
                                                     "name":  "Luke Minns",
                                                     "club":  "blackpool",
-                                                    "id":  "SEN",
+                                                    "ageCategory": "SEN",
                                                     "seriesRunnerId":  474
                                                 },
                                                 {
                                                     "position":  2,
                                                     "name":  "Rob Danson",
                                                     "club":  "preston",
-                                                    "id":  "SEN",
+                                                    "ageCategory": "SEN",
                                                     "seriesRunnerId":  100
                                                 },
                                                 {
                                                     "position":  3,
                                                     "name":  "Sam Evans",
                                                     "club":  "preston",
-                                                    "id":  "SEN",
+                                                    "ageCategory": "SEN",
                                                     "seriesRunnerId":  475
                                                 }
                                             ]


### PR DESCRIPTION
## Summary

- Renames stray `"id"` fields on individual award entry objects in 7 historical road-gp `awards.json` files (2017–2025) to `"ageCategory"`
- Affected values were short uppercase age-category strings: `SEN`, `JUN`, `V35`, `V40`, `V45`, `V50`, `V55`, etc.
- Category-level `"id"` fields (values like `"female"`, `"male"`, `"sen-male"`, `"v40-female"`) are unchanged
- Aligns the data with the `IndividualAwardEntry` TypeScript type which has `ageCategory?: string`

## Files changed

`src/data/{2017,2018,2019,2022,2023,2024,2025}/road-gp/awards.json`

## Test plan

- [x] `npm test` passes (60/60 tests)
- [x] No remaining `"id": "<UPPERCASE>"` patterns in any `awards.json` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)