### PR TITLE
data: add sex/ageCategory mappings to all individualAwards entries

### DIFF
--- a/src/data/2005/road-gp/awards.json
+++ b/src/data/2005/road-gp/awards.json
@@ -1,34 +1,43 @@
-﻿{
-    "individualAwards":  [
-                           {
-                               "id":  "overall",
-                               "awards":  [
-                                              { "position": 1, "name": "S. Hallas", "club": "preston" }
-                                          ]
-                           },
-                           {
-                               "id":  "ladies",
-                               "awards":  [
-                                              { "position": 1, "name": "G. Titterington", "club": "blackpool-fylde" }
-                                          ]
-                           }
-                       ],
-    "teamAwards":  [
-                       {
-                           "club":  "north-fylde",
-                           "id":  "open"
-                       },
-                       {
-                           "club":  "north-fylde",
-                           "id":  "vets"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet50"
-                       },
-                       {
-                           "club":  "north-fylde",
-                           "id":  "ladies"
-                       }
-                   ]
+{
+    "individualAwards": [
+        {
+            "id": "overall",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "S. Hallas",
+                    "club": "preston"
+                }
+            ]
+        },
+        {
+            "id": "ladies",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "G. Titterington",
+                    "club": "blackpool-fylde"
+                }
+            ],
+            "sex": "F"
+        }
+    ],
+    "teamAwards": [
+        {
+            "club": "north-fylde",
+            "id": "open"
+        },
+        {
+            "club": "north-fylde",
+            "id": "vets"
+        },
+        {
+            "club": "wesham",
+            "id": "vet50"
+        },
+        {
+            "club": "north-fylde",
+            "id": "ladies"
+        }
+    ]
 }

--- a/src/data/2005/road-gp/awards.json
+++ b/src/data/2005/road-gp/awards.json
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "id": "ladies",
+            "id": "f",
             "awards": [
                 {
                     "position": 1,

--- a/src/data/2006/road-gp/awards.json
+++ b/src/data/2006/road-gp/awards.json
@@ -1,38 +1,47 @@
-﻿{
-    "individualAwards":  [
-                           {
-                               "id":  "overall",
-                               "awards":  [
-                                              { "position": 1, "name": "A. Sutton", "club": "preston" }
-                                          ]
-                           },
-                           {
-                               "id":  "ladies",
-                               "awards":  [
-                                              { "position": 1, "name": "C. Betmead", "club": "north-fylde" }
-                                          ]
-                           }
-                       ],
-    "teamAwards":  [
-                       {
-                           "club":  "preston",
-                           "id":  "open"
-                       },
-                       {
-                           "club":  "north-fylde",
-                           "id":  "vets"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet50"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet60"
-                       },
-                       {
-                           "club":  "blackpool-fylde",
-                           "id":  "ladies"
-                       }
-                   ]
+{
+    "individualAwards": [
+        {
+            "id": "overall",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "A. Sutton",
+                    "club": "preston"
+                }
+            ]
+        },
+        {
+            "id": "ladies",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "C. Betmead",
+                    "club": "north-fylde"
+                }
+            ],
+            "sex": "F"
+        }
+    ],
+    "teamAwards": [
+        {
+            "club": "preston",
+            "id": "open"
+        },
+        {
+            "club": "north-fylde",
+            "id": "vets"
+        },
+        {
+            "club": "wesham",
+            "id": "vet50"
+        },
+        {
+            "club": "wesham",
+            "id": "vet60"
+        },
+        {
+            "club": "blackpool-fylde",
+            "id": "ladies"
+        }
+    ]
 }

--- a/src/data/2006/road-gp/awards.json
+++ b/src/data/2006/road-gp/awards.json
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "id": "ladies",
+            "id": "f",
             "awards": [
                 {
                     "position": 1,

--- a/src/data/2007/road-gp/awards.json
+++ b/src/data/2007/road-gp/awards.json
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "id": "ladies",
+            "id": "f",
             "awards": [
                 {
                     "position": 1,

--- a/src/data/2007/road-gp/awards.json
+++ b/src/data/2007/road-gp/awards.json
@@ -1,38 +1,47 @@
-﻿{
-    "individualAwards":  [
-                           {
-                               "id":  "overall",
-                               "awards":  [
-                                              { "position": 1, "name": "A. Ford", "club": "blackpool" }
-                                          ]
-                           },
-                           {
-                               "id":  "ladies",
-                               "awards":  [
-                                              { "position": 1, "name": "C. Betmead", "club": "blackpool" }
-                                          ]
-                           }
-                       ],
-    "teamAwards":  [
-                       {
-                           "club":  "blackpool",
-                           "id":  "open"
-                       },
-                       {
-                           "club":  "blackpool",
-                           "id":  "vets"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet50"
-                       },
-                       {
-                           "club":  "blackpool",
-                           "id":  "vet60"
-                       },
-                       {
-                           "club":  "blackpool",
-                           "id":  "ladies"
-                       }
-                   ]
+{
+    "individualAwards": [
+        {
+            "id": "overall",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "A. Ford",
+                    "club": "blackpool"
+                }
+            ]
+        },
+        {
+            "id": "ladies",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "C. Betmead",
+                    "club": "blackpool"
+                }
+            ],
+            "sex": "F"
+        }
+    ],
+    "teamAwards": [
+        {
+            "club": "blackpool",
+            "id": "open"
+        },
+        {
+            "club": "blackpool",
+            "id": "vets"
+        },
+        {
+            "club": "wesham",
+            "id": "vet50"
+        },
+        {
+            "club": "blackpool",
+            "id": "vet60"
+        },
+        {
+            "club": "blackpool",
+            "id": "ladies"
+        }
+    ]
 }

--- a/src/data/2008/road-gp/awards.json
+++ b/src/data/2008/road-gp/awards.json
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "id": "ladies",
+            "id": "f",
             "awards": [
                 {
                     "position": 1,

--- a/src/data/2008/road-gp/awards.json
+++ b/src/data/2008/road-gp/awards.json
@@ -1,38 +1,47 @@
-﻿{
-    "individualAwards":  [
-                           {
-                               "id":  "overall",
-                               "awards":  [
-                                              { "position": 1, "name": "J. Prowse", "club": "blackpool" }
-                                          ]
-                           },
-                           {
-                               "id":  "ladies",
-                               "awards":  [
-                                              { "position": 1, "name": "G. Unsworth", "club": "blackpool" }
-                                          ]
-                           }
-                       ],
-    "teamAwards":  [
-                       {
-                           "club":  "preston",
-                           "id":  "open"
-                       },
-                       {
-                           "club":  "preston",
-                           "id":  "vets"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet50"
-                       },
-                       {
-                           "club":  "blackpool",
-                           "id":  "vet60"
-                       },
-                       {
-                           "club":  "blackpool",
-                           "id":  "ladies"
-                       }
-                   ]
+{
+    "individualAwards": [
+        {
+            "id": "overall",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "J. Prowse",
+                    "club": "blackpool"
+                }
+            ]
+        },
+        {
+            "id": "ladies",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "G. Unsworth",
+                    "club": "blackpool"
+                }
+            ],
+            "sex": "F"
+        }
+    ],
+    "teamAwards": [
+        {
+            "club": "preston",
+            "id": "open"
+        },
+        {
+            "club": "preston",
+            "id": "vets"
+        },
+        {
+            "club": "wesham",
+            "id": "vet50"
+        },
+        {
+            "club": "blackpool",
+            "id": "vet60"
+        },
+        {
+            "club": "blackpool",
+            "id": "ladies"
+        }
+    ]
 }

--- a/src/data/2009/road-gp/awards.json
+++ b/src/data/2009/road-gp/awards.json
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "id": "ladies",
+            "id": "f",
             "awards": [
                 {
                     "position": 1,

--- a/src/data/2009/road-gp/awards.json
+++ b/src/data/2009/road-gp/awards.json
@@ -1,38 +1,47 @@
-﻿{
-    "individualAwards":  [
-                           {
-                               "id":  "overall",
-                               "awards":  [
-                                              { "position": 1, "name": "S. Robinson", "club": "blackpool" }
-                                          ]
-                           },
-                           {
-                               "id":  "ladies",
-                               "awards":  [
-                                              { "position": 1, "name": "L. Abbott", "club": "preston" }
-                                          ]
-                           }
-                       ],
-    "teamAwards":  [
-                       {
-                           "club":  "preston",
-                           "id":  "open"
-                       },
-                       {
-                           "club":  "preston",
-                           "id":  "vets"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet50"
-                       },
-                       {
-                           "club":  "red-rose",
-                           "id":  "vet60"
-                       },
-                       {
-                           "club":  "blackpool",
-                           "id":  "ladies"
-                       }
-                   ]
+{
+    "individualAwards": [
+        {
+            "id": "overall",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "S. Robinson",
+                    "club": "blackpool"
+                }
+            ]
+        },
+        {
+            "id": "ladies",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "L. Abbott",
+                    "club": "preston"
+                }
+            ],
+            "sex": "F"
+        }
+    ],
+    "teamAwards": [
+        {
+            "club": "preston",
+            "id": "open"
+        },
+        {
+            "club": "preston",
+            "id": "vets"
+        },
+        {
+            "club": "wesham",
+            "id": "vet50"
+        },
+        {
+            "club": "red-rose",
+            "id": "vet60"
+        },
+        {
+            "club": "blackpool",
+            "id": "ladies"
+        }
+    ]
 }

--- a/src/data/2010/road-gp/awards.json
+++ b/src/data/2010/road-gp/awards.json
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "id": "ladies",
+            "id": "f",
             "awards": [
                 {
                     "position": 1,

--- a/src/data/2010/road-gp/awards.json
+++ b/src/data/2010/road-gp/awards.json
@@ -1,38 +1,47 @@
-﻿{
-    "individualAwards":  [
-                           {
-                               "id":  "overall",
-                               "awards":  [
-                                              { "position": 1, "name": "G. Pennington", "club": "preston" }
-                                          ]
-                           },
-                           {
-                               "id":  "ladies",
-                               "awards":  [
-                                              { "position": 1, "name": "J. Goorney", "club": "wesham" }
-                                          ]
-                           }
-                       ],
-    "teamAwards":  [
-                       {
-                           "club":  "preston",
-                           "id":  "open"
-                       },
-                       {
-                           "club":  "preston",
-                           "id":  "vets"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet50"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet60"
-                       },
-                       {
-                           "club":  "blackpool",
-                           "id":  "ladies"
-                       }
-                   ]
+{
+    "individualAwards": [
+        {
+            "id": "overall",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "G. Pennington",
+                    "club": "preston"
+                }
+            ]
+        },
+        {
+            "id": "ladies",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "J. Goorney",
+                    "club": "wesham"
+                }
+            ],
+            "sex": "F"
+        }
+    ],
+    "teamAwards": [
+        {
+            "club": "preston",
+            "id": "open"
+        },
+        {
+            "club": "preston",
+            "id": "vets"
+        },
+        {
+            "club": "wesham",
+            "id": "vet50"
+        },
+        {
+            "club": "wesham",
+            "id": "vet60"
+        },
+        {
+            "club": "blackpool",
+            "id": "ladies"
+        }
+    ]
 }

--- a/src/data/2011/road-gp/awards.json
+++ b/src/data/2011/road-gp/awards.json
@@ -1,38 +1,47 @@
-﻿{
-    "individualAwards":  [
-                           {
-                               "id":  "overall",
-                               "awards":  [
-                                              { "position": 1, "name": "S. Robinson", "club": "blackpool" }
-                                          ]
-                           },
-                           {
-                               "id":  "ladies",
-                               "awards":  [
-                                              { "position": 1, "name": "C. Betmead", "club": "blackpool" }
-                                          ]
-                           }
-                       ],
-    "teamAwards":  [
-                       {
-                           "club":  "preston",
-                           "id":  "open"
-                       },
-                       {
-                           "club":  "preston",
-                           "id":  "vets"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet50"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet60"
-                       },
-                       {
-                           "club":  "blackpool",
-                           "id":  "ladies"
-                       }
-                   ]
+{
+    "individualAwards": [
+        {
+            "id": "overall",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "S. Robinson",
+                    "club": "blackpool"
+                }
+            ]
+        },
+        {
+            "id": "ladies",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "C. Betmead",
+                    "club": "blackpool"
+                }
+            ],
+            "sex": "F"
+        }
+    ],
+    "teamAwards": [
+        {
+            "club": "preston",
+            "id": "open"
+        },
+        {
+            "club": "preston",
+            "id": "vets"
+        },
+        {
+            "club": "wesham",
+            "id": "vet50"
+        },
+        {
+            "club": "wesham",
+            "id": "vet60"
+        },
+        {
+            "club": "blackpool",
+            "id": "ladies"
+        }
+    ]
 }

--- a/src/data/2011/road-gp/awards.json
+++ b/src/data/2011/road-gp/awards.json
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "id": "ladies",
+            "id": "f",
             "awards": [
                 {
                     "position": 1,

--- a/src/data/2012/fell/awards.json
+++ b/src/data/2012/fell/awards.json
@@ -49,7 +49,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "male",
+      "id": "m",
       "awards": [
         {
           "position": 1,
@@ -71,7 +71,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "female",
+      "id": "f",
       "awards": [
         {
           "position": 1,
@@ -82,7 +82,7 @@
       "sex": "F"
     },
     {
-      "id": "female-vet",
+      "id": "f",
       "awards": [
         {
           "position": 1,

--- a/src/data/2012/fell/awards.json
+++ b/src/data/2012/fell/awards.json
@@ -1,54 +1,107 @@
-﻿{
+{
   "teamAwards": [
-    { "id": "open", "club": "preston" },
-    { "id": "vets", "club": "preston" },
-    { "id": "v50", "club": "wesham" },
-    { "id": "v60", "club": "chorley" },
-    { "id": "ladies", "club": "red-rose" }
+    {
+      "id": "open",
+      "club": "preston"
+    },
+    {
+      "id": "vets",
+      "club": "preston"
+    },
+    {
+      "id": "v50",
+      "club": "wesham"
+    },
+    {
+      "id": "v60",
+      "club": "chorley"
+    },
+    {
+      "id": "ladies",
+      "club": "red-rose"
+    }
   ],
   "individualAwards": [
     {
       "id": "overall",
       "awards": [
-        { "position": 1, "name": "Alex Rowe", "club": "wesham" }
+        {
+          "position": 1,
+          "name": "Alex Rowe",
+          "club": "wesham"
+        }
       ]
     },
     {
       "id": "v40",
       "awards": [
-        { "position": 1, "name": "John Griffiths", "club": "preston" },
-        { "position": 2, "name": "Shane Cliffe", "club": "red-rose" }
-      ]
+        {
+          "position": 1,
+          "name": "John Griffiths",
+          "club": "preston"
+        },
+        {
+          "position": 2,
+          "name": "Shane Cliffe",
+          "club": "red-rose"
+        }
+      ],
+      "ageCategory": "V40"
     },
     {
       "id": "male",
       "awards": [
-        { "position": 1, "name": "Barry Wheeler", "club": "red-rose" }
-      ]
+        {
+          "position": 1,
+          "name": "Barry Wheeler",
+          "club": "red-rose"
+        }
+      ],
+      "sex": "M"
     },
     {
       "id": "v50",
       "awards": [
-        { "position": 2, "name": "John Rainford", "club": "preston" }
-      ]
+        {
+          "position": 2,
+          "name": "John Rainford",
+          "club": "preston"
+        }
+      ],
+      "ageCategory": "V50"
     },
     {
       "id": "female",
       "awards": [
-        { "position": 1, "name": "Nichola Jackson", "club": "preston" }
-      ]
+        {
+          "position": 1,
+          "name": "Nichola Jackson",
+          "club": "preston"
+        }
+      ],
+      "sex": "F"
     },
     {
       "id": "female-vet",
       "awards": [
-        { "position": 1, "name": "Paula Plowman", "club": "red-rose" }
-      ]
+        {
+          "position": 1,
+          "name": "Paula Plowman",
+          "club": "red-rose"
+        }
+      ],
+      "sex": "F"
     },
     {
       "id": "v60",
       "awards": [
-        { "position": 1, "name": "Tom Hilton", "club": "chorley" }
-      ]
+        {
+          "position": 1,
+          "name": "Tom Hilton",
+          "club": "chorley"
+        }
+      ],
+      "ageCategory": "V60"
     }
   ]
 }

--- a/src/data/2012/road-gp/awards.json
+++ b/src/data/2012/road-gp/awards.json
@@ -1,38 +1,47 @@
-﻿{
-    "individualAwards":  [
-                           {
-                               "id":  "overall",
-                               "awards":  [
-                                              { "position": 1, "name": "R. Affleck", "club": "preston" }
-                                          ]
-                           },
-                           {
-                               "id":  "ladies",
-                               "awards":  [
-                                              { "position": 1, "name": "G. Adams", "club": "preston" }
-                                          ]
-                           }
-                       ],
-    "teamAwards":  [
-                       {
-                           "club":  "preston",
-                           "id":  "open"
-                       },
-                       {
-                           "club":  "preston",
-                           "id":  "vets"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet50"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet60"
-                       },
-                       {
-                           "club":  "preston",
-                           "id":  "ladies"
-                       }
-                   ]
+{
+    "individualAwards": [
+        {
+            "id": "overall",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "R. Affleck",
+                    "club": "preston"
+                }
+            ]
+        },
+        {
+            "id": "ladies",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "G. Adams",
+                    "club": "preston"
+                }
+            ],
+            "sex": "F"
+        }
+    ],
+    "teamAwards": [
+        {
+            "club": "preston",
+            "id": "open"
+        },
+        {
+            "club": "preston",
+            "id": "vets"
+        },
+        {
+            "club": "wesham",
+            "id": "vet50"
+        },
+        {
+            "club": "wesham",
+            "id": "vet60"
+        },
+        {
+            "club": "preston",
+            "id": "ladies"
+        }
+    ]
 }

--- a/src/data/2012/road-gp/awards.json
+++ b/src/data/2012/road-gp/awards.json
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "id": "ladies",
+            "id": "f",
             "awards": [
                 {
                     "position": 1,

--- a/src/data/2013/fell/awards.json
+++ b/src/data/2013/fell/awards.json
@@ -1,52 +1,110 @@
-﻿{
+{
   "teamAwards": [
-    { "id": "open", "club": "chorley" },
-    { "id": "vets", "club": "wesham" },
-    { "id": "v50", "club": "wesham" },
-    { "id": "v60", "club": "chorley" },
-    { "id": "ladies", "club": "wesham" }
+    {
+      "id": "open",
+      "club": "chorley"
+    },
+    {
+      "id": "vets",
+      "club": "wesham"
+    },
+    {
+      "id": "v50",
+      "club": "wesham"
+    },
+    {
+      "id": "v60",
+      "club": "chorley"
+    },
+    {
+      "id": "ladies",
+      "club": "wesham"
+    }
   ],
   "individualAwards": [
     {
       "id": "overall",
       "awards": [
-        { "position": 1, "name": "Lee Barlow" }
+        {
+          "position": 1,
+          "name": "Lee Barlow"
+        }
       ]
     },
     {
       "id": "sen-m",
       "awards": [
-        { "position": 1, "name": "Ben Donoghue" }
-      ]
+        {
+          "position": 1,
+          "name": "Ben Donoghue"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "SEN"
     },
     {
       "id": "sen-f",
       "awards": [
-        { "position": 1, "name": "Kath Hoyer" },
-        { "position": 2, "name": "Debbie Cooper" },
-        { "position": 3, "name": "Jenny Salt" }
-      ]
+        {
+          "position": 1,
+          "name": "Kath Hoyer"
+        },
+        {
+          "position": 2,
+          "name": "Debbie Cooper"
+        },
+        {
+          "position": 3,
+          "name": "Jenny Salt"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "SEN"
     },
     {
       "id": "v40-m",
       "awards": [
-        { "position": 2, "name": "Darren Fishwick" },
-        { "position": 3, "name": "Jason Barlow" }
-      ]
+        {
+          "position": 2,
+          "name": "Darren Fishwick"
+        },
+        {
+          "position": 3,
+          "name": "Jason Barlow"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "v50-m",
       "awards": [
-        { "position": 1, "name": "Alex Rowe" },
-        { "position": 2, "name": "Fred Lynch" },
-        { "position": 3, "name": "John Collier" }
-      ]
+        {
+          "position": 1,
+          "name": "Alex Rowe"
+        },
+        {
+          "position": 2,
+          "name": "Fred Lynch"
+        },
+        {
+          "position": 3,
+          "name": "John Collier"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "v60-m",
       "awards": [
-        { "position": 1, "name": "Graham Schofield" }
-      ]
+        {
+          "position": 1,
+          "name": "Graham Schofield"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     }
   ]
 }

--- a/src/data/2013/fell/awards.json
+++ b/src/data/2013/fell/awards.json
@@ -32,7 +32,7 @@
       ]
     },
     {
-      "id": "sen-m",
+      "id": "m-sen",
       "awards": [
         {
           "position": 1,
@@ -43,7 +43,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "sen-f",
+      "id": "f-sen",
       "awards": [
         {
           "position": 1,
@@ -62,7 +62,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "v40-m",
+      "id": "m-v40",
       "awards": [
         {
           "position": 2,
@@ -77,7 +77,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v50-m",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -96,7 +96,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v60-m",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,

--- a/src/data/2013/road-gp/awards.json
+++ b/src/data/2013/road-gp/awards.json
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "id": "ladies",
+            "id": "f",
             "awards": [
                 {
                     "position": 1,

--- a/src/data/2013/road-gp/awards.json
+++ b/src/data/2013/road-gp/awards.json
@@ -1,38 +1,47 @@
-﻿{
-    "individualAwards":  [
-                           {
-                               "id":  "overall",
-                               "awards":  [
-                                              { "position": 1, "name": "R. Affleck", "club": "preston" }
-                                          ]
-                           },
-                           {
-                               "id":  "ladies",
-                               "awards":  [
-                                              { "position": 1, "name": "J. Goorney", "club": "wesham" }
-                                          ]
-                           }
-                       ],
-    "teamAwards":  [
-                       {
-                           "club":  "preston",
-                           "id":  "open"
-                       },
-                       {
-                           "club":  "preston",
-                           "id":  "vets"
-                       },
-                       {
-                           "club":  "preston",
-                           "id":  "vet50"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet60"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "ladies"
-                       }
-                   ]
+{
+    "individualAwards": [
+        {
+            "id": "overall",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "R. Affleck",
+                    "club": "preston"
+                }
+            ]
+        },
+        {
+            "id": "ladies",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "J. Goorney",
+                    "club": "wesham"
+                }
+            ],
+            "sex": "F"
+        }
+    ],
+    "teamAwards": [
+        {
+            "club": "preston",
+            "id": "open"
+        },
+        {
+            "club": "preston",
+            "id": "vets"
+        },
+        {
+            "club": "preston",
+            "id": "vet50"
+        },
+        {
+            "club": "wesham",
+            "id": "vet60"
+        },
+        {
+            "club": "wesham",
+            "id": "ladies"
+        }
+    ]
 }

--- a/src/data/2014/fell/awards.json
+++ b/src/data/2014/fell/awards.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "teamAwards": [
     {
       "id": "open",
@@ -42,7 +42,8 @@
           "position": 2,
           "name": "Mark Ellithorn"
         }
-      ]
+      ],
+      "ageCategory": "V40"
     },
     {
       "id": "v50",
@@ -55,7 +56,8 @@
           "position": 2,
           "name": "Stuart Cann"
         }
-      ]
+      ],
+      "ageCategory": "V50"
     },
     {
       "id": "v60",
@@ -64,7 +66,8 @@
           "position": 1,
           "name": "George Fletcher"
         }
-      ]
+      ],
+      "ageCategory": "V60"
     },
     {
       "id": "female",
@@ -77,7 +80,8 @@
           "position": 2,
           "name": "Paula Plowman"
         }
-      ]
+      ],
+      "sex": "F"
     }
   ]
 }

--- a/src/data/2014/fell/awards.json
+++ b/src/data/2014/fell/awards.json
@@ -70,7 +70,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "female",
+      "id": "f",
       "awards": [
         {
           "position": 1,

--- a/src/data/2014/road-gp/awards.json
+++ b/src/data/2014/road-gp/awards.json
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "id": "ladies",
+            "id": "f",
             "awards": [
                 {
                     "position": 1,

--- a/src/data/2014/road-gp/awards.json
+++ b/src/data/2014/road-gp/awards.json
@@ -1,38 +1,47 @@
-﻿{
-    "individualAwards":  [
-                           {
-                               "id":  "overall",
-                               "awards":  [
-                                              { "position": 1, "name": "R. Affleck", "club": "preston" }
-                                          ]
-                           },
-                           {
-                               "id":  "ladies",
-                               "awards":  [
-                                              { "position": 1, "name": "J. Goorney", "club": "lytham" }
-                                          ]
-                           }
-                       ],
-    "teamAwards":  [
-                       {
-                           "club":  "preston",
-                           "id":  "open"
-                       },
-                       {
-                           "club":  "preston",
-                           "id":  "vets"
-                       },
-                       {
-                           "club":  "red-rose",
-                           "id":  "vet50"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "vet60"
-                       },
-                       {
-                           "club":  "blackpool",
-                           "id":  "ladies"
-                       }
-                   ]
+{
+    "individualAwards": [
+        {
+            "id": "overall",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "R. Affleck",
+                    "club": "preston"
+                }
+            ]
+        },
+        {
+            "id": "ladies",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "J. Goorney",
+                    "club": "lytham"
+                }
+            ],
+            "sex": "F"
+        }
+    ],
+    "teamAwards": [
+        {
+            "club": "preston",
+            "id": "open"
+        },
+        {
+            "club": "preston",
+            "id": "vets"
+        },
+        {
+            "club": "red-rose",
+            "id": "vet50"
+        },
+        {
+            "club": "wesham",
+            "id": "vet60"
+        },
+        {
+            "club": "blackpool",
+            "id": "ladies"
+        }
+    ]
 }

--- a/src/data/2015/fell/awards.json
+++ b/src/data/2015/fell/awards.json
@@ -33,7 +33,7 @@
       ]
     },
     {
-      "id": "sen-m",
+      "id": "m-sen",
       "awards": [
         {
           "position": 2,
@@ -45,7 +45,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "v40-m",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -62,7 +62,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v50-m",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -79,7 +79,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v60-m",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,
@@ -96,7 +96,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "sen-f",
+      "id": "f-sen",
       "awards": [
         {
           "position": 1,
@@ -108,7 +108,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "v40-f",
+      "id": "f-v40",
       "awards": [
         {
           "position": 2,
@@ -120,7 +120,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v50-f",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,

--- a/src/data/2015/fell/awards.json
+++ b/src/data/2015/fell/awards.json
@@ -1,62 +1,135 @@
-﻿{
+{
   "teamAwards": [
-    { "id": "open", "club": "red-rose" },
-    { "id": "vets", "club": "chorley" },
-    { "id": "v50", "club": "chorley" },
-    { "id": "v60", "club": "chorley" },
-    { "id": "ladies", "club": "lytham" }
+    {
+      "id": "open",
+      "club": "red-rose"
+    },
+    {
+      "id": "vets",
+      "club": "chorley"
+    },
+    {
+      "id": "v50",
+      "club": "chorley"
+    },
+    {
+      "id": "v60",
+      "club": "chorley"
+    },
+    {
+      "id": "ladies",
+      "club": "lytham"
+    }
   ],
   "individualAwards": [
     {
       "id": "overall",
       "awards": [
-        { "position": 1, "name": "Joe Greenwood", "club": "lytham" }
+        {
+          "position": 1,
+          "name": "Joe Greenwood",
+          "club": "lytham"
+        }
       ]
     },
     {
       "id": "sen-m",
       "awards": [
-        { "position": 2, "name": "Daniel Hughes", "club": "red-rose" }
-      ]
+        {
+          "position": 2,
+          "name": "Daniel Hughes",
+          "club": "red-rose"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "SEN"
     },
     {
       "id": "v40-m",
       "awards": [
-        { "position": 1, "name": "Chris Charnley", "club": "red-rose" },
-        { "position": 2, "name": "Andrew Fairbairn", "club": "thornton" }
-      ]
+        {
+          "position": 1,
+          "name": "Chris Charnley",
+          "club": "red-rose"
+        },
+        {
+          "position": 2,
+          "name": "Andrew Fairbairn",
+          "club": "thornton"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "v50-m",
       "awards": [
-        { "position": 1, "name": "Mark Ellithorn", "club": "chorley" },
-        { "position": 2, "name": "Alex Rowe", "club": "wesham" }
-      ]
+        {
+          "position": 1,
+          "name": "Mark Ellithorn",
+          "club": "chorley"
+        },
+        {
+          "position": 2,
+          "name": "Alex Rowe",
+          "club": "wesham"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "v60-m",
       "awards": [
-        { "position": 1, "name": "Terry Hellings", "club": "lytham" },
-        { "position": 2, "name": "Malcolm Sherwood", "club": "thornton" }
-      ]
+        {
+          "position": 1,
+          "name": "Terry Hellings",
+          "club": "lytham"
+        },
+        {
+          "position": 2,
+          "name": "Malcolm Sherwood",
+          "club": "thornton"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     },
     {
       "id": "sen-f",
       "awards": [
-        { "position": 1, "name": "Joanna Goorney", "club": "lytham" }
-      ]
+        {
+          "position": 1,
+          "name": "Joanna Goorney",
+          "club": "lytham"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "SEN"
     },
     {
       "id": "v40-f",
       "awards": [
-        { "position": 2, "name": "Lynne Clough", "club": "chorley" }
-      ]
+        {
+          "position": 2,
+          "name": "Lynne Clough",
+          "club": "chorley"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V40"
     },
     {
       "id": "v50-f",
       "awards": [
-        { "position": 1, "name": "Deborah Myerscough", "club": "wesham" }
-      ]
+        {
+          "position": 1,
+          "name": "Deborah Myerscough",
+          "club": "wesham"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     }
   ]
 }

--- a/src/data/2015/road-gp/awards.json
+++ b/src/data/2015/road-gp/awards.json
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "id": "ladies",
+            "id": "f",
             "awards": [
                 {
                     "position": 1,
@@ -22,7 +22,7 @@
             "sex": "F"
         },
         {
-            "id": "v40-male",
+            "id": "m-v40",
             "awards": [
                 {
                     "position": 1,
@@ -34,7 +34,7 @@
             "ageCategory": "V40"
         },
         {
-            "id": "v50-male",
+            "id": "m-v50",
             "awards": [
                 {
                     "position": 1,
@@ -46,7 +46,7 @@
             "ageCategory": "V50"
         },
         {
-            "id": "v60-male",
+            "id": "m-v60",
             "awards": [
                 {
                     "position": 1,

--- a/src/data/2015/road-gp/awards.json
+++ b/src/data/2015/road-gp/awards.json
@@ -1,56 +1,83 @@
-﻿{
-    "individualAwards":  [
-                           {
-                               "id":  "overall",
-                               "awards":  [
-                                              { "position": 1, "name": "R. Danson", "club": "wesham" }
-                                          ]
-                           },
-                           {
-                               "id":  "ladies",
-                               "awards":  [
-                                              { "position": 1, "name": "E. Japp", "club": "blackpool" }
-                                          ]
-                           },
-                           {
-                               "id":  "v40-male",
-                               "awards":  [
-                                              { "position": 1, "name": "R. Affleck", "club": "preston" }
-                                          ]
-                           },
-                           {
-                               "id":  "v50-male",
-                               "awards":  [
-                                              { "position": 1, "name": "J. Wright", "club": "blackpool" }
-                                          ]
-                           },
-                           {
-                               "id":  "v60-male",
-                               "awards":  [
-                                              { "position": 1, "name": "J. Collier", "club": "wesham" }
-                                          ]
-                           }
-                       ],
-    "teamAwards":  [
-                       {
-                           "club":  "preston",
-                           "id":  "open"
-                       },
-                       {
-                           "club":  "preston",
-                           "id":  "vets"
-                       },
-                       {
-                           "club":  "red-rose",
-                           "id":  "vet50"
-                       },
-                       {
-                           "club":  "blackpool",
-                           "id":  "vet60"
-                       },
-                       {
-                           "club":  "blackpool",
-                           "id":  "ladies"
-                       }
-                   ]
+{
+    "individualAwards": [
+        {
+            "id": "overall",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "R. Danson",
+                    "club": "wesham"
+                }
+            ]
+        },
+        {
+            "id": "ladies",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "E. Japp",
+                    "club": "blackpool"
+                }
+            ],
+            "sex": "F"
+        },
+        {
+            "id": "v40-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "R. Affleck",
+                    "club": "preston"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V40"
+        },
+        {
+            "id": "v50-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "J. Wright",
+                    "club": "blackpool"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V50"
+        },
+        {
+            "id": "v60-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "J. Collier",
+                    "club": "wesham"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V60"
+        }
+    ],
+    "teamAwards": [
+        {
+            "club": "preston",
+            "id": "open"
+        },
+        {
+            "club": "preston",
+            "id": "vets"
+        },
+        {
+            "club": "red-rose",
+            "id": "vet50"
+        },
+        {
+            "club": "blackpool",
+            "id": "vet60"
+        },
+        {
+            "club": "blackpool",
+            "id": "ladies"
+        }
+    ]
 }

--- a/src/data/2016/fell/awards.json
+++ b/src/data/2016/fell/awards.json
@@ -32,7 +32,7 @@
       ]
     },
     {
-      "id": "male",
+      "id": "m",
       "awards": [
         {
           "position": 2,
@@ -88,7 +88,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "female",
+      "id": "f",
       "awards": [
         {
           "position": 1,
@@ -98,7 +98,7 @@
       "sex": "F"
     },
     {
-      "id": "f40",
+      "id": "f-v40",
       "awards": [
         {
           "position": 1,
@@ -113,7 +113,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "f50",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,

--- a/src/data/2016/fell/awards.json
+++ b/src/data/2016/fell/awards.json
@@ -1,65 +1,131 @@
-﻿{
+{
   "teamAwards": [
-    { "id": "open", "club": "preston" },
-    { "id": "vets", "club": "red-rose" },
-    { "id": "v50", "club": "red-rose" },
-    { "id": "v60", "club": "preston" },
-    { "id": "ladies", "club": "red-rose" }
+    {
+      "id": "open",
+      "club": "preston"
+    },
+    {
+      "id": "vets",
+      "club": "red-rose"
+    },
+    {
+      "id": "v50",
+      "club": "red-rose"
+    },
+    {
+      "id": "v60",
+      "club": "preston"
+    },
+    {
+      "id": "ladies",
+      "club": "red-rose"
+    }
   ],
   "individualAwards": [
     {
       "id": "overall",
       "awards": [
-        { "position": 1, "name": "Richard Smith" }
+        {
+          "position": 1,
+          "name": "Richard Smith"
+        }
       ]
     },
     {
       "id": "male",
       "awards": [
-        { "position": 2, "name": "Duncan Anderson" }
-      ]
+        {
+          "position": 2,
+          "name": "Duncan Anderson"
+        }
+      ],
+      "sex": "M"
     },
     {
       "id": "v40",
       "awards": [
-        { "position": 1, "name": "Chris Wales" },
-        { "position": 2, "name": "Steve Myerscough" }
-      ]
+        {
+          "position": 1,
+          "name": "Chris Wales"
+        },
+        {
+          "position": 2,
+          "name": "Steve Myerscough"
+        }
+      ],
+      "ageCategory": "V40"
     },
     {
       "id": "v50",
       "awards": [
-        { "position": 1, "name": "John Rainford" },
-        { "position": 2, "name": "Philip Butler" },
-        { "position": 3, "name": "Stuart Cann" }
-      ]
+        {
+          "position": 1,
+          "name": "John Rainford"
+        },
+        {
+          "position": 2,
+          "name": "Philip Butler"
+        },
+        {
+          "position": 3,
+          "name": "Stuart Cann"
+        }
+      ],
+      "ageCategory": "V50"
     },
     {
       "id": "v60",
       "awards": [
-        { "position": 1, "name": "Steve Taylor" },
-        { "position": 2, "name": "Michael McLoughlin" }
-      ]
+        {
+          "position": 1,
+          "name": "Steve Taylor"
+        },
+        {
+          "position": 2,
+          "name": "Michael McLoughlin"
+        }
+      ],
+      "ageCategory": "V60"
     },
     {
       "id": "female",
       "awards": [
-        { "position": 1, "name": "Katey Foster" }
-      ]
+        {
+          "position": 1,
+          "name": "Katey Foster"
+        }
+      ],
+      "sex": "F"
     },
     {
       "id": "f40",
       "awards": [
-        { "position": 1, "name": "Sarah Sherratt" },
-        { "position": 2, "name": "Debbie Cooper" }
-      ]
+        {
+          "position": 1,
+          "name": "Sarah Sherratt"
+        },
+        {
+          "position": 2,
+          "name": "Debbie Cooper"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V40"
     },
     {
       "id": "f50",
       "awards": [
-        { "position": 1, "name": "Alison Mercer" },
-        { "position": 2, "name": "Karen Clark" }
-      ]
+        {
+          "position": 1,
+          "name": "Alison Mercer"
+        },
+        {
+          "position": 2,
+          "name": "Karen Clark"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     }
   ]
 }

--- a/src/data/2016/road-gp/awards.json
+++ b/src/data/2016/road-gp/awards.json
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "id": "ladies",
+            "id": "f",
             "awards": [
                 {
                     "position": 1,
@@ -22,7 +22,7 @@
             "sex": "F"
         },
         {
-            "id": "v40-male",
+            "id": "m-v40",
             "awards": [
                 {
                     "position": 1,
@@ -34,7 +34,7 @@
             "ageCategory": "V40"
         },
         {
-            "id": "v50-male",
+            "id": "m-v50",
             "awards": [
                 {
                     "position": 1,
@@ -46,7 +46,7 @@
             "ageCategory": "V50"
         },
         {
-            "id": "v60-male",
+            "id": "m-v60",
             "awards": [
                 {
                     "position": 1,

--- a/src/data/2016/road-gp/awards.json
+++ b/src/data/2016/road-gp/awards.json
@@ -1,56 +1,83 @@
-﻿{
-    "individualAwards":  [
-                           {
-                               "id":  "overall",
-                               "awards":  [
-                                              { "position": 1, "name": "R. Danson", "club": "wesham" }
-                                          ]
-                           },
-                           {
-                               "id":  "ladies",
-                               "awards":  [
-                                              { "position": 1, "name": "J. Goorney", "club": "lytham" }
-                                          ]
-                           },
-                           {
-                               "id":  "v40-male",
-                               "awards":  [
-                                              { "position": 1, "name": "R. Affleck", "club": "preston" }
-                                          ]
-                           },
-                           {
-                               "id":  "v50-male",
-                               "awards":  [
-                                              { "position": 1, "name": "J. Wright", "club": "blackpool" }
-                                          ]
-                           },
-                           {
-                               "id":  "v60-male",
-                               "awards":  [
-                                              { "position": 1, "name": "K. Addison", "club": "red-rose" }
-                                          ]
-                           }
-                       ],
-    "teamAwards":  [
-                       {
-                           "club":  "preston",
-                           "id":  "open"
-                       },
-                       {
-                           "club":  "preston",
-                           "id":  "vets"
-                       },
-                       {
-                           "club":  "red-rose",
-                           "id":  "vet50"
-                       },
-                       {
-                           "club":  "red-rose",
-                           "id":  "vet60"
-                       },
-                       {
-                           "club":  "wesham",
-                           "id":  "ladies"
-                       }
-                   ]
+{
+    "individualAwards": [
+        {
+            "id": "overall",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "R. Danson",
+                    "club": "wesham"
+                }
+            ]
+        },
+        {
+            "id": "ladies",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "J. Goorney",
+                    "club": "lytham"
+                }
+            ],
+            "sex": "F"
+        },
+        {
+            "id": "v40-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "R. Affleck",
+                    "club": "preston"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V40"
+        },
+        {
+            "id": "v50-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "J. Wright",
+                    "club": "blackpool"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V50"
+        },
+        {
+            "id": "v60-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "K. Addison",
+                    "club": "red-rose"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V60"
+        }
+    ],
+    "teamAwards": [
+        {
+            "club": "preston",
+            "id": "open"
+        },
+        {
+            "club": "preston",
+            "id": "vets"
+        },
+        {
+            "club": "red-rose",
+            "id": "vet50"
+        },
+        {
+            "club": "red-rose",
+            "id": "vet60"
+        },
+        {
+            "club": "wesham",
+            "id": "ladies"
+        }
+    ]
 }

--- a/src/data/2017/fell/awards.json
+++ b/src/data/2017/fell/awards.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "individualAwards": [
     {
       "id": "sen-male",
@@ -15,7 +15,9 @@
           "club": "red-rose",
           "ageCategory": "SEN"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "SEN"
     },
     {
       "id": "v40-male",
@@ -32,7 +34,9 @@
           "club": "chorley",
           "ageCategory": "V40"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "v50-male",
@@ -49,7 +53,9 @@
           "club": "chorley",
           "ageCategory": "V50"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "v60-male",
@@ -66,7 +72,9 @@
           "club": "preston",
           "ageCategory": "V65"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     },
     {
       "id": "sen-female",
@@ -77,7 +85,9 @@
           "club": "lytham",
           "ageCategory": "V40"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "SEN"
     },
     {
       "id": "v50-female",
@@ -94,7 +104,9 @@
           "club": "red-rose",
           "ageCategory": "V55"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     }
   ],
   "teamAwards": [

--- a/src/data/2017/fell/awards.json
+++ b/src/data/2017/fell/awards.json
@@ -1,7 +1,7 @@
 {
   "individualAwards": [
     {
-      "id": "sen-male",
+      "id": "m-sen",
       "awards": [
         {
           "position": 1,
@@ -20,7 +20,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "v40-male",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -39,7 +39,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v50-male",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -58,7 +58,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v60-male",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,
@@ -77,7 +77,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "sen-female",
+      "id": "f-sen",
       "awards": [
         {
           "position": 1,
@@ -90,7 +90,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "v50-female",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,

--- a/src/data/2017/road-gp/awards.json
+++ b/src/data/2017/road-gp/awards.json
@@ -1,7 +1,7 @@
 {
   "individualAwards": [
     {
-      "id": "female",
+      "id": "f",
       "awards": [
         {
           "position": 1,
@@ -67,7 +67,7 @@
       "sex": "F"
     },
     {
-      "id": "male",
+      "id": "m",
       "awards": [
         {
           "position": 1,
@@ -133,7 +133,7 @@
       "sex": "M"
     },
     {
-      "id": "jun-female",
+      "id": "f-jun",
       "awards": [
         {
           "position": 1,
@@ -144,7 +144,7 @@
       "ageCategory": "JUN"
     },
     {
-      "id": "jun-male",
+      "id": "m-jun",
       "awards": [
         {
           "position": 1,
@@ -159,7 +159,7 @@
       "ageCategory": "JUN"
     },
     {
-      "id": "sen-female",
+      "id": "f-sen",
       "awards": [
         {
           "position": 1,
@@ -174,7 +174,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "sen-male",
+      "id": "m-sen",
       "awards": [
         {
           "position": 1,
@@ -189,7 +189,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "v35-female",
+      "id": "f-v35",
       "awards": [
         {
           "position": 1,
@@ -204,7 +204,7 @@
       "ageCategory": "V35"
     },
     {
-      "id": "v40-female",
+      "id": "f-v40",
       "awards": [
         {
           "position": 1,
@@ -219,7 +219,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v40-male",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -234,7 +234,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v45-female",
+      "id": "f-v45",
       "awards": [
         {
           "position": 1,
@@ -249,7 +249,7 @@
       "ageCategory": "V45"
     },
     {
-      "id": "v45-male",
+      "id": "m-v45",
       "awards": [
         {
           "position": 1,
@@ -264,7 +264,7 @@
       "ageCategory": "V45"
     },
     {
-      "id": "v50-female",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,
@@ -279,7 +279,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v50-male",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -294,7 +294,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v55-female",
+      "id": "f-v55",
       "awards": [
         {
           "position": 1,
@@ -309,7 +309,7 @@
       "ageCategory": "V55"
     },
     {
-      "id": "v55-male",
+      "id": "m-v55",
       "awards": [
         {
           "position": 1,
@@ -324,7 +324,7 @@
       "ageCategory": "V55"
     },
     {
-      "id": "v60-female",
+      "id": "f-v60",
       "awards": [
         {
           "position": 1,
@@ -339,7 +339,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "v60-male",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,
@@ -354,7 +354,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "v65-female",
+      "id": "f-v65",
       "awards": [
         {
           "position": 1,
@@ -369,7 +369,7 @@
       "ageCategory": "V65"
     },
     {
-      "id": "v65-male",
+      "id": "m-v65",
       "awards": [
         {
           "position": 1,
@@ -384,7 +384,7 @@
       "ageCategory": "V65"
     },
     {
-      "id": "v70-female",
+      "id": "f-v70",
       "awards": [
         {
           "position": 1,
@@ -399,7 +399,7 @@
       "ageCategory": "V70"
     },
     {
-      "id": "v70-male",
+      "id": "m-v70",
       "awards": [
         {
           "position": 1,
@@ -410,7 +410,7 @@
       "ageCategory": "V70"
     },
     {
-      "id": "v75-male",
+      "id": "m-v75",
       "awards": [
         {
           "position": 1,

--- a/src/data/2017/road-gp/awards.json
+++ b/src/data/2017/road-gp/awards.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "individualAwards": [
     {
       "id": "female",
@@ -63,7 +63,8 @@
           "club": "blackpool",
           "ageCategory": "V40"
         }
-      ]
+      ],
+      "sex": "F"
     },
     {
       "id": "male",
@@ -128,7 +129,8 @@
           "club": "wesham",
           "ageCategory": "SEN"
         }
-      ]
+      ],
+      "sex": "M"
     },
     {
       "id": "jun-female",
@@ -137,7 +139,9 @@
           "position": 1,
           "name": "E. Ingham"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "JUN"
     },
     {
       "id": "jun-male",
@@ -150,7 +154,9 @@
           "position": 2,
           "name": "J. Bretherton"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "JUN"
     },
     {
       "id": "sen-female",
@@ -163,7 +169,9 @@
           "position": 2,
           "name": "N. Hughes"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "SEN"
     },
     {
       "id": "sen-male",
@@ -176,7 +184,9 @@
           "position": 2,
           "name": "M. Toft"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "SEN"
     },
     {
       "id": "v35-female",
@@ -189,7 +199,9 @@
           "position": 2,
           "name": "R. Gibson"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V35"
     },
     {
       "id": "v40-female",
@@ -202,7 +214,9 @@
           "position": 2,
           "name": "L. Murphy"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V40"
     },
     {
       "id": "v40-male",
@@ -215,7 +229,9 @@
           "position": 2,
           "name": "S. Myerscough"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "v45-female",
@@ -228,7 +244,9 @@
           "position": 2,
           "name": "S. Coulthurst"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V45"
     },
     {
       "id": "v45-male",
@@ -241,7 +259,9 @@
           "position": 2,
           "name": "L. Barlow"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V45"
     },
     {
       "id": "v50-female",
@@ -254,7 +274,9 @@
           "position": 2,
           "name": "K. Dunford"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     },
     {
       "id": "v50-male",
@@ -267,7 +289,9 @@
           "position": 2,
           "name": "G. Barnett"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "v55-female",
@@ -280,7 +304,9 @@
           "position": 2,
           "name": "A. Cleave"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V55"
     },
     {
       "id": "v55-male",
@@ -293,7 +319,9 @@
           "position": 2,
           "name": "S. Shaw"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V55"
     },
     {
       "id": "v60-female",
@@ -306,7 +334,9 @@
           "position": 2,
           "name": "A. Norris"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V60"
     },
     {
       "id": "v60-male",
@@ -319,7 +349,9 @@
           "position": 2,
           "name": "K. Addison"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     },
     {
       "id": "v65-female",
@@ -332,7 +364,9 @@
           "position": 2,
           "name": "M. Kirby"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V65"
     },
     {
       "id": "v65-male",
@@ -345,7 +379,9 @@
           "position": 2,
           "name": "A. Hudson"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V65"
     },
     {
       "id": "v70-female",
@@ -358,7 +394,9 @@
           "position": 2,
           "name": "H. Goorney"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V70"
     },
     {
       "id": "v70-male",
@@ -367,7 +405,9 @@
           "position": 1,
           "name": "D. Aspin"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V70"
     },
     {
       "id": "v75-male",
@@ -376,7 +416,9 @@
           "position": 1,
           "name": "E. Murray"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V75"
     }
   ],
   "teamAwards": [

--- a/src/data/2018/fell/awards.json
+++ b/src/data/2018/fell/awards.json
@@ -1,59 +1,152 @@
-﻿{
+{
   "teamAwards": [
-    { "id": "overall", "club": "preston" },
-    { "id": "m40", "club": "preston" },
-    { "id": "m50", "club": "preston" },
-    { "id": "m60", "club": "preston" },
-    { "id": "women", "club": "red-rose" }
+    {
+      "id": "overall",
+      "club": "preston"
+    },
+    {
+      "id": "m40",
+      "club": "preston"
+    },
+    {
+      "id": "m50",
+      "club": "preston"
+    },
+    {
+      "id": "m60",
+      "club": "preston"
+    },
+    {
+      "id": "women",
+      "club": "red-rose"
+    }
   ],
   "individualAwards": [
     {
       "id": "sen-m",
       "awards": [
-        { "position": 1, "name": "Richard Smith", "club": "preston", "ageCategory": "SEN" },
-        { "position": 3, "name": "Simon Collins", "club": "preston", "ageCategory": "SEN" }
-      ]
+        {
+          "position": 1,
+          "name": "Richard Smith",
+          "club": "preston",
+          "ageCategory": "SEN"
+        },
+        {
+          "position": 3,
+          "name": "Simon Collins",
+          "club": "preston",
+          "ageCategory": "SEN"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "SEN"
     },
     {
       "id": "m40",
       "awards": [
-        { "position": 1, "name": "Jon Green", "club": "preston", "ageCategory": "V40" },
-        { "position": 2, "name": "Andy Whaley", "club": "preston", "ageCategory": "V40" }
-      ]
+        {
+          "position": 1,
+          "name": "Jon Green",
+          "club": "preston",
+          "ageCategory": "V40"
+        },
+        {
+          "position": 2,
+          "name": "Andy Whaley",
+          "club": "preston",
+          "ageCategory": "V40"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "m50",
       "awards": [
-        { "position": 1, "name": "John Rainford", "club": "preston", "ageCategory": "V50" },
-        { "position": 2, "name": "Frank Nightingale", "club": "red-rose", "ageCategory": "V50" }
-      ]
+        {
+          "position": 1,
+          "name": "John Rainford",
+          "club": "preston",
+          "ageCategory": "V50"
+        },
+        {
+          "position": 2,
+          "name": "Frank Nightingale",
+          "club": "red-rose",
+          "ageCategory": "V50"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "m60",
       "awards": [
-        { "position": 1, "name": "Peter Singleton", "club": "blackpool", "ageCategory": "V60" },
-        { "position": 2, "name": "Alan Appleby", "club": "preston", "ageCategory": "V70" }
-      ]
+        {
+          "position": 1,
+          "name": "Peter Singleton",
+          "club": "blackpool",
+          "ageCategory": "V60"
+        },
+        {
+          "position": 2,
+          "name": "Alan Appleby",
+          "club": "preston",
+          "ageCategory": "V70"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     },
     {
       "id": "women",
       "awards": [
-        { "position": 1, "name": "Vicki Sherrington", "club": "preston", "ageCategory": "V40" },
-        { "position": 2, "name": "Olga Wiggins", "club": "preston", "ageCategory": "SEN" }
-      ]
+        {
+          "position": 1,
+          "name": "Vicki Sherrington",
+          "club": "preston",
+          "ageCategory": "V40"
+        },
+        {
+          "position": 2,
+          "name": "Olga Wiggins",
+          "club": "preston",
+          "ageCategory": "SEN"
+        }
+      ],
+      "sex": "F"
     },
     {
       "id": "f40",
       "awards": [
-        { "position": 2, "name": "Debbie Porter", "club": "red-rose", "ageCategory": "V40" }
-      ]
+        {
+          "position": 2,
+          "name": "Debbie Porter",
+          "club": "red-rose",
+          "ageCategory": "V40"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V40"
     },
     {
       "id": "f50",
       "awards": [
-        { "position": 1, "name": "Alison Mercer", "club": "red-rose", "ageCategory": "V50" },
-        { "position": 2, "name": "Lynn Melvin", "club": "red-rose", "ageCategory": "V50" }
-      ]
+        {
+          "position": 1,
+          "name": "Alison Mercer",
+          "club": "red-rose",
+          "ageCategory": "V50"
+        },
+        {
+          "position": 2,
+          "name": "Lynn Melvin",
+          "club": "red-rose",
+          "ageCategory": "V50"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     }
   ]
 }

--- a/src/data/2018/fell/awards.json
+++ b/src/data/2018/fell/awards.json
@@ -23,7 +23,7 @@
   ],
   "individualAwards": [
     {
-      "id": "sen-m",
+      "id": "m-sen",
       "awards": [
         {
           "position": 1,
@@ -42,7 +42,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "m40",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -61,7 +61,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "m50",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -80,7 +80,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "m60",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,
@@ -99,7 +99,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "women",
+      "id": "f",
       "awards": [
         {
           "position": 1,
@@ -117,7 +117,7 @@
       "sex": "F"
     },
     {
-      "id": "f40",
+      "id": "f-v40",
       "awards": [
         {
           "position": 2,
@@ -130,7 +130,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "f50",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,

--- a/src/data/2018/road-gp/awards.json
+++ b/src/data/2018/road-gp/awards.json
@@ -1,7 +1,7 @@
 {
   "individualAwards": [
     {
-      "id": "female",
+      "id": "f",
       "awards": [
         {
           "position": 1,
@@ -67,7 +67,7 @@
       "sex": "F"
     },
     {
-      "id": "male",
+      "id": "m",
       "awards": [
         {
           "position": 1,
@@ -133,7 +133,7 @@
       "sex": "M"
     },
     {
-      "id": "jun-female",
+      "id": "f-jun",
       "awards": [
         {
           "position": 1,
@@ -148,7 +148,7 @@
       "ageCategory": "JUN"
     },
     {
-      "id": "jun-male",
+      "id": "m-jun",
       "awards": [
         {
           "position": 1,
@@ -163,7 +163,7 @@
       "ageCategory": "JUN"
     },
     {
-      "id": "sen-female",
+      "id": "f-sen",
       "awards": [
         {
           "position": 1,
@@ -178,7 +178,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "sen-male",
+      "id": "m-sen",
       "awards": [
         {
           "position": 1,
@@ -193,7 +193,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "v35-female",
+      "id": "f-v35",
       "awards": [
         {
           "position": 1,
@@ -208,7 +208,7 @@
       "ageCategory": "V35"
     },
     {
-      "id": "v40-female",
+      "id": "f-v40",
       "awards": [
         {
           "position": 1,
@@ -223,7 +223,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v40-male",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -238,7 +238,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v45-female",
+      "id": "f-v45",
       "awards": [
         {
           "position": 1,
@@ -253,7 +253,7 @@
       "ageCategory": "V45"
     },
     {
-      "id": "v45-male",
+      "id": "m-v45",
       "awards": [
         {
           "position": 1,
@@ -268,7 +268,7 @@
       "ageCategory": "V45"
     },
     {
-      "id": "v50-female",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,
@@ -283,7 +283,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v50-male",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -298,7 +298,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v55-female",
+      "id": "f-v55",
       "awards": [
         {
           "position": 1,
@@ -313,7 +313,7 @@
       "ageCategory": "V55"
     },
     {
-      "id": "v55-male",
+      "id": "m-v55",
       "awards": [
         {
           "position": 1,
@@ -328,7 +328,7 @@
       "ageCategory": "V55"
     },
     {
-      "id": "v60-female",
+      "id": "f-v60",
       "awards": [
         {
           "position": 1,
@@ -343,7 +343,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "v60-male",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,
@@ -358,7 +358,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "v65-female",
+      "id": "f-v65",
       "awards": [
         {
           "position": 1,
@@ -373,7 +373,7 @@
       "ageCategory": "V65"
     },
     {
-      "id": "v65-male",
+      "id": "m-v65",
       "awards": [
         {
           "position": 1,
@@ -388,7 +388,7 @@
       "ageCategory": "V65"
     },
     {
-      "id": "v70-female",
+      "id": "f-v70",
       "awards": [
         {
           "position": 1,
@@ -403,7 +403,7 @@
       "ageCategory": "V70"
     },
     {
-      "id": "v70-male",
+      "id": "m-v70",
       "awards": [
         {
           "position": 1,
@@ -418,7 +418,7 @@
       "ageCategory": "V70"
     },
     {
-      "id": "v75-male",
+      "id": "m-v75",
       "awards": [
         {
           "position": 1,
@@ -429,7 +429,7 @@
       "ageCategory": "V75"
     },
     {
-      "id": "v80-male",
+      "id": "m-v80",
       "awards": [
         {
           "position": 1,
@@ -440,7 +440,7 @@
       "ageCategory": "V80"
     },
     {
-      "id": "v85-male",
+      "id": "m-v85",
       "awards": [
         {
           "position": 1,

--- a/src/data/2018/road-gp/awards.json
+++ b/src/data/2018/road-gp/awards.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "individualAwards": [
     {
       "id": "female",
@@ -63,7 +63,8 @@
           "club": "chorley",
           "ageCategory": "SEN"
         }
-      ]
+      ],
+      "sex": "F"
     },
     {
       "id": "male",
@@ -128,7 +129,8 @@
           "club": "lytham",
           "ageCategory": "SEN"
         }
-      ]
+      ],
+      "sex": "M"
     },
     {
       "id": "jun-female",
@@ -141,7 +143,9 @@
           "position": 2,
           "name": "O. Sutch"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "JUN"
     },
     {
       "id": "jun-male",
@@ -154,7 +158,9 @@
           "position": 2,
           "name": "D. Fletcher"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "JUN"
     },
     {
       "id": "sen-female",
@@ -167,7 +173,9 @@
           "position": 2,
           "name": "H. McCusker"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "SEN"
     },
     {
       "id": "sen-male",
@@ -180,7 +188,9 @@
           "position": 2,
           "name": "D. Taylor"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "SEN"
     },
     {
       "id": "v35-female",
@@ -193,7 +203,9 @@
           "position": 2,
           "name": "S. Jeffrey"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V35"
     },
     {
       "id": "v40-female",
@@ -206,7 +218,9 @@
           "position": 2,
           "name": "S. Brookes"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V40"
     },
     {
       "id": "v40-male",
@@ -219,7 +233,9 @@
           "position": 2,
           "name": "S. Abbott"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "v45-female",
@@ -232,7 +248,9 @@
           "position": 2,
           "name": "H. Haigh"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V45"
     },
     {
       "id": "v45-male",
@@ -245,7 +263,9 @@
           "position": 2,
           "name": "L. Barlow"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V45"
     },
     {
       "id": "v50-female",
@@ -258,7 +278,9 @@
           "position": 2,
           "name": "A. Parkinson"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     },
     {
       "id": "v50-male",
@@ -271,7 +293,9 @@
           "position": 2,
           "name": "J. Wright"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "v55-female",
@@ -284,7 +308,9 @@
           "position": 2,
           "name": "P. Hardman"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V55"
     },
     {
       "id": "v55-male",
@@ -297,7 +323,9 @@
           "position": 2,
           "name": "J. Allen"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V55"
     },
     {
       "id": "v60-female",
@@ -310,7 +338,9 @@
           "position": 2,
           "name": "S. Tonge"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V60"
     },
     {
       "id": "v60-male",
@@ -323,7 +353,9 @@
           "position": 2,
           "name": "K. Addison"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     },
     {
       "id": "v65-female",
@@ -336,7 +368,9 @@
           "position": 2,
           "name": "M. Kirkby"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V65"
     },
     {
       "id": "v65-male",
@@ -349,7 +383,9 @@
           "position": 2,
           "name": "R. Taylor"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V65"
     },
     {
       "id": "v70-female",
@@ -362,7 +398,9 @@
           "position": 2,
           "name": "P. Binns"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V70"
     },
     {
       "id": "v70-male",
@@ -375,7 +413,9 @@
           "position": 2,
           "name": "R. Smallbone"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V70"
     },
     {
       "id": "v75-male",
@@ -384,7 +424,9 @@
           "position": 1,
           "name": "J. Swift"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V75"
     },
     {
       "id": "v80-male",
@@ -393,7 +435,9 @@
           "position": 1,
           "name": "J. Winters"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V80"
     },
     {
       "id": "v85-male",
@@ -402,7 +446,9 @@
           "position": 1,
           "name": "M. Walsh"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V85"
     }
   ],
   "teamAwards": [

--- a/src/data/2019/fell/awards.json
+++ b/src/data/2019/fell/awards.json
@@ -1,57 +1,129 @@
-﻿{
+{
   "teamAwards": [
-    { "id": "overall", "club": "preston" },
-    { "id": "v40", "club": "preston" },
-    { "id": "v50", "club": "preston" },
-    { "id": "v60", "club": "preston" },
-    { "id": "women", "club": "red-rose" }
+    {
+      "id": "overall",
+      "club": "preston"
+    },
+    {
+      "id": "v40",
+      "club": "preston"
+    },
+    {
+      "id": "v50",
+      "club": "preston"
+    },
+    {
+      "id": "v60",
+      "club": "preston"
+    },
+    {
+      "id": "women",
+      "club": "red-rose"
+    }
   ],
   "individualAwards": [
     {
       "id": "sen-m",
       "awards": [
-        { "position": 1, "name": "Daniel Hughes", "club": "red-rose" },
-        { "position": 2, "name": "Barry Wheeler", "club": "red-rose" }
-      ]
+        {
+          "position": 1,
+          "name": "Daniel Hughes",
+          "club": "red-rose"
+        },
+        {
+          "position": 2,
+          "name": "Barry Wheeler",
+          "club": "red-rose"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "SEN"
     },
     {
       "id": "v40-m",
       "awards": [
-        { "position": 1, "name": "Neil Whipp", "club": "wesham" },
-        { "position": 2, "name": "Chris Charnley", "club": "red-rose" }
-      ]
+        {
+          "position": 1,
+          "name": "Neil Whipp",
+          "club": "wesham"
+        },
+        {
+          "position": 2,
+          "name": "Chris Charnley",
+          "club": "red-rose"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "v50-m",
       "awards": [
-        { "position": 1, "name": "Stephen Woodruff", "club": "red-rose" },
-        { "position": 2, "name": "Frank Nightingale", "club": "red-rose" }
-      ]
+        {
+          "position": 1,
+          "name": "Stephen Woodruff",
+          "club": "red-rose"
+        },
+        {
+          "position": 2,
+          "name": "Frank Nightingale",
+          "club": "red-rose"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "v60-m",
       "awards": [
-        { "position": 1, "name": "Graham Schofield", "club": "chorley" }
-      ]
+        {
+          "position": 1,
+          "name": "Graham Schofield",
+          "club": "chorley"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     },
     {
       "id": "f",
       "awards": [
-        { "position": 1, "name": "Nicola Hughes", "club": "red-rose" }
-      ]
+        {
+          "position": 1,
+          "name": "Nicola Hughes",
+          "club": "red-rose"
+        }
+      ],
+      "sex": "F"
     },
     {
       "id": "v40-f",
       "awards": [
-        { "position": 1, "name": "Vicki Sherrington", "club": "preston" },
-        { "position": 2, "name": "Amanda Fuller", "club": "blackpool" }
-      ]
+        {
+          "position": 1,
+          "name": "Vicki Sherrington",
+          "club": "preston"
+        },
+        {
+          "position": 2,
+          "name": "Amanda Fuller",
+          "club": "blackpool"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V40"
     },
     {
       "id": "v50-f",
       "awards": [
-        { "position": 1, "name": "Paula Plowman", "club": "red-rose" }
-      ]
+        {
+          "position": 1,
+          "name": "Paula Plowman",
+          "club": "red-rose"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     }
   ]
 }

--- a/src/data/2019/fell/awards.json
+++ b/src/data/2019/fell/awards.json
@@ -23,7 +23,7 @@
   ],
   "individualAwards": [
     {
-      "id": "sen-m",
+      "id": "m-sen",
       "awards": [
         {
           "position": 1,
@@ -40,7 +40,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "v40-m",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -57,7 +57,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v50-m",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -74,7 +74,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v60-m",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,
@@ -97,7 +97,7 @@
       "sex": "F"
     },
     {
-      "id": "v40-f",
+      "id": "f-v40",
       "awards": [
         {
           "position": 1,
@@ -114,7 +114,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v50-f",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,

--- a/src/data/2019/road-gp/awards.json
+++ b/src/data/2019/road-gp/awards.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "individualAwards": [
     {
       "id": "female",
@@ -21,7 +21,8 @@
           "club": "chorley",
           "ageCategory": "V35"
         }
-      ]
+      ],
+      "sex": "F"
     },
     {
       "id": "male",
@@ -44,7 +45,8 @@
           "club": "blackpool",
           "ageCategory": "SEN"
         }
-      ]
+      ],
+      "sex": "M"
     },
     {
       "id": "jun-female",
@@ -57,7 +59,9 @@
           "position": 2,
           "name": "B. Reid"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "JUN"
     },
     {
       "id": "jun-male",
@@ -70,7 +74,9 @@
           "position": 2,
           "name": "G. Norris"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "JUN"
     },
     {
       "id": "sen-female",
@@ -83,7 +89,9 @@
           "position": 2,
           "name": "S. Edwards"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "SEN"
     },
     {
       "id": "sen-male",
@@ -96,7 +104,9 @@
           "position": 2,
           "name": "M. Toft"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "SEN"
     },
     {
       "id": "v35-female",
@@ -109,7 +119,9 @@
           "position": 2,
           "name": "F. Connolly"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V35"
     },
     {
       "id": "v40-female",
@@ -122,7 +134,9 @@
           "position": 2,
           "name": "J. Rayton"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V40"
     },
     {
       "id": "v40-male",
@@ -135,7 +149,9 @@
           "position": 2,
           "name": "A. Whaley"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "v45-female",
@@ -148,7 +164,9 @@
           "position": 2,
           "name": "N. Unsworth"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V45"
     },
     {
       "id": "v45-male",
@@ -161,7 +179,9 @@
           "position": 2,
           "name": "R. Walsh"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V45"
     },
     {
       "id": "v50-female",
@@ -174,7 +194,9 @@
           "position": 2,
           "name": "C. Sullivan"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     },
     {
       "id": "v50-male",
@@ -187,7 +209,9 @@
           "position": 2,
           "name": "D. Parkinson"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "v55-female",
@@ -200,7 +224,9 @@
           "position": 2,
           "name": "P. Plowman"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V55"
     },
     {
       "id": "v55-male",
@@ -213,7 +239,9 @@
           "position": 2,
           "name": "W. Johnstone"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V55"
     },
     {
       "id": "v60-female",
@@ -226,7 +254,9 @@
           "position": 2,
           "name": "J. Coates"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V60"
     },
     {
       "id": "v60-male",
@@ -239,7 +269,9 @@
           "position": 2,
           "name": "J. Swarbrick"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     },
     {
       "id": "v65-female",
@@ -248,7 +280,9 @@
           "position": 1,
           "name": "M. Kirkby"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V65"
     },
     {
       "id": "v65-male",
@@ -261,7 +295,9 @@
           "position": 2,
           "name": "J. Collier"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V65"
     },
     {
       "id": "v70-female",
@@ -274,7 +310,9 @@
           "position": 2,
           "name": "D. Bowling"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V70"
     },
     {
       "id": "v70-male",
@@ -287,7 +325,9 @@
           "position": 2,
           "name": "R. Smallbone"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V70"
     },
     {
       "id": "v75-female",
@@ -296,7 +336,9 @@
           "position": 1,
           "name": "H. Goorney"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V75"
     },
     {
       "id": "v75-male",
@@ -305,7 +347,9 @@
           "position": 1,
           "name": "A. Littler"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V75"
     },
     {
       "id": "v80-male",
@@ -314,7 +358,9 @@
           "position": 1,
           "name": "J. Winters"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V80"
     },
     {
       "id": "v85-male",
@@ -323,7 +369,9 @@
           "position": 1,
           "name": "M. Walsh"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V85"
     }
   ],
   "teamAwards": [

--- a/src/data/2019/road-gp/awards.json
+++ b/src/data/2019/road-gp/awards.json
@@ -1,7 +1,7 @@
 {
   "individualAwards": [
     {
-      "id": "female",
+      "id": "f",
       "awards": [
         {
           "position": 1,
@@ -25,7 +25,7 @@
       "sex": "F"
     },
     {
-      "id": "male",
+      "id": "m",
       "awards": [
         {
           "position": 1,
@@ -49,7 +49,7 @@
       "sex": "M"
     },
     {
-      "id": "jun-female",
+      "id": "f-jun",
       "awards": [
         {
           "position": 1,
@@ -64,7 +64,7 @@
       "ageCategory": "JUN"
     },
     {
-      "id": "jun-male",
+      "id": "m-jun",
       "awards": [
         {
           "position": 1,
@@ -79,7 +79,7 @@
       "ageCategory": "JUN"
     },
     {
-      "id": "sen-female",
+      "id": "f-sen",
       "awards": [
         {
           "position": 1,
@@ -94,7 +94,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "sen-male",
+      "id": "m-sen",
       "awards": [
         {
           "position": 1,
@@ -109,7 +109,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "v35-female",
+      "id": "f-v35",
       "awards": [
         {
           "position": 1,
@@ -124,7 +124,7 @@
       "ageCategory": "V35"
     },
     {
-      "id": "v40-female",
+      "id": "f-v40",
       "awards": [
         {
           "position": 1,
@@ -139,7 +139,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v40-male",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -154,7 +154,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v45-female",
+      "id": "f-v45",
       "awards": [
         {
           "position": 1,
@@ -169,7 +169,7 @@
       "ageCategory": "V45"
     },
     {
-      "id": "v45-male",
+      "id": "m-v45",
       "awards": [
         {
           "position": 1,
@@ -184,7 +184,7 @@
       "ageCategory": "V45"
     },
     {
-      "id": "v50-female",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,
@@ -199,7 +199,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v50-male",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -214,7 +214,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v55-female",
+      "id": "f-v55",
       "awards": [
         {
           "position": 1,
@@ -229,7 +229,7 @@
       "ageCategory": "V55"
     },
     {
-      "id": "v55-male",
+      "id": "m-v55",
       "awards": [
         {
           "position": 1,
@@ -244,7 +244,7 @@
       "ageCategory": "V55"
     },
     {
-      "id": "v60-female",
+      "id": "f-v60",
       "awards": [
         {
           "position": 1,
@@ -259,7 +259,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "v60-male",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,
@@ -274,7 +274,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "v65-female",
+      "id": "f-v65",
       "awards": [
         {
           "position": 1,
@@ -285,7 +285,7 @@
       "ageCategory": "V65"
     },
     {
-      "id": "v65-male",
+      "id": "m-v65",
       "awards": [
         {
           "position": 1,
@@ -300,7 +300,7 @@
       "ageCategory": "V65"
     },
     {
-      "id": "v70-female",
+      "id": "f-v70",
       "awards": [
         {
           "position": 1,
@@ -315,7 +315,7 @@
       "ageCategory": "V70"
     },
     {
-      "id": "v70-male",
+      "id": "m-v70",
       "awards": [
         {
           "position": 1,
@@ -330,7 +330,7 @@
       "ageCategory": "V70"
     },
     {
-      "id": "v75-female",
+      "id": "f-v75",
       "awards": [
         {
           "position": 1,
@@ -341,7 +341,7 @@
       "ageCategory": "V75"
     },
     {
-      "id": "v75-male",
+      "id": "m-v75",
       "awards": [
         {
           "position": 1,
@@ -352,7 +352,7 @@
       "ageCategory": "V75"
     },
     {
-      "id": "v80-male",
+      "id": "m-v80",
       "awards": [
         {
           "position": 1,
@@ -363,7 +363,7 @@
       "ageCategory": "V80"
     },
     {
-      "id": "v85-male",
+      "id": "m-v85",
       "awards": [
         {
           "position": 1,

--- a/src/data/2022/fell/awards.json
+++ b/src/data/2022/fell/awards.json
@@ -23,7 +23,7 @@
   ],
   "individualAwards": [
     {
-      "id": "male",
+      "id": "m",
       "awards": [
         {
           "position": 1,
@@ -47,7 +47,7 @@
       "sex": "M"
     },
     {
-      "id": "female",
+      "id": "f",
       "awards": [
         {
           "position": 1,
@@ -65,7 +65,7 @@
       "sex": "F"
     },
     {
-      "id": "v40-male",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -78,7 +78,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v50-male",
+      "id": "m-v50",
       "awards": [
         {
           "position": 2,
@@ -91,7 +91,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v60-male",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,
@@ -104,7 +104,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "v40-female",
+      "id": "f-v40",
       "awards": [
         {
           "position": 1,
@@ -123,7 +123,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v50-female",
+      "id": "f-v50",
       "awards": [
         {
           "position": 2,

--- a/src/data/2022/fell/awards.json
+++ b/src/data/2022/fell/awards.json
@@ -1,57 +1,139 @@
-﻿{
+{
   "teamAwards": [
-    {"id": "open", "club": "chorley"},
-    {"id": "ladies", "club": "preston"},
-    {"id": "vets", "club": "chorley"},
-    {"id": "v50", "club": "chorley"},
-    {"id": "v60", "club": "chorley"}
+    {
+      "id": "open",
+      "club": "chorley"
+    },
+    {
+      "id": "ladies",
+      "club": "preston"
+    },
+    {
+      "id": "vets",
+      "club": "chorley"
+    },
+    {
+      "id": "v50",
+      "club": "chorley"
+    },
+    {
+      "id": "v60",
+      "club": "chorley"
+    }
   ],
   "individualAwards": [
     {
       "id": "male",
       "awards": [
-        {"position": 1, "name": "Darren McDermott", "club": "preston", "ageCategory": "V50"},
-        {"position": 2, "name": "Steve Baker", "club": "chorley", "ageCategory": "V60"},
-        {"position": 3, "name": "Paul Lancashire", "club": "wesham", "ageCategory": "V40"}
-      ]
+        {
+          "position": 1,
+          "name": "Darren McDermott",
+          "club": "preston",
+          "ageCategory": "V50"
+        },
+        {
+          "position": 2,
+          "name": "Steve Baker",
+          "club": "chorley",
+          "ageCategory": "V60"
+        },
+        {
+          "position": 3,
+          "name": "Paul Lancashire",
+          "club": "wesham",
+          "ageCategory": "V40"
+        }
+      ],
+      "sex": "M"
     },
     {
       "id": "female",
       "awards": [
-        {"position": 1, "name": "Claire McDermott", "club": "preston", "ageCategory": "V50"},
-        {"position": 3, "name": "Amanda Fuller", "club": "blackpool", "ageCategory": "V40"}
-      ]
+        {
+          "position": 1,
+          "name": "Claire McDermott",
+          "club": "preston",
+          "ageCategory": "V50"
+        },
+        {
+          "position": 3,
+          "name": "Amanda Fuller",
+          "club": "blackpool",
+          "ageCategory": "V40"
+        }
+      ],
+      "sex": "F"
     },
     {
       "id": "v40-male",
       "awards": [
-        {"position": 1, "name": "John Naylor", "club": "red-rose", "ageCategory": "V40"}
-      ]
+        {
+          "position": 1,
+          "name": "John Naylor",
+          "club": "red-rose",
+          "ageCategory": "V40"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "v50-male",
       "awards": [
-        {"position": 2, "name": "Mark Ellithorn", "club": "chorley", "ageCategory": "V50"}
-      ]
+        {
+          "position": 2,
+          "name": "Mark Ellithorn",
+          "club": "chorley",
+          "ageCategory": "V50"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "v60-male",
       "awards": [
-        {"position": 1, "name": "Steve Baker", "club": "chorley", "ageCategory": "V60"}
-      ]
+        {
+          "position": 1,
+          "name": "Steve Baker",
+          "club": "chorley",
+          "ageCategory": "V60"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     },
     {
       "id": "v40-female",
       "awards": [
-        {"position": 1, "name": "Claire Markham", "club": "lytham", "ageCategory": "V40"},
-        {"position": 2, "name": "Olga Wiggins", "club": "preston", "ageCategory": "V40"}
-      ]
+        {
+          "position": 1,
+          "name": "Claire Markham",
+          "club": "lytham",
+          "ageCategory": "V40"
+        },
+        {
+          "position": 2,
+          "name": "Olga Wiggins",
+          "club": "preston",
+          "ageCategory": "V40"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V40"
     },
     {
       "id": "v50-female",
       "awards": [
-        {"position": 2, "name": "Pamela Hardman", "club": "lytham", "ageCategory": "V60"}
-      ]
+        {
+          "position": 2,
+          "name": "Pamela Hardman",
+          "club": "lytham",
+          "ageCategory": "V60"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     }
   ]
 }

--- a/src/data/2022/road-gp/awards.json
+++ b/src/data/2022/road-gp/awards.json
@@ -1,7 +1,7 @@
 {
   "individualAwards": [
     {
-      "id": "female",
+      "id": "f",
       "awards": [
         {
           "position": 1,
@@ -25,7 +25,7 @@
       "sex": "F"
     },
     {
-      "id": "male",
+      "id": "m",
       "awards": [
         {
           "position": 1,
@@ -49,7 +49,7 @@
       "sex": "M"
     },
     {
-      "id": "jun-female",
+      "id": "f-jun",
       "awards": [
         {
           "position": 1,
@@ -64,7 +64,7 @@
       "ageCategory": "JUN"
     },
     {
-      "id": "jun-male",
+      "id": "m-jun",
       "awards": [
         {
           "position": 1,
@@ -79,7 +79,7 @@
       "ageCategory": "JUN"
     },
     {
-      "id": "sen-female",
+      "id": "f-sen",
       "awards": [
         {
           "position": 1,
@@ -94,7 +94,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "sen-male",
+      "id": "m-sen",
       "awards": [
         {
           "position": 1,
@@ -109,7 +109,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "v35-female",
+      "id": "f-v35",
       "awards": [
         {
           "position": 1,
@@ -124,7 +124,7 @@
       "ageCategory": "V35"
     },
     {
-      "id": "v40-female",
+      "id": "f-v40",
       "awards": [
         {
           "position": 1,
@@ -139,7 +139,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v40-male",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -154,7 +154,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v45-female",
+      "id": "f-v45",
       "awards": [
         {
           "position": 1,
@@ -169,7 +169,7 @@
       "ageCategory": "V45"
     },
     {
-      "id": "v45-male",
+      "id": "m-v45",
       "awards": [
         {
           "position": 1,
@@ -184,7 +184,7 @@
       "ageCategory": "V45"
     },
     {
-      "id": "v50-female",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,
@@ -199,7 +199,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v50-male",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -214,7 +214,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v55-female",
+      "id": "f-v55",
       "awards": [
         {
           "position": 1,
@@ -229,7 +229,7 @@
       "ageCategory": "V55"
     },
     {
-      "id": "v55-male",
+      "id": "m-v55",
       "awards": [
         {
           "position": 1,
@@ -244,7 +244,7 @@
       "ageCategory": "V55"
     },
     {
-      "id": "v60-female",
+      "id": "f-v60",
       "awards": [
         {
           "position": 1,
@@ -259,7 +259,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "v60-male",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,
@@ -274,7 +274,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "v65-female",
+      "id": "f-v65",
       "awards": [
         {
           "position": 1,
@@ -285,7 +285,7 @@
       "ageCategory": "V65"
     },
     {
-      "id": "v65-male",
+      "id": "m-v65",
       "awards": [
         {
           "position": 1,
@@ -300,7 +300,7 @@
       "ageCategory": "V65"
     },
     {
-      "id": "v70-female",
+      "id": "f-v70",
       "awards": [
         {
           "position": 1,
@@ -311,7 +311,7 @@
       "ageCategory": "V70"
     },
     {
-      "id": "v70-male",
+      "id": "m-v70",
       "awards": [
         {
           "position": 1,
@@ -326,7 +326,7 @@
       "ageCategory": "V70"
     },
     {
-      "id": "v75-female",
+      "id": "f-v75",
       "awards": [
         {
           "position": 1,
@@ -337,7 +337,7 @@
       "ageCategory": "V75"
     },
     {
-      "id": "v75-male",
+      "id": "m-v75",
       "awards": [
         {
           "position": 1,

--- a/src/data/2022/road-gp/awards.json
+++ b/src/data/2022/road-gp/awards.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "individualAwards": [
     {
       "id": "female",
@@ -21,7 +21,8 @@
           "club": "lytham",
           "ageCategory": "V50"
         }
-      ]
+      ],
+      "sex": "F"
     },
     {
       "id": "male",
@@ -44,7 +45,8 @@
           "club": "lytham",
           "ageCategory": "SEN"
         }
-      ]
+      ],
+      "sex": "M"
     },
     {
       "id": "jun-female",
@@ -57,7 +59,9 @@
           "position": 2,
           "name": "A. Pilkington"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "JUN"
     },
     {
       "id": "jun-male",
@@ -70,7 +74,9 @@
           "position": 2,
           "name": "N. Cox"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "JUN"
     },
     {
       "id": "sen-female",
@@ -83,7 +89,9 @@
           "position": 2,
           "name": "A. Townsend"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "SEN"
     },
     {
       "id": "sen-male",
@@ -96,7 +104,9 @@
           "position": 2,
           "name": "M. Holmes"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "SEN"
     },
     {
       "id": "v35-female",
@@ -109,7 +119,9 @@
           "position": 2,
           "name": "J. Hill"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V35"
     },
     {
       "id": "v40-female",
@@ -122,7 +134,9 @@
           "position": 2,
           "name": "H. Hall"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V40"
     },
     {
       "id": "v40-male",
@@ -135,7 +149,9 @@
           "position": 2,
           "name": "J. Bretherton"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "v45-female",
@@ -148,7 +164,9 @@
           "position": 2,
           "name": "L. Murphy"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V45"
     },
     {
       "id": "v45-male",
@@ -161,7 +179,9 @@
           "position": 2,
           "name": "S. Abbott"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V45"
     },
     {
       "id": "v50-female",
@@ -174,7 +194,9 @@
           "position": 2,
           "name": "L. Lawler"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     },
     {
       "id": "v50-male",
@@ -187,7 +209,9 @@
           "position": 2,
           "name": "L. Barlow"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "v55-female",
@@ -200,7 +224,9 @@
           "position": 2,
           "name": "C. Sullivan"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V55"
     },
     {
       "id": "v55-male",
@@ -213,7 +239,9 @@
           "position": 2,
           "name": "J. Wright"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V55"
     },
     {
       "id": "v60-female",
@@ -226,7 +254,9 @@
           "position": 2,
           "name": "M. Tomlinson"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V60"
     },
     {
       "id": "v60-male",
@@ -239,7 +269,9 @@
           "position": 2,
           "name": "J. Hickman"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     },
     {
       "id": "v65-female",
@@ -248,7 +280,9 @@
           "position": 1,
           "name": "M. Hesketh"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V65"
     },
     {
       "id": "v65-male",
@@ -261,7 +295,9 @@
           "position": 2,
           "name": "K. Addison"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V65"
     },
     {
       "id": "v70-female",
@@ -270,7 +306,9 @@
           "position": 1,
           "name": "M. Kirkby"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V70"
     },
     {
       "id": "v70-male",
@@ -283,7 +321,9 @@
           "position": 2,
           "name": "A. Appleby"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V70"
     },
     {
       "id": "v75-female",
@@ -292,7 +332,9 @@
           "position": 1,
           "name": "P. Binns"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V75"
     },
     {
       "id": "v75-male",
@@ -301,7 +343,9 @@
           "position": 1,
           "name": "D. Aspin"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V75"
     }
   ],
   "teamAwards": [

--- a/src/data/2023/fell/awards.json
+++ b/src/data/2023/fell/awards.json
@@ -1,58 +1,147 @@
-﻿{
+{
   "teamAwards": [
-    {"id": "overall", "club": "chorley"},
-    {"id": "m40", "club": "chorley"},
-    {"id": "m50", "club": "chorley"},
-    {"id": "m60", "club": "red-rose"},
-    {"id": "women", "club": "red-rose"}
+    {
+      "id": "overall",
+      "club": "chorley"
+    },
+    {
+      "id": "m40",
+      "club": "chorley"
+    },
+    {
+      "id": "m50",
+      "club": "chorley"
+    },
+    {
+      "id": "m60",
+      "club": "red-rose"
+    },
+    {
+      "id": "women",
+      "club": "red-rose"
+    }
   ],
   "individualAwards": [
     {
       "id": "sen-m",
       "awards": [
-        {"position": 1, "name": "Alek Walker", "club": "wesham", "ageCategory": "M"},
-        {"position": 3, "name": "Christopher Bridge", "club": "red-rose", "ageCategory": "M"}
-      ]
+        {
+          "position": 1,
+          "name": "Alek Walker",
+          "club": "wesham",
+          "ageCategory": "M"
+        },
+        {
+          "position": 3,
+          "name": "Christopher Bridge",
+          "club": "red-rose",
+          "ageCategory": "M"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "SEN"
     },
     {
       "id": "m40",
       "awards": [
-        {"position": 1, "name": "David Cowburn", "club": "chorley", "ageCategory": "M40"},
-        {"position": 2, "name": "Steve Myerscough", "club": "wesham", "ageCategory": "M40"}
-      ]
+        {
+          "position": 1,
+          "name": "David Cowburn",
+          "club": "chorley",
+          "ageCategory": "M40"
+        },
+        {
+          "position": 2,
+          "name": "Steve Myerscough",
+          "club": "wesham",
+          "ageCategory": "M40"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "m50",
       "awards": [
-        {"position": 1, "name": "Darren McDermott", "club": "preston", "ageCategory": "M50"},
-        {"position": 2, "name": "Carl Groome", "club": "wesham", "ageCategory": "M50"}
-      ]
+        {
+          "position": 1,
+          "name": "Darren McDermott",
+          "club": "preston",
+          "ageCategory": "M50"
+        },
+        {
+          "position": 2,
+          "name": "Carl Groome",
+          "club": "wesham",
+          "ageCategory": "M50"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "m60",
       "awards": [
-        {"position": 1, "name": "Steve Baker", "club": "chorley", "ageCategory": "M60"},
-        {"position": 2, "name": "Philip Butler", "club": "red-rose", "ageCategory": "M60"}
-      ]
+        {
+          "position": 1,
+          "name": "Steve Baker",
+          "club": "chorley",
+          "ageCategory": "M60"
+        },
+        {
+          "position": 2,
+          "name": "Philip Butler",
+          "club": "red-rose",
+          "ageCategory": "M60"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     },
     {
       "id": "f-sen",
       "awards": [
-        {"position": 1, "name": "Kay Twist", "club": "wesham", "ageCategory": "F50"},
-        {"position": 3, "name": "Julia Rolfe", "club": "lytham", "ageCategory": "F60"}
-      ]
+        {
+          "position": 1,
+          "name": "Kay Twist",
+          "club": "wesham",
+          "ageCategory": "F50"
+        },
+        {
+          "position": 3,
+          "name": "Julia Rolfe",
+          "club": "lytham",
+          "ageCategory": "F60"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "SEN"
     },
     {
       "id": "f40",
       "awards": [
-        {"position": 1, "name": "Olga Wiggins", "club": "preston", "ageCategory": "F40"}
-      ]
+        {
+          "position": 1,
+          "name": "Olga Wiggins",
+          "club": "preston",
+          "ageCategory": "F40"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V40"
     },
     {
       "id": "f50",
       "awards": [
-        {"position": 1, "name": "Claire McDermott", "club": "preston", "ageCategory": "F50"}
-      ]
+        {
+          "position": 1,
+          "name": "Claire McDermott",
+          "club": "preston",
+          "ageCategory": "F50"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     }
   ]
 }

--- a/src/data/2023/fell/awards.json
+++ b/src/data/2023/fell/awards.json
@@ -23,7 +23,7 @@
   ],
   "individualAwards": [
     {
-      "id": "sen-m",
+      "id": "m-sen",
       "awards": [
         {
           "position": 1,
@@ -42,7 +42,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "m40",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -61,7 +61,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "m50",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -80,7 +80,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "m60",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,
@@ -118,7 +118,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "f40",
+      "id": "f-v40",
       "awards": [
         {
           "position": 1,
@@ -131,7 +131,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "f50",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,

--- a/src/data/2023/road-gp/awards.json
+++ b/src/data/2023/road-gp/awards.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "teamAwards": [],
   "individualAwards": [
     {
@@ -22,7 +22,8 @@
           "club": "preston",
           "ageCategory": "SEN"
         }
-      ]
+      ],
+      "sex": "F"
     },
     {
       "id": "male",
@@ -45,7 +46,8 @@
           "club": "preston",
           "ageCategory": "SEN"
         }
-      ]
+      ],
+      "sex": "M"
     },
     {
       "id": "jun-female",
@@ -58,7 +60,9 @@
           "position": 2,
           "name": "E. Leonard"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "JUN"
     },
     {
       "id": "jun-male",
@@ -71,7 +75,9 @@
           "position": 2,
           "name": "N. Cox"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "JUN"
     },
     {
       "id": "sen-female",
@@ -84,7 +90,9 @@
           "position": 2,
           "name": "K. Gurley"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "SEN"
     },
     {
       "id": "sen-male",
@@ -97,7 +105,9 @@
           "position": 2,
           "name": "G. Matthew"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "SEN"
     },
     {
       "id": "v35-female",
@@ -110,7 +120,9 @@
           "position": 2,
           "name": "S. Edwards"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V35"
     },
     {
       "id": "v40-female",
@@ -123,7 +135,9 @@
           "position": 2,
           "name": "K. Dewhirst"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V40"
     },
     {
       "id": "v40-male",
@@ -136,7 +150,9 @@
           "position": 2,
           "name": "M. Osinski-Gray"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "v45-female",
@@ -149,7 +165,9 @@
           "position": 2,
           "name": "C. Taylor"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V45"
     },
     {
       "id": "v45-male",
@@ -162,7 +180,9 @@
           "position": 2,
           "name": "M. Finlayson"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V45"
     },
     {
       "id": "v50-female",
@@ -175,7 +195,9 @@
           "position": 2,
           "name": "S. Leonard"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     },
     {
       "id": "v50-male",
@@ -188,7 +210,9 @@
           "position": 2,
           "name": "S. Ross"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "v55-female",
@@ -201,7 +225,9 @@
           "position": 2,
           "name": "C. Sullivan"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V55"
     },
     {
       "id": "v55-male",
@@ -214,7 +240,9 @@
           "position": 2,
           "name": "D. Watson"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V55"
     },
     {
       "id": "v60-female",
@@ -227,7 +255,9 @@
           "position": 2,
           "name": "B. Wilding"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V60"
     },
     {
       "id": "v60-male",
@@ -240,7 +270,9 @@
           "position": 2,
           "name": "A. Neal"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     },
     {
       "id": "v65-male",
@@ -253,7 +285,9 @@
           "position": 2,
           "name": "P. Quibell"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V65"
     },
     {
       "id": "v70-male",
@@ -262,7 +296,9 @@
           "position": 1,
           "name": "A. Hudson"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V70"
     },
     {
       "id": "v75-female",
@@ -271,7 +307,9 @@
           "position": 1,
           "name": "H. Goorney"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V75"
     },
     {
       "id": "v75-male",
@@ -284,7 +322,9 @@
           "position": 2,
           "name": "S. Young"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V75"
     }
   ]
 }

--- a/src/data/2023/road-gp/awards.json
+++ b/src/data/2023/road-gp/awards.json
@@ -2,7 +2,7 @@
   "teamAwards": [],
   "individualAwards": [
     {
-      "id": "female",
+      "id": "f",
       "awards": [
         {
           "position": 1,
@@ -26,7 +26,7 @@
       "sex": "F"
     },
     {
-      "id": "male",
+      "id": "m",
       "awards": [
         {
           "position": 1,
@@ -50,7 +50,7 @@
       "sex": "M"
     },
     {
-      "id": "jun-female",
+      "id": "f-jun",
       "awards": [
         {
           "position": 1,
@@ -65,7 +65,7 @@
       "ageCategory": "JUN"
     },
     {
-      "id": "jun-male",
+      "id": "m-jun",
       "awards": [
         {
           "position": 1,
@@ -80,7 +80,7 @@
       "ageCategory": "JUN"
     },
     {
-      "id": "sen-female",
+      "id": "f-sen",
       "awards": [
         {
           "position": 1,
@@ -95,7 +95,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "sen-male",
+      "id": "m-sen",
       "awards": [
         {
           "position": 1,
@@ -110,7 +110,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "v35-female",
+      "id": "f-v35",
       "awards": [
         {
           "position": 1,
@@ -125,7 +125,7 @@
       "ageCategory": "V35"
     },
     {
-      "id": "v40-female",
+      "id": "f-v40",
       "awards": [
         {
           "position": 1,
@@ -140,7 +140,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v40-male",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -155,7 +155,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v45-female",
+      "id": "f-v45",
       "awards": [
         {
           "position": 1,
@@ -170,7 +170,7 @@
       "ageCategory": "V45"
     },
     {
-      "id": "v45-male",
+      "id": "m-v45",
       "awards": [
         {
           "position": 1,
@@ -185,7 +185,7 @@
       "ageCategory": "V45"
     },
     {
-      "id": "v50-female",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,
@@ -200,7 +200,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v50-male",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -215,7 +215,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v55-female",
+      "id": "f-v55",
       "awards": [
         {
           "position": 1,
@@ -230,7 +230,7 @@
       "ageCategory": "V55"
     },
     {
-      "id": "v55-male",
+      "id": "m-v55",
       "awards": [
         {
           "position": 1,
@@ -245,7 +245,7 @@
       "ageCategory": "V55"
     },
     {
-      "id": "v60-female",
+      "id": "f-v60",
       "awards": [
         {
           "position": 1,
@@ -260,7 +260,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "v60-male",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,
@@ -275,7 +275,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "v65-male",
+      "id": "m-v65",
       "awards": [
         {
           "position": 1,
@@ -290,7 +290,7 @@
       "ageCategory": "V65"
     },
     {
-      "id": "v70-male",
+      "id": "m-v70",
       "awards": [
         {
           "position": 1,
@@ -301,7 +301,7 @@
       "ageCategory": "V70"
     },
     {
-      "id": "v75-female",
+      "id": "f-v75",
       "awards": [
         {
           "position": 1,
@@ -312,7 +312,7 @@
       "ageCategory": "V75"
     },
     {
-      "id": "v75-male",
+      "id": "m-v75",
       "awards": [
         {
           "position": 1,

--- a/src/data/2024/fell/awards.json
+++ b/src/data/2024/fell/awards.json
@@ -23,7 +23,7 @@
   ],
   "individualAwards": [
     {
-      "id": "male",
+      "id": "m",
       "awards": [
         {
           "position": 1,
@@ -39,7 +39,7 @@
       "sex": "M"
     },
     {
-      "id": "v40-male",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -56,7 +56,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v50-male",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -68,7 +68,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v60-male",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,
@@ -80,7 +80,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "female",
+      "id": "f",
       "awards": [
         {
           "position": 1,
@@ -91,7 +91,7 @@
       "sex": "F"
     },
     {
-      "id": "v50-female",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,

--- a/src/data/2024/fell/awards.json
+++ b/src/data/2024/fell/awards.json
@@ -1,49 +1,106 @@
-﻿{
+{
   "teamAwards": [
-    { "id": "open", "club": "preston" },
-    { "id": "ladies", "club": "red-rose" },
-    { "id": "vets", "club": "preston" },
-    { "id": "v50", "club": "preston" },
-    { "id": "v60", "club": "lytham" }
+    {
+      "id": "open",
+      "club": "preston"
+    },
+    {
+      "id": "ladies",
+      "club": "red-rose"
+    },
+    {
+      "id": "vets",
+      "club": "preston"
+    },
+    {
+      "id": "v50",
+      "club": "preston"
+    },
+    {
+      "id": "v60",
+      "club": "lytham"
+    }
   ],
   "individualAwards": [
     {
       "id": "male",
       "awards": [
-        { "position": 1, "name": "Patrick Brown", "club": "preston" },
-        { "position": 2, "name": "Alistair Palmer", "club": "preston" }
-      ]
+        {
+          "position": 1,
+          "name": "Patrick Brown",
+          "club": "preston"
+        },
+        {
+          "position": 2,
+          "name": "Alistair Palmer",
+          "club": "preston"
+        }
+      ],
+      "sex": "M"
     },
     {
       "id": "v40-male",
       "awards": [
-        { "position": 1, "name": "Andy Cottam", "club": "chorley" },
-        { "position": 2, "name": "Dan Edwards", "club": "lytham" }
-      ]
+        {
+          "position": 1,
+          "name": "Andy Cottam",
+          "club": "chorley"
+        },
+        {
+          "position": 2,
+          "name": "Dan Edwards",
+          "club": "lytham"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "v50-male",
       "awards": [
-        { "position": 1, "name": "Paul Bass", "club": "wesham" }
-      ]
+        {
+          "position": 1,
+          "name": "Paul Bass",
+          "club": "wesham"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "v60-male",
       "awards": [
-        { "position": 1, "name": "Philip Butler", "club": "lytham" }
-      ]
+        {
+          "position": 1,
+          "name": "Philip Butler",
+          "club": "lytham"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     },
     {
       "id": "female",
       "awards": [
-        { "position": 1, "name": "Basia Pawelczak", "club": "blackpool" }
-      ]
+        {
+          "position": 1,
+          "name": "Basia Pawelczak",
+          "club": "blackpool"
+        }
+      ],
+      "sex": "F"
     },
     {
       "id": "v50-female",
       "awards": [
-        { "position": 1, "name": "Kay Twist", "club": "lytham" }
-      ]
+        {
+          "position": 1,
+          "name": "Kay Twist",
+          "club": "lytham"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     }
   ]
 }

--- a/src/data/2024/road-gp/awards.json
+++ b/src/data/2024/road-gp/awards.json
@@ -2,7 +2,7 @@
   "teamAwards": [],
   "individualAwards": [
     {
-      "id": "female",
+      "id": "f",
       "awards": [
         {
           "position": 1,
@@ -26,7 +26,7 @@
       "sex": "F"
     },
     {
-      "id": "male",
+      "id": "m",
       "awards": [
         {
           "position": 1,
@@ -50,7 +50,7 @@
       "sex": "M"
     },
     {
-      "id": "jun-male",
+      "id": "m-jun",
       "awards": [
         {
           "position": 1,
@@ -65,7 +65,7 @@
       "ageCategory": "JUN"
     },
     {
-      "id": "sen-female",
+      "id": "f-sen",
       "awards": [
         {
           "position": 1,
@@ -80,7 +80,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "sen-male",
+      "id": "m-sen",
       "awards": [
         {
           "position": 1,
@@ -95,7 +95,7 @@
       "ageCategory": "SEN"
     },
     {
-      "id": "v35-female",
+      "id": "f-v35",
       "awards": [
         {
           "position": 1,
@@ -110,7 +110,7 @@
       "ageCategory": "V35"
     },
     {
-      "id": "v40-female",
+      "id": "f-v40",
       "awards": [
         {
           "position": 1,
@@ -125,7 +125,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v40-male",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -140,7 +140,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v45-female",
+      "id": "f-v45",
       "awards": [
         {
           "position": 1,
@@ -155,7 +155,7 @@
       "ageCategory": "V45"
     },
     {
-      "id": "v45-male",
+      "id": "m-v45",
       "awards": [
         {
           "position": 1,
@@ -170,7 +170,7 @@
       "ageCategory": "V45"
     },
     {
-      "id": "v50-female",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,
@@ -185,7 +185,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v50-male",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -200,7 +200,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v55-female",
+      "id": "f-v55",
       "awards": [
         {
           "position": 1,
@@ -215,7 +215,7 @@
       "ageCategory": "V55"
     },
     {
-      "id": "v55-male",
+      "id": "m-v55",
       "awards": [
         {
           "position": 1,
@@ -230,7 +230,7 @@
       "ageCategory": "V55"
     },
     {
-      "id": "v60-female",
+      "id": "f-v60",
       "awards": [
         {
           "position": 1,
@@ -245,7 +245,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "v60-male",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,
@@ -260,7 +260,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "v65-female",
+      "id": "f-v65",
       "awards": [
         {
           "position": 1,
@@ -275,7 +275,7 @@
       "ageCategory": "V65"
     },
     {
-      "id": "v65-male",
+      "id": "m-v65",
       "awards": [
         {
           "position": 1,
@@ -290,7 +290,7 @@
       "ageCategory": "V65"
     },
     {
-      "id": "v70-female",
+      "id": "f-v70",
       "awards": [
         {
           "position": 1,
@@ -301,7 +301,7 @@
       "ageCategory": "V70"
     },
     {
-      "id": "v70-male",
+      "id": "m-v70",
       "awards": [
         {
           "position": 1,
@@ -316,7 +316,7 @@
       "ageCategory": "V70"
     },
     {
-      "id": "v75-male",
+      "id": "m-v75",
       "awards": [
         {
           "position": 1,
@@ -327,7 +327,7 @@
       "ageCategory": "V75"
     },
     {
-      "id": "v80-female",
+      "id": "f-v80",
       "awards": [
         {
           "position": 1,

--- a/src/data/2024/road-gp/awards.json
+++ b/src/data/2024/road-gp/awards.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "teamAwards": [],
   "individualAwards": [
     {
@@ -22,7 +22,8 @@
           "club": "preston",
           "ageCategory": "SEN"
         }
-      ]
+      ],
+      "sex": "F"
     },
     {
       "id": "male",
@@ -45,7 +46,8 @@
           "club": "preston",
           "ageCategory": "SEN"
         }
-      ]
+      ],
+      "sex": "M"
     },
     {
       "id": "jun-male",
@@ -58,7 +60,9 @@
           "position": 2,
           "name": "N. Burrill"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "JUN"
     },
     {
       "id": "sen-female",
@@ -71,7 +75,9 @@
           "position": 2,
           "name": "K. Littlefair"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "SEN"
     },
     {
       "id": "sen-male",
@@ -84,7 +90,9 @@
           "position": 2,
           "name": "S. Evans"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "SEN"
     },
     {
       "id": "v35-female",
@@ -97,7 +105,9 @@
           "position": 2,
           "name": "E. Watson"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V35"
     },
     {
       "id": "v40-female",
@@ -110,7 +120,9 @@
           "position": 2,
           "name": "R. Courtney"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V40"
     },
     {
       "id": "v40-male",
@@ -123,7 +135,9 @@
           "position": 2,
           "name": "T. Bamber"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "v45-female",
@@ -136,7 +150,9 @@
           "position": 2,
           "name": "C. Taylor"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V45"
     },
     {
       "id": "v45-male",
@@ -149,7 +165,9 @@
           "position": 2,
           "name": "M. Finlayson"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V45"
     },
     {
       "id": "v50-female",
@@ -162,7 +180,9 @@
           "position": 2,
           "name": "S. Leonard"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     },
     {
       "id": "v50-male",
@@ -175,7 +195,9 @@
           "position": 2,
           "name": "S. Hallas"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "v55-female",
@@ -188,7 +210,9 @@
           "position": 2,
           "name": "C. Sullivan"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V55"
     },
     {
       "id": "v55-male",
@@ -201,7 +225,9 @@
           "position": 2,
           "name": "M. Hall"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V55"
     },
     {
       "id": "v60-female",
@@ -214,7 +240,9 @@
           "position": 2,
           "name": "B. Wright"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V60"
     },
     {
       "id": "v60-male",
@@ -227,7 +255,9 @@
           "position": 2,
           "name": "N. Hayhurst"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     },
     {
       "id": "v65-female",
@@ -240,7 +270,9 @@
           "position": 2,
           "name": "H. Whelan"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V65"
     },
     {
       "id": "v65-male",
@@ -253,7 +285,9 @@
           "position": 2,
           "name": "G. Kennedy"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V65"
     },
     {
       "id": "v70-female",
@@ -262,7 +296,9 @@
           "position": 1,
           "name": "M. Kirkby"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V70"
     },
     {
       "id": "v70-male",
@@ -275,7 +311,9 @@
           "position": 2,
           "name": "A. Hudson"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V70"
     },
     {
       "id": "v75-male",
@@ -284,7 +322,9 @@
           "position": 1,
           "name": "A. Appleby"
         }
-      ]
+      ],
+      "sex": "M",
+      "ageCategory": "V75"
     },
     {
       "id": "v80-female",
@@ -293,7 +333,9 @@
           "position": 1,
           "name": "H. Goorney"
         }
-      ]
+      ],
+      "sex": "F",
+      "ageCategory": "V80"
     }
   ]
 }

--- a/src/data/2025/fell/awards.json
+++ b/src/data/2025/fell/awards.json
@@ -23,7 +23,7 @@
   ],
   "individualAwards": [
     {
-      "id": "male",
+      "id": "m",
       "awards": [
         {
           "position": 1,
@@ -44,7 +44,7 @@
       "sex": "M"
     },
     {
-      "id": "female",
+      "id": "f",
       "awards": [
         {
           "position": 1,
@@ -60,7 +60,7 @@
       "sex": "F"
     },
     {
-      "id": "v40-male",
+      "id": "m-v40",
       "awards": [
         {
           "position": 1,
@@ -77,7 +77,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v40-female",
+      "id": "f-v40",
       "awards": [
         {
           "position": 1,
@@ -94,7 +94,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "v50-male",
+      "id": "m-v50",
       "awards": [
         {
           "position": 1,
@@ -111,7 +111,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v50-female",
+      "id": "f-v50",
       "awards": [
         {
           "position": 1,
@@ -123,7 +123,7 @@
       "ageCategory": "V50"
     },
     {
-      "id": "v60-male",
+      "id": "m-v60",
       "awards": [
         {
           "position": 1,

--- a/src/data/2025/fell/awards.json
+++ b/src/data/2025/fell/awards.json
@@ -1,60 +1,143 @@
-﻿{
+{
   "teamAwards": [
-    { "id": "open", "club": "wesham" },
-    { "id": "ladies", "club": "blackpool" },
-    { "id": "vets", "club": "chorley" },
-    { "id": "v50", "club": "chorley" },
-    { "id": "v60", "club": "red-rose" }
+    {
+      "id": "open",
+      "club": "wesham"
+    },
+    {
+      "id": "ladies",
+      "club": "blackpool"
+    },
+    {
+      "id": "vets",
+      "club": "chorley"
+    },
+    {
+      "id": "v50",
+      "club": "chorley"
+    },
+    {
+      "id": "v60",
+      "club": "red-rose"
+    }
   ],
   "individualAwards": [
     {
       "id": "male",
       "awards": [
-        { "position": 1, "name": "A. Palmer", "club": "preston" },
-        { "position": 2, "name": "T. Belcher", "club": "chorley" },
-        { "position": 3, "name": "T. Crabtree", "club": "wesham" }
-      ]
+        {
+          "position": 1,
+          "name": "A. Palmer",
+          "club": "preston"
+        },
+        {
+          "position": 2,
+          "name": "T. Belcher",
+          "club": "chorley"
+        },
+        {
+          "position": 3,
+          "name": "T. Crabtree",
+          "club": "wesham"
+        }
+      ],
+      "sex": "M"
     },
     {
       "id": "female",
       "awards": [
-        { "position": 1, "name": "B. Pawelczak", "club": "blackpool" },
-        { "position": 2, "name": "O. Wiggans", "club": "chorley" }
-      ]
+        {
+          "position": 1,
+          "name": "B. Pawelczak",
+          "club": "blackpool"
+        },
+        {
+          "position": 2,
+          "name": "O. Wiggans",
+          "club": "chorley"
+        }
+      ],
+      "sex": "F"
     },
     {
       "id": "v40-male",
       "awards": [
-        { "position": 1, "name": "C. Banks", "club": "wesham" },
-        { "position": 2, "name": "A. Walker", "club": "wesham" }
-      ]
+        {
+          "position": 1,
+          "name": "C. Banks",
+          "club": "wesham"
+        },
+        {
+          "position": 2,
+          "name": "A. Walker",
+          "club": "wesham"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V40"
     },
     {
       "id": "v40-female",
       "awards": [
-        { "position": 1, "name": "J. Hall", "club": "blackpool" },
-        { "position": 2, "name": "O. Wiggins", "club": "preston" }
-      ]
+        {
+          "position": 1,
+          "name": "J. Hall",
+          "club": "blackpool"
+        },
+        {
+          "position": 2,
+          "name": "O. Wiggins",
+          "club": "preston"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V40"
     },
     {
       "id": "v50-male",
       "awards": [
-        { "position": 1, "name": "D. McDermott", "club": "preston" },
-        { "position": 2, "name": "P. Bass", "club": "chorley" }
-      ]
+        {
+          "position": 1,
+          "name": "D. McDermott",
+          "club": "preston"
+        },
+        {
+          "position": 2,
+          "name": "P. Bass",
+          "club": "chorley"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V50"
     },
     {
       "id": "v50-female",
       "awards": [
-        { "position": 1, "name": "L. Lawler", "club": "blackpool" }
-      ]
+        {
+          "position": 1,
+          "name": "L. Lawler",
+          "club": "blackpool"
+        }
+      ],
+      "sex": "F",
+      "ageCategory": "V50"
     },
     {
       "id": "v60-male",
       "awards": [
-        { "position": 1, "name": "J. Griffiths", "club": "preston" },
-        { "position": 2, "name": "P. Butler", "club": "red-rose" }
-      ]
+        {
+          "position": 1,
+          "name": "J. Griffiths",
+          "club": "preston"
+        },
+        {
+          "position": 2,
+          "name": "P. Butler",
+          "club": "red-rose"
+        }
+      ],
+      "sex": "M",
+      "ageCategory": "V60"
     }
   ]
 }

--- a/src/data/2025/road-gp/awards.json
+++ b/src/data/2025/road-gp/awards.json
@@ -1,392 +1,452 @@
-﻿{
-    "teamAwards":  [
-                       { "id": "open",      "club": "preston" },
-                       { "id": "ladies",    "club": "preston" },
-                       { "id": "vets",      "club": "wesham"  },
-                       { "id": "lady-vets", "club": "lytham"  },
-                       { "id": "v50",       "club": "preston" },
-                       { "id": "v60",       "club": "preston" }
-                   ],
-    "individualAwards":  [
-                             {
-                                 "id":  "female",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Katie Littlefair",
-                                                    "club":  "preston",
-                                                    "ageCategory": "SEN",
-                                                    "seriesRunnerId":  164
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Emma Watson",
-                                                    "club":  "preston",
-                                                    "ageCategory": "V35",
-                                                    "seriesRunnerId":  185
-                                                },
-                                                {
-                                                    "position":  3,
-                                                    "name":  "Cass Chisholm",
-                                                    "club":  "lytham",
-                                                    "ageCategory": "V40",
-                                                    "seriesRunnerId":  497
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "male",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Luke Minns",
-                                                    "club":  "blackpool",
-                                                    "ageCategory": "SEN",
-                                                    "seriesRunnerId":  474
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Rob Danson",
-                                                    "club":  "preston",
-                                                    "ageCategory": "SEN",
-                                                    "seriesRunnerId":  100
-                                                },
-                                                {
-                                                    "position":  3,
-                                                    "name":  "Sam Evans",
-                                                    "club":  "preston",
-                                                    "ageCategory": "SEN",
-                                                    "seriesRunnerId":  475
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "jun-female",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Lucy Dewhurst",
-                                                    "seriesRunnerId":  358,
-                                                    "club":  "red-rose"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "jun-male",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Luke Suffolk",
-                                                    "seriesRunnerId":  105,
-                                                    "club":  "preston"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Craig Sarson",
-                                                    "seriesRunnerId":  134,
-                                                    "club":  "chorley"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "sen-female",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Melissa Metcalf",
-                                                    "seriesRunnerId":  504,
-                                                    "club":  "preston"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Charlotte Gregory",
-                                                    "seriesRunnerId":  368,
-                                                    "club":  "preston"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "sen-male",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Mike Toft",
-                                                    "seriesRunnerId":  102,
-                                                    "club":  "lytham"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Adam Wilding",
-                                                    "seriesRunnerId":  103,
-                                                    "club":  "wesham"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v35-female",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Leanne Neild",
-                                                    "seriesRunnerId":  192,
-                                                    "club":  "lytham"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Hannah Bruce",
-                                                    "seriesRunnerId":  212,
-                                                    "club":  "preston"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v40-female",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Gill Draper",
-                                                    "seriesRunnerId":  166,
-                                                    "club":  "lytham"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Emma Lund",
-                                                    "seriesRunnerId":  287,
-                                                    "club":  "wesham"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v40-male",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Simon Croft",
-                                                    "seriesRunnerId":  478,
-                                                    "club":  "red-rose"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Mark Belfield",
-                                                    "seriesRunnerId":  124,
-                                                    "club":  "wesham"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v45-female",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Janette Rayton",
-                                                    "seriesRunnerId":  518,
-                                                    "club":  "red-rose"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Clare Taylor",
-                                                    "seriesRunnerId":  253,
-                                                    "club":  "lytham"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v45-male",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Tom Bamber",
-                                                    "seriesRunnerId":  106,
-                                                    "club":  "wesham"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Andy Cottam",
-                                                    "seriesRunnerId":  127,
-                                                    "club":  "preston"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v50-female",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Elizabeth Horne",
-                                                    "seriesRunnerId":  245,
-                                                    "club":  "preston"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Tracey Mullan",
-                                                    "seriesRunnerId":  236,
-                                                    "club":  "thornton"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v50-male",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Robert Walsh",
-                                                    "seriesRunnerId":  125,
-                                                    "club":  "chorley"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Jonathan Tuck",
-                                                    "seriesRunnerId":  491,
-                                                    "club":  "lytham"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v55-female",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Susan Coulthurst",
-                                                    "seriesRunnerId":  219,
-                                                    "club":  "wesham"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Jo Goorney",
-                                                    "seriesRunnerId":  241,
-                                                    "club":  "lytham"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v55-male",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "David Parkinson",
-                                                    "seriesRunnerId":  168,
-                                                    "club":  "red-rose"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Carl Groome",
-                                                    "seriesRunnerId":  186,
-                                                    "club":  "wesham"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v60-female",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Jane Hodkinson",
-                                                    "seriesRunnerId":  326,
-                                                    "club":  "preston"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Alison Bowden",
-                                                    "seriesRunnerId":  311,
-                                                    "club":  "thornton"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v60-male",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Mark Lee",
-                                                    "seriesRunnerId":  171,
-                                                    "club":  "preston"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "David Lea",
-                                                    "seriesRunnerId":  144,
-                                                    "club":  "preston"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v65-female",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Barbara Holmes",
-                                                    "seriesRunnerId":  527,
-                                                    "club":  "lytham"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Heather Whelan",
-                                                    "seriesRunnerId":  413,
-                                                    "club":  "red-rose"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v65-male",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Michael Edge",
-                                                    "seriesRunnerId":  223,
-                                                    "club":  "wesham"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Nigel Shepherd",
-                                                    "seriesRunnerId":  244,
-                                                    "club":  "wesham"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v70-female",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Maureen Kirkby",
-                                                    "seriesRunnerId":  441,
-                                                    "club":  "preston"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v70-male",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Philip Quibell",
-                                                    "seriesRunnerId":  222,
-                                                    "club":  "wesham"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Graham Webster",
-                                                    "seriesRunnerId":  308,
-                                                    "club":  "lytham"
-                                                }
-                                            ]
-                             },
-                             {
-                                 "id":  "v75-male",
-                                 "awards":  [
-                                                {
-                                                    "position":  1,
-                                                    "name":  "Alan Appleby",
-                                                    "seriesRunnerId":  373,
-                                                    "club":  "preston"
-                                                },
-                                                {
-                                                    "position":  2,
-                                                    "name":  "Simon David Young",
-                                                    "seriesRunnerId":  564,
-                                                    "club":  "wesham"
-                                                }
-                                            ]
-                             }
-                         ]
+{
+    "teamAwards": [
+        {
+            "id": "open",
+            "club": "preston"
+        },
+        {
+            "id": "ladies",
+            "club": "preston"
+        },
+        {
+            "id": "vets",
+            "club": "wesham"
+        },
+        {
+            "id": "lady-vets",
+            "club": "lytham"
+        },
+        {
+            "id": "v50",
+            "club": "preston"
+        },
+        {
+            "id": "v60",
+            "club": "preston"
+        }
+    ],
+    "individualAwards": [
+        {
+            "id": "female",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Katie Littlefair",
+                    "club": "preston",
+                    "ageCategory": "SEN",
+                    "seriesRunnerId": 164
+                },
+                {
+                    "position": 2,
+                    "name": "Emma Watson",
+                    "club": "preston",
+                    "ageCategory": "V35",
+                    "seriesRunnerId": 185
+                },
+                {
+                    "position": 3,
+                    "name": "Cass Chisholm",
+                    "club": "lytham",
+                    "ageCategory": "V40",
+                    "seriesRunnerId": 497
+                }
+            ],
+            "sex": "F"
+        },
+        {
+            "id": "male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Luke Minns",
+                    "club": "blackpool",
+                    "ageCategory": "SEN",
+                    "seriesRunnerId": 474
+                },
+                {
+                    "position": 2,
+                    "name": "Rob Danson",
+                    "club": "preston",
+                    "ageCategory": "SEN",
+                    "seriesRunnerId": 100
+                },
+                {
+                    "position": 3,
+                    "name": "Sam Evans",
+                    "club": "preston",
+                    "ageCategory": "SEN",
+                    "seriesRunnerId": 475
+                }
+            ],
+            "sex": "M"
+        },
+        {
+            "id": "jun-female",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Lucy Dewhurst",
+                    "seriesRunnerId": 358,
+                    "club": "red-rose"
+                }
+            ],
+            "sex": "F",
+            "ageCategory": "JUN"
+        },
+        {
+            "id": "jun-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Luke Suffolk",
+                    "seriesRunnerId": 105,
+                    "club": "preston"
+                },
+                {
+                    "position": 2,
+                    "name": "Craig Sarson",
+                    "seriesRunnerId": 134,
+                    "club": "chorley"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "JUN"
+        },
+        {
+            "id": "sen-female",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Melissa Metcalf",
+                    "seriesRunnerId": 504,
+                    "club": "preston"
+                },
+                {
+                    "position": 2,
+                    "name": "Charlotte Gregory",
+                    "seriesRunnerId": 368,
+                    "club": "preston"
+                }
+            ],
+            "sex": "F",
+            "ageCategory": "SEN"
+        },
+        {
+            "id": "sen-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Mike Toft",
+                    "seriesRunnerId": 102,
+                    "club": "lytham"
+                },
+                {
+                    "position": 2,
+                    "name": "Adam Wilding",
+                    "seriesRunnerId": 103,
+                    "club": "wesham"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "SEN"
+        },
+        {
+            "id": "v35-female",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Leanne Neild",
+                    "seriesRunnerId": 192,
+                    "club": "lytham"
+                },
+                {
+                    "position": 2,
+                    "name": "Hannah Bruce",
+                    "seriesRunnerId": 212,
+                    "club": "preston"
+                }
+            ],
+            "sex": "F",
+            "ageCategory": "V35"
+        },
+        {
+            "id": "v40-female",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Gill Draper",
+                    "seriesRunnerId": 166,
+                    "club": "lytham"
+                },
+                {
+                    "position": 2,
+                    "name": "Emma Lund",
+                    "seriesRunnerId": 287,
+                    "club": "wesham"
+                }
+            ],
+            "sex": "F",
+            "ageCategory": "V40"
+        },
+        {
+            "id": "v40-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Simon Croft",
+                    "seriesRunnerId": 478,
+                    "club": "red-rose"
+                },
+                {
+                    "position": 2,
+                    "name": "Mark Belfield",
+                    "seriesRunnerId": 124,
+                    "club": "wesham"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V40"
+        },
+        {
+            "id": "v45-female",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Janette Rayton",
+                    "seriesRunnerId": 518,
+                    "club": "red-rose"
+                },
+                {
+                    "position": 2,
+                    "name": "Clare Taylor",
+                    "seriesRunnerId": 253,
+                    "club": "lytham"
+                }
+            ],
+            "sex": "F",
+            "ageCategory": "V45"
+        },
+        {
+            "id": "v45-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Tom Bamber",
+                    "seriesRunnerId": 106,
+                    "club": "wesham"
+                },
+                {
+                    "position": 2,
+                    "name": "Andy Cottam",
+                    "seriesRunnerId": 127,
+                    "club": "preston"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V45"
+        },
+        {
+            "id": "v50-female",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Elizabeth Horne",
+                    "seriesRunnerId": 245,
+                    "club": "preston"
+                },
+                {
+                    "position": 2,
+                    "name": "Tracey Mullan",
+                    "seriesRunnerId": 236,
+                    "club": "thornton"
+                }
+            ],
+            "sex": "F",
+            "ageCategory": "V50"
+        },
+        {
+            "id": "v50-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Robert Walsh",
+                    "seriesRunnerId": 125,
+                    "club": "chorley"
+                },
+                {
+                    "position": 2,
+                    "name": "Jonathan Tuck",
+                    "seriesRunnerId": 491,
+                    "club": "lytham"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V50"
+        },
+        {
+            "id": "v55-female",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Susan Coulthurst",
+                    "seriesRunnerId": 219,
+                    "club": "wesham"
+                },
+                {
+                    "position": 2,
+                    "name": "Jo Goorney",
+                    "seriesRunnerId": 241,
+                    "club": "lytham"
+                }
+            ],
+            "sex": "F",
+            "ageCategory": "V55"
+        },
+        {
+            "id": "v55-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "David Parkinson",
+                    "seriesRunnerId": 168,
+                    "club": "red-rose"
+                },
+                {
+                    "position": 2,
+                    "name": "Carl Groome",
+                    "seriesRunnerId": 186,
+                    "club": "wesham"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V55"
+        },
+        {
+            "id": "v60-female",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Jane Hodkinson",
+                    "seriesRunnerId": 326,
+                    "club": "preston"
+                },
+                {
+                    "position": 2,
+                    "name": "Alison Bowden",
+                    "seriesRunnerId": 311,
+                    "club": "thornton"
+                }
+            ],
+            "sex": "F",
+            "ageCategory": "V60"
+        },
+        {
+            "id": "v60-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Mark Lee",
+                    "seriesRunnerId": 171,
+                    "club": "preston"
+                },
+                {
+                    "position": 2,
+                    "name": "David Lea",
+                    "seriesRunnerId": 144,
+                    "club": "preston"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V60"
+        },
+        {
+            "id": "v65-female",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Barbara Holmes",
+                    "seriesRunnerId": 527,
+                    "club": "lytham"
+                },
+                {
+                    "position": 2,
+                    "name": "Heather Whelan",
+                    "seriesRunnerId": 413,
+                    "club": "red-rose"
+                }
+            ],
+            "sex": "F",
+            "ageCategory": "V65"
+        },
+        {
+            "id": "v65-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Michael Edge",
+                    "seriesRunnerId": 223,
+                    "club": "wesham"
+                },
+                {
+                    "position": 2,
+                    "name": "Nigel Shepherd",
+                    "seriesRunnerId": 244,
+                    "club": "wesham"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V65"
+        },
+        {
+            "id": "v70-female",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Maureen Kirkby",
+                    "seriesRunnerId": 441,
+                    "club": "preston"
+                }
+            ],
+            "sex": "F",
+            "ageCategory": "V70"
+        },
+        {
+            "id": "v70-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Philip Quibell",
+                    "seriesRunnerId": 222,
+                    "club": "wesham"
+                },
+                {
+                    "position": 2,
+                    "name": "Graham Webster",
+                    "seriesRunnerId": 308,
+                    "club": "lytham"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V70"
+        },
+        {
+            "id": "v75-male",
+            "awards": [
+                {
+                    "position": 1,
+                    "name": "Alan Appleby",
+                    "seriesRunnerId": 373,
+                    "club": "preston"
+                },
+                {
+                    "position": 2,
+                    "name": "Simon David Young",
+                    "seriesRunnerId": 564,
+                    "club": "wesham"
+                }
+            ],
+            "sex": "M",
+            "ageCategory": "V75"
+        }
+    ]
 }

--- a/src/data/2025/road-gp/awards.json
+++ b/src/data/2025/road-gp/awards.json
@@ -27,7 +27,7 @@
     ],
     "individualAwards": [
         {
-            "id": "female",
+            "id": "f",
             "awards": [
                 {
                     "position": 1,
@@ -54,7 +54,7 @@
             "sex": "F"
         },
         {
-            "id": "male",
+            "id": "m",
             "awards": [
                 {
                     "position": 1,
@@ -81,7 +81,7 @@
             "sex": "M"
         },
         {
-            "id": "jun-female",
+            "id": "f-jun",
             "awards": [
                 {
                     "position": 1,
@@ -94,7 +94,7 @@
             "ageCategory": "JUN"
         },
         {
-            "id": "jun-male",
+            "id": "m-jun",
             "awards": [
                 {
                     "position": 1,
@@ -113,7 +113,7 @@
             "ageCategory": "JUN"
         },
         {
-            "id": "sen-female",
+            "id": "f-sen",
             "awards": [
                 {
                     "position": 1,
@@ -132,7 +132,7 @@
             "ageCategory": "SEN"
         },
         {
-            "id": "sen-male",
+            "id": "m-sen",
             "awards": [
                 {
                     "position": 1,
@@ -151,7 +151,7 @@
             "ageCategory": "SEN"
         },
         {
-            "id": "v35-female",
+            "id": "f-v35",
             "awards": [
                 {
                     "position": 1,
@@ -170,7 +170,7 @@
             "ageCategory": "V35"
         },
         {
-            "id": "v40-female",
+            "id": "f-v40",
             "awards": [
                 {
                     "position": 1,
@@ -189,7 +189,7 @@
             "ageCategory": "V40"
         },
         {
-            "id": "v40-male",
+            "id": "m-v40",
             "awards": [
                 {
                     "position": 1,
@@ -208,7 +208,7 @@
             "ageCategory": "V40"
         },
         {
-            "id": "v45-female",
+            "id": "f-v45",
             "awards": [
                 {
                     "position": 1,
@@ -227,7 +227,7 @@
             "ageCategory": "V45"
         },
         {
-            "id": "v45-male",
+            "id": "m-v45",
             "awards": [
                 {
                     "position": 1,
@@ -246,7 +246,7 @@
             "ageCategory": "V45"
         },
         {
-            "id": "v50-female",
+            "id": "f-v50",
             "awards": [
                 {
                     "position": 1,
@@ -265,7 +265,7 @@
             "ageCategory": "V50"
         },
         {
-            "id": "v50-male",
+            "id": "m-v50",
             "awards": [
                 {
                     "position": 1,
@@ -284,7 +284,7 @@
             "ageCategory": "V50"
         },
         {
-            "id": "v55-female",
+            "id": "f-v55",
             "awards": [
                 {
                     "position": 1,
@@ -303,7 +303,7 @@
             "ageCategory": "V55"
         },
         {
-            "id": "v55-male",
+            "id": "m-v55",
             "awards": [
                 {
                     "position": 1,
@@ -322,7 +322,7 @@
             "ageCategory": "V55"
         },
         {
-            "id": "v60-female",
+            "id": "f-v60",
             "awards": [
                 {
                     "position": 1,
@@ -341,7 +341,7 @@
             "ageCategory": "V60"
         },
         {
-            "id": "v60-male",
+            "id": "m-v60",
             "awards": [
                 {
                     "position": 1,
@@ -360,7 +360,7 @@
             "ageCategory": "V60"
         },
         {
-            "id": "v65-female",
+            "id": "f-v65",
             "awards": [
                 {
                     "position": 1,
@@ -379,7 +379,7 @@
             "ageCategory": "V65"
         },
         {
-            "id": "v65-male",
+            "id": "m-v65",
             "awards": [
                 {
                     "position": 1,
@@ -398,7 +398,7 @@
             "ageCategory": "V65"
         },
         {
-            "id": "v70-female",
+            "id": "f-v70",
             "awards": [
                 {
                     "position": 1,
@@ -411,7 +411,7 @@
             "ageCategory": "V70"
         },
         {
-            "id": "v70-male",
+            "id": "m-v70",
             "awards": [
                 {
                     "position": 1,
@@ -430,7 +430,7 @@
             "ageCategory": "V70"
         },
         {
-            "id": "v75-male",
+            "id": "m-v75",
             "awards": [
                 {
                     "position": 1,

--- a/src/data/2025/road-gp/individual-standings.json
+++ b/src/data/2025/road-gp/individual-standings.json
@@ -1,5 +1,5 @@
 ﻿{
-    "provisional":  true,
+    "provisional":  false,
     "maxCountingRaces":  4,
     "races":  [
                   "blackpool",


### PR DESCRIPTION
## Summary

- Added `sex` and `ageCategory` fields to `individualAwards` entries across all 31 `awards.json` files (2005–2025, both road-gp and fell series)
- Cleared the `provisional` flag on the 2025 Road GP individual standings

## Mapping rules applied

| id pattern | sex | ageCategory |
|---|---|---|
| `overall` | — | — |
| `male`, `*-male`, `*-m`, `m40`, `m50`, `m60` | `M` | — |
| `female`, `ladies`, `lady*`, `women`, `*-f`, `f-*`, `f40`, `f50` | `F` | — |
| `vNN`, `vNN-*`, `*-vNN`, `mNN`, `fNN` | (as above) | `VNN` |
| `sen-*`, `*-sen`, `f-sen` | (as above) | `SEN` |
| `jun-*` | (as above) | `JUN` |

Files with only `overall` entries (1985–2004) were left unchanged. Existing `sex`/`ageCategory` fields were not overwritten.

## Reviewer notes

The `sex` and `ageCategory` fields on `individualAwards` drive column layout on past-year index pages (male=left column, female=right column, neither=full-width) and are resolved via `resolveIndividualCategoryName`. These were missing from all historical files and need to be present for the awards section to render correctly.