### PR TITLE
feat: add client-side fuzzy search

### DIFF
--- a/docs/superpowers/plans/2026-05-19-search.md
+++ b/docs/superpowers/plans/2026-05-19-search.md
@@ -1,0 +1,742 @@
+# Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add client-side fuzzy search to the InterClub static site, covering runners, race detail pages, race results, year archives, and standings pages.
+
+**Architecture:** A build-time Astro API endpoint (`search-index.json.ts`) generates a flat JSON index from existing data-loading functions. A shared `search-client.ts` module wraps Fuse.js with pure helper functions. A navbar `SearchBox.astro` component provides instant dropdown results; a `search.astro` page shows the full grouped result set. The `[raceId].astro` race detail page is restricted to the current year only (previously generated for all years).
+
+**Tech Stack:** Astro v6, Fuse.js, TypeScript, Tailwind CSS / DaisyUI v5, Vitest
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|---|---|---|
+| Create | `src/lib/search-client.ts` | `SearchRecord` type, `createFuse`, `runSearch`, `loadIndex` |
+| Create | `tests/search-client.test.ts` | Unit tests for `createFuse` / `runSearch` |
+| Create | `src/pages/search-index.json.ts` | Build-time API endpoint — outputs flat JSON index |
+| Create | `src/components/SearchBox.astro` | Navbar search input + live dropdown |
+| Create | `src/pages/search.astro` | Full search results page (grouped, capped at 50) |
+| Modify | `src/pages/road-gp/[year]/[raceId].astro` | Restrict `getStaticPaths` to current year only |
+| Modify | `src/components/Layout.astro` | Import and render `<SearchBox />` in navbar |
+| Modify | `package.json` | Add `fuse.js` dependency |
+
+---
+
+## Task 1: Install fuse.js
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install the package**
+
+```bash
+npm install fuse.js
+```
+
+- [ ] **Step 2: Verify**
+
+Check `package.json` — `fuse.js` should appear under `dependencies`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add fuse.js dependency"
+```
+
+---
+
+## Task 2: Create search-client module
+
+**Files:**
+- Create: `src/lib/search-client.ts`
+
+- [ ] **Step 1: Write the file**
+
+```typescript
+// src/lib/search-client.ts
+import Fuse from 'fuse.js'
+
+export type SearchRecord = {
+  type: 'runner' | 'race-detail' | 'race-results' | 'year' | 'standings'
+  label: string
+  url: string
+}
+
+export function createFuse(records: SearchRecord[]): Fuse<SearchRecord> {
+  return new Fuse(records, { keys: ['label'], threshold: 0.3 })
+}
+
+export function runSearch(fuse: Fuse<SearchRecord>, query: string, limit = 50): SearchRecord[] {
+  if (query.trim().length < 3) return []
+  return fuse.search(query).slice(0, limit).map(r => r.item)
+}
+
+export async function loadIndex(): Promise<SearchRecord[]> {
+  const res = await fetch(`${import.meta.env.BASE_URL}search-index.json`)
+  return res.json()
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/lib/search-client.ts
+git commit -m "feat: add search-client module with Fuse.js helpers"
+```
+
+---
+
+## Task 3: Unit tests for search-client
+
+**Files:**
+- Create: `tests/search-client.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// tests/search-client.test.ts
+import { describe, it, expect } from 'vitest'
+import { createFuse, runSearch, type SearchRecord } from '../src/lib/search-client'
+
+const records: SearchRecord[] = [
+  { type: 'runner', label: 'Steve Smith', url: '/runners/1-steve-smith/' },
+  { type: 'runner', label: 'Sarah Jones', url: '/runners/2-sarah-jones/' },
+  { type: 'runner', label: 'Alan Smithson', url: '/runners/3-alan-smithson/' },
+  { type: 'race-results', label: 'Preston Inter Club Results 2012', url: '/road-gp/2012/preston/results/' },
+  { type: 'year', label: 'Road GP 2012', url: '/road-gp/2012/' },
+]
+
+describe('runSearch', () => {
+  const fuse = createFuse(records)
+
+  it('returns empty array for query shorter than 3 characters', () => {
+    expect(runSearch(fuse, '')).toEqual([])
+    expect(runSearch(fuse, 'st')).toEqual([])
+    expect(runSearch(fuse, '  ')).toEqual([])
+  })
+
+  it('finds a runner by surname', () => {
+    const results = runSearch(fuse, 'smith')
+    const labels = results.map(r => r.label)
+    expect(labels).toContain('Steve Smith')
+  })
+
+  it('finds a race by partial name', () => {
+    const results = runSearch(fuse, 'preston')
+    const labels = results.map(r => r.label)
+    expect(labels.some(l => l.includes('Preston'))).toBe(true)
+  })
+
+  it('respects the limit', () => {
+    const manyRecords: SearchRecord[] = Array.from({ length: 100 }, (_, i) => ({
+      type: 'runner' as const,
+      label: `Runner ${String(i).padStart(3, '0')} Smith`,
+      url: `/runners/${i}/`,
+    }))
+    const bigFuse = createFuse(manyRecords)
+    const results = runSearch(bigFuse, 'smith', 10)
+    expect(results.length).toBeLessThanOrEqual(10)
+  })
+
+  it('returns at most 50 results by default', () => {
+    const manyRecords: SearchRecord[] = Array.from({ length: 200 }, (_, i) => ({
+      type: 'runner' as const,
+      label: `Runner ${String(i).padStart(3, '0')} Smith`,
+      url: `/runners/${i}/`,
+    }))
+    const bigFuse = createFuse(manyRecords)
+    expect(runSearch(bigFuse, 'smith').length).toBeLessThanOrEqual(50)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npm test
+```
+
+Expected output: all 5 tests in `tests/search-client.test.ts` pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/search-client.test.ts
+git commit -m "test: add unit tests for search-client runSearch"
+```
+
+---
+
+## Task 4: Search index API endpoint
+
+**Files:**
+- Create: `src/pages/search-index.json.ts`
+
+- [ ] **Step 1: Write the endpoint**
+
+```typescript
+// src/pages/search-index.json.ts
+import type { APIRoute } from 'astro'
+import { getGlobalRunners, runnerSlug } from '../lib/runners'
+import { getAvailableYears, getRaces, getCurrentYear } from '../lib/data'
+import { hasResults, hasTeamStandings, hasIndividualStandings } from '../lib/results'
+import { siteUrl } from '../lib/url'
+import type { SearchRecord } from '../lib/search-client'
+
+export const GET: APIRoute = () => {
+  const records: SearchRecord[] = []
+  const currentYear = getCurrentYear()
+  const allRoadYears = getAvailableYears('road-gp')
+  const allFellYears = getAvailableYears('fell')
+
+  // Runners
+  for (const runner of getGlobalRunners()) {
+    records.push({
+      type: 'runner',
+      label: `${runner.firstName} ${runner.lastName}`,
+      url: siteUrl(`/runners/${runnerSlug(runner)}/`),
+    })
+  }
+
+  // Current year race detail pages (road-gp only — fell has no detail pages)
+  for (const race of getRaces(currentYear, 'road-gp')) {
+    records.push({
+      type: 'race-detail',
+      label: race.name,
+      url: siteUrl(`/road-gp/${currentYear}/${race.id}/`),
+    })
+  }
+
+  // Race results — all years, road-gp
+  for (const year of allRoadYears) {
+    for (const race of getRaces(year, 'road-gp')) {
+      if (hasResults(year, 'road-gp', race.id)) {
+        records.push({
+          type: 'race-results',
+          label: `${race.name} Results ${year}`,
+          url: siteUrl(`/road-gp/${year}/${race.id}/results/`),
+        })
+      }
+    }
+  }
+
+  // Race results — all years, fell
+  for (const year of allFellYears) {
+    for (const race of getRaces(year, 'fell')) {
+      if (hasResults(year, 'fell', race.id)) {
+        records.push({
+          type: 'race-results',
+          label: `${race.name} Results ${year}`,
+          url: siteUrl(`/fell/${year}/${race.id}/results/`),
+        })
+      }
+    }
+  }
+
+  // Year archive pages — past years only
+  for (const year of allRoadYears.filter(y => y < currentYear)) {
+    records.push({
+      type: 'year',
+      label: `Road GP ${year}`,
+      url: siteUrl(`/road-gp/${year}/`),
+    })
+  }
+  for (const year of allFellYears.filter(y => y < currentYear)) {
+    records.push({
+      type: 'year',
+      label: `Fell Championship ${year}`,
+      url: siteUrl(`/fell/${year}/`),
+    })
+  }
+
+  // Standings pages (any year, both series)
+  for (const year of allRoadYears) {
+    if (hasIndividualStandings(year, 'road-gp')) {
+      records.push({
+        type: 'standings',
+        label: `Road GP ${year} Individual Standings`,
+        url: siteUrl(`/road-gp/${year}/individual-standings/`),
+      })
+    }
+    if (hasTeamStandings(year, 'road-gp')) {
+      records.push({
+        type: 'standings',
+        label: `Road GP ${year} Team Standings`,
+        url: siteUrl(`/road-gp/${year}/team-standings/`),
+      })
+    }
+  }
+  for (const year of allFellYears) {
+    if (hasIndividualStandings(year, 'fell')) {
+      records.push({
+        type: 'standings',
+        label: `Fell Championship ${year} Individual Standings`,
+        url: siteUrl(`/fell/${year}/individual-standings/`),
+      })
+    }
+    if (hasTeamStandings(year, 'fell')) {
+      records.push({
+        type: 'standings',
+        label: `Fell Championship ${year} Team Standings`,
+        url: siteUrl(`/fell/${year}/team-standings/`),
+      })
+    }
+  }
+
+  return new Response(JSON.stringify(records), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+```
+
+- [ ] **Step 2: Build and verify the index is produced**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds with no errors. Then check:
+
+```bash
+ls dist/search-index.json
+```
+
+Expected: file exists. Spot-check its contents:
+
+```bash
+head -c 500 dist/search-index.json
+```
+
+Expected: a JSON array starting with runner records like `[{"type":"runner","label":"Luke Minns","url":"/InterClub/runners/..."},...`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/search-index.json.ts
+git commit -m "feat: add search index API endpoint"
+```
+
+---
+
+## Task 5: Restrict race detail pages to current year
+
+**Files:**
+- Modify: `src/pages/road-gp/[year]/[raceId].astro:10-25`
+
+- [ ] **Step 1: Update getStaticPaths**
+
+Replace the existing `getStaticPaths` function (lines 10–25):
+
+```typescript
+export async function getStaticPaths() {
+  const currentYear = getCurrentYear();
+  const allYears = getAvailableYears('road-gp');
+  return getRaces(currentYear, 'road-gp').map(race => {
+    const pastResults = allYears
+      .filter(y => y < currentYear && hasResults(y, 'road-gp', race.id))
+      .sort((a, b) => b - a)
+      .map(y => ({ year: y, url: siteUrl(`/road-gp/${y}/${race.id}/results/`) }));
+    return {
+      params: { year: String(currentYear), raceId: race.id },
+      props: { race, year: currentYear, pastResults },
+    };
+  });
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds. Verify only current year race detail pages are generated:
+
+```bash
+ls dist/road-gp/2026/
+```
+
+Expected: directories for each current year race id (e.g. `chorley/`, `preston/`, etc.) — no other years' race id directories at the top level of past year paths.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/road-gp/[year]/[raceId].astro
+git commit -m "feat: restrict race detail pages to current year only"
+```
+
+---
+
+## Task 6: Create SearchBox component
+
+**Files:**
+- Create: `src/components/SearchBox.astro`
+
+- [ ] **Step 1: Write the component**
+
+```astro
+---
+// src/components/SearchBox.astro
+---
+
+<div class="relative" id="search-box">
+  <input
+    id="search-input"
+    type="search"
+    placeholder="Search…"
+    autocomplete="off"
+    class="input input-bordered input-sm w-32 sm:w-44 transition-all focus:w-44 sm:focus:w-56"
+  />
+  <ul
+    id="search-dropdown"
+    class="hidden absolute right-0 top-full mt-1 w-72 bg-base-100 rounded-box shadow-lg border border-base-200 z-50 overflow-hidden"
+  ></ul>
+</div>
+
+<script>
+  import Fuse from 'fuse.js'
+  import { createFuse, loadIndex, runSearch } from '../lib/search-client'
+  import type { SearchRecord } from '../lib/search-client'
+
+  const input = document.getElementById('search-input') as HTMLInputElement
+  const dropdown = document.getElementById('search-dropdown') as HTMLUListElement
+  const base = import.meta.env.BASE_URL.replace(/\/$/, '')
+
+  let fuseInstance: Fuse<SearchRecord> | null = null
+
+  async function ensureFuse(): Promise<Fuse<SearchRecord>> {
+    if (fuseInstance) return fuseInstance
+    const records = await loadIndex()
+    fuseInstance = createFuse(records)
+    return fuseInstance
+  }
+
+  function typeLabel(type: SearchRecord['type']): string {
+    const labels: Record<SearchRecord['type'], string> = {
+      'runner': 'Runner',
+      'race-detail': 'Race',
+      'race-results': 'Results',
+      'year': 'Archive',
+      'standings': 'Standings',
+    }
+    return labels[type]
+  }
+
+  function renderDropdown(results: SearchRecord[], query: string): void {
+    if (results.length === 0) {
+      dropdown.classList.add('hidden')
+      return
+    }
+    const items = results.slice(0, 8).map(r =>
+      `<li><a href="${r.url}" class="flex items-center gap-2 px-3 py-2 hover:bg-base-200 text-sm">` +
+      `<span class="badge badge-ghost badge-sm shrink-0">${typeLabel(r.type)}</span>` +
+      `<span class="truncate">${r.label}</span></a></li>`
+    ).join('')
+    const footer =
+      `<li class="border-t border-base-200">` +
+      `<a href="${base}/search?q=${encodeURIComponent(query)}" class="block px-3 py-2 text-sm text-primary hover:bg-base-200">` +
+      `See all results →</a></li>`
+    dropdown.innerHTML = items + footer
+    dropdown.classList.remove('hidden')
+  }
+
+  async function handleQuery(query: string): Promise<void> {
+    if (query.trim().length < 3) {
+      dropdown.classList.add('hidden')
+      return
+    }
+    const fuse = await ensureFuse()
+    renderDropdown(runSearch(fuse, query, 8), query)
+  }
+
+  input.addEventListener('focus', () => handleQuery(input.value))
+  input.addEventListener('input', () => handleQuery(input.value))
+
+  input.addEventListener('keydown', (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      dropdown.classList.add('hidden')
+      input.blur()
+    }
+    if (e.key === 'Enter' && input.value.trim().length >= 3) {
+      window.location.href = `${base}/search?q=${encodeURIComponent(input.value.trim())}`
+    }
+  })
+
+  document.addEventListener('click', (e: MouseEvent) => {
+    if (!document.getElementById('search-box')?.contains(e.target as Node)) {
+      dropdown.classList.add('hidden')
+    }
+  })
+</script>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/SearchBox.astro
+git commit -m "feat: add SearchBox navbar component"
+```
+
+---
+
+## Task 7: Add SearchBox to Layout
+
+**Files:**
+- Modify: `src/components/Layout.astro`
+
+- [ ] **Step 1: Import SearchBox in the frontmatter**
+
+Add to the existing imports at the top of the frontmatter:
+
+```typescript
+import SearchBox from './SearchBox.astro';
+```
+
+- [ ] **Step 2: Add SearchBox to the navbar**
+
+In the `navbar-end` div (currently contains Road GP, Fell, Contact links), add `<SearchBox />` at the end:
+
+```astro
+<div class="navbar-end gap-1">
+  <a
+    href={`${base}/road-gp/`}
+    class={`btn btn-ghost btn-sm ${isActive('/road-gp') ? 'btn-active' : ''}`}
+  >Road GP</a>
+  <a
+    href={`${base}/fell/`}
+    class={`btn btn-ghost btn-sm ${isActive('/fell') ? 'btn-active' : ''}`}
+  >Fell</a>
+  <a
+    href={`${base}/contact/`}
+    class={`btn btn-ghost btn-sm ${isActive('/contact') ? 'btn-active' : ''}`}
+  >Contact</a>
+  <SearchBox />
+</div>
+```
+
+- [ ] **Step 3: Build and verify**
+
+```bash
+npm run build && npm run preview
+```
+
+Open `http://localhost:4321/InterClub/` in a browser. Confirm the search input is visible in the navbar. Type "steve" — after 3 characters a dropdown should appear with runner results.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Layout.astro
+git commit -m "feat: add search box to site navbar"
+```
+
+---
+
+## Task 8: Create search results page
+
+**Files:**
+- Create: `src/pages/search.astro`
+
+- [ ] **Step 1: Write the page**
+
+```astro
+---
+// src/pages/search.astro
+import Layout from '../components/Layout.astro';
+---
+
+<Layout title="Search">
+  <h1 class="text-2xl font-bold mb-4">Search</h1>
+
+  <input
+    id="search-input"
+    type="search"
+    placeholder="Search runners, races, history…"
+    autocomplete="off"
+    class="input input-bordered w-full mb-3"
+  />
+
+  <p id="search-status" class="text-sm text-base-content/60 mb-6">Type at least 3 characters to search.</p>
+
+  <div id="results-runners" class="mb-8 hidden">
+    <h2 class="text-lg font-semibold mb-3">Runners</h2>
+    <ul id="list-runners" class="flex flex-col gap-1"></ul>
+  </div>
+
+  <div id="results-races" class="mb-8 hidden">
+    <h2 class="text-lg font-semibold mb-3">Races</h2>
+    <ul id="list-races" class="flex flex-col gap-1"></ul>
+  </div>
+
+  <div id="results-pages" class="mb-8 hidden">
+    <h2 class="text-lg font-semibold mb-3">Pages</h2>
+    <ul id="list-pages" class="flex flex-col gap-1"></ul>
+  </div>
+</Layout>
+
+<script>
+  import Fuse from 'fuse.js'
+  import { createFuse, loadIndex, runSearch } from '../lib/search-client'
+  import type { SearchRecord } from '../lib/search-client'
+
+  const LIMIT = 50
+
+  const input = document.getElementById('search-input') as HTMLInputElement
+  const status = document.getElementById('search-status') as HTMLParagraphElement
+  const base = import.meta.env.BASE_URL.replace(/\/$/, '')
+
+  let fuseInstance: Fuse<SearchRecord> | null = null
+
+  function typeLabel(type: SearchRecord['type']): string {
+    const labels: Record<SearchRecord['type'], string> = {
+      'runner': 'Runner',
+      'race-detail': 'Race',
+      'race-results': 'Results',
+      'year': 'Archive',
+      'standings': 'Standings',
+    }
+    return labels[type]
+  }
+
+  function renderSection(
+    sectionId: string,
+    listId: string,
+    items: SearchRecord[],
+    showBadge: boolean
+  ): void {
+    const section = document.getElementById(sectionId)!
+    const list = document.getElementById(listId)!
+    if (items.length === 0) {
+      section.classList.add('hidden')
+      return
+    }
+    list.innerHTML = items.map(r =>
+      `<li><a href="${r.url}" class="flex items-center gap-2 py-1.5 hover:text-primary text-sm">` +
+      (showBadge ? `<span class="badge badge-ghost badge-sm shrink-0">${typeLabel(r.type)}</span>` : '') +
+      `<span>${r.label}</span></a></li>`
+    ).join('')
+    section.classList.remove('hidden')
+  }
+
+  function displayResults(results: SearchRecord[], query: string, total: number): void {
+    const runners = results.filter(r => r.type === 'runner')
+    const races = results.filter(r => r.type === 'race-detail' || r.type === 'race-results')
+    const pages = results.filter(r => r.type === 'year' || r.type === 'standings')
+
+    renderSection('results-runners', 'list-runners', runners, false)
+    renderSection('results-races', 'list-races', races, true)
+    renderSection('results-pages', 'list-pages', pages, true)
+
+    if (results.length === 0) {
+      status.textContent = `No results for "${query}".`
+    } else if (total > LIMIT) {
+      status.textContent = `Showing ${LIMIT} of ${total} results — try a more specific search.`
+    } else {
+      status.textContent = `${results.length} result${results.length === 1 ? '' : 's'} for "${query}".`
+    }
+  }
+
+  function clearResults(): void {
+    for (const id of ['results-runners', 'results-races', 'results-pages']) {
+      document.getElementById(id)!.classList.add('hidden')
+    }
+  }
+
+  async function search(query: string): Promise<void> {
+    if (query.trim().length < 3) {
+      clearResults()
+      status.textContent = 'Type at least 3 characters to search.'
+      return
+    }
+    if (!fuseInstance) {
+      status.textContent = 'Loading…'
+      const records = await loadIndex()
+      fuseInstance = createFuse(records)
+    }
+    const allResults = fuseInstance.search(query)
+    const limited = allResults.slice(0, LIMIT).map(r => r.item)
+    displayResults(limited, query, allResults.length)
+  }
+
+  // On load: read ?q= from URL and run search
+  const params = new URLSearchParams(window.location.search)
+  const initialQuery = params.get('q') ?? ''
+  input.value = initialQuery
+  if (initialQuery) search(initialQuery)
+
+  // Live updates
+  input.addEventListener('input', () => {
+    const q = input.value.trim()
+    history.replaceState(null, '', q ? `${base}/search?q=${encodeURIComponent(q)}` : `${base}/search`)
+    search(q)
+  })
+</script>
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds with no TypeScript errors.
+
+- [ ] **Step 3: Verify in browser**
+
+```bash
+npm run preview
+```
+
+Open `http://localhost:4321/InterClub/search?q=smith`. Confirm:
+- Input is pre-filled with "smith"
+- Runners section shows matching runners
+- Status shows result count
+- Typing in the input updates results live and updates the URL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/search.astro
+git commit -m "feat: add search results page"
+```
+
+---
+
+## Task 9: Final build verification
+
+- [ ] **Step 1: Run full build**
+
+```bash
+npm run build
+```
+
+Expected: clean build with no errors or warnings about TypeScript.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Smoke test in browser**
+
+```bash
+npm run preview
+```
+
+Verify:
+1. Navbar shows search input on every page
+2. Typing "smi" (3 chars) in the navbar opens dropdown with runner matches
+3. Typing "press" shows Preston race entries
+4. Pressing Enter navigates to `/InterClub/search?q=press`
+5. The search page groups results under Runners / Races / Pages
+6. Typing "2012" on the search page shows year archive and results entries
+7. Clicking any result navigates to the correct page
+8. Escape closes the navbar dropdown
+9. Navigating to `/InterClub/road-gp/2026/` shows the current year's race cards (detail pages still exist for current year only)
+10. An old year path like `/InterClub/road-gp/2024/preston` returns a 404 (detail pages no longer generated for past years — only results at `/road-gp/2024/preston/results/` still exist)

--- a/docs/superpowers/specs/2026-05-19-search-design.md
+++ b/docs/superpowers/specs/2026-05-19-search-design.md
@@ -1,0 +1,148 @@
+# Search Design
+
+**Date:** 2026-05-19  
+**Status:** Approved
+
+## Overview
+
+Add client-side fuzzy search to the InterClub static site. Users can search for runners by name and navigate to historical or current-year race pages. A search box in the navbar provides instant results; a dedicated `/search` page shows the full result set.
+
+## Approach
+
+Build-time JSON index + Fuse.js client-side fuzzy matching. The index is generated as an Astro API endpoint from existing data-loading functions. Fuse.js is loaded lazily on first interaction. No server required; no post-build tooling.
+
+`astro-fuse` was considered and rejected — it targets markdown/content-collection sites, not JSON/CSV data pipelines.
+
+---
+
+## Code change: restrict race detail pages to current year
+
+`src/pages/road-gp/[year]/[raceId].astro` currently generates a detail page for every race in every year. Change `getStaticPaths()` to only generate pages for `currentYear`.
+
+Rationale: historical race detail pages are not useful (outdated info); historical races are already accessible via their results pages. The index only needs current-year race details.
+
+---
+
+## 1. Search index endpoint
+
+**File:** `src/pages/search-index.json.ts`
+
+An Astro API endpoint (`GET` export) that outputs a static `search-index.json` file at build time. Uses `import.meta.glob` at module scope (Vite constraint) and the existing data-loading functions.
+
+### Record schema
+
+```ts
+type SearchRecord = {
+  type: 'runner' | 'race-detail' | 'race-results' | 'year' | 'standings'
+  label: string
+  url: string
+}
+```
+
+### Record sources
+
+| Type | Label format | URL | Condition |
+|---|---|---|---|
+| `runner` | `{firstName} {lastName}` | `/runners/{slug}/` | all global runners |
+| `race-detail` | `{race.name}` | `/road-gp/{currentYear}/{raceId}/` | current year road-gp only |
+| `race-results` | `{race.name} Results {year}` | `/{series}/{year}/{raceId}/results/` | `hasResults()` is true |
+| `year` | `Road GP {year}` / `Fell Championship {year}` | `/{series}/{year}/` | past years only |
+| `standings` | `Road GP {year} Individual Standings` etc | `/{series}/{year}/individual-standings/` | file exists |
+| `standings` | `Road GP {year} Team Standings` etc | `/{series}/{year}/team-standings/` | file exists |
+
+### Standings existence check
+
+Standings files are checked via the same `import.meta.glob` patterns already used for standings pages (`individual-standings.json`, `team-standings.json`). Only years where the file exists produce a standings record.
+
+### Estimated index size
+
+~900 runners + ~600 race-results entries + year/standings pages ≈ ~1,500 records. At ~80 bytes each: ~120 KB raw, ~40 KB gzipped. Fetched once per session.
+
+---
+
+## 2. Navbar search box
+
+**File:** `src/components/SearchBox.astro`  
+**Change:** `Layout.astro` — replace the right-hand nav buttons area to include `<SearchBox />` alongside the existing nav links.
+
+### Markup
+
+```
+[Road GP] [Fell] [Contact]  [ Search…  ▼ ]
+                             ┌──────────────────┐
+                             │ 🏃 Steve Smith    │
+                             │ 📄 Preston 2026   │
+                             │ …                 │
+                             │ See all results → │
+                             └──────────────────┘
+```
+
+### Behaviour
+
+- **Min 3 characters** — fewer than 3 chars: dropdown hidden, no search performed
+- **Lazy initialisation** — on first focus: `fetch('/search-index.json')`, then `const Fuse = (await import('fuse.js')).default`, create instance. Subsequent keystrokes reuse the instance.
+- **Dropdown** — top 8 results rendered as `<li>` links; each shows a small type label and the record label; footer link "See all results →" navigates to `/search?q={query}`
+- **Keyboard** — `Enter` → `/search?q={query}`; `Escape` → close; `ArrowDown`/`ArrowUp` → move focus within list
+- **Click outside** → close dropdown
+
+### Fuse.js config
+
+```js
+new Fuse(records, {
+  keys: ['label'],
+  threshold: 0.3,
+  includeScore: false,
+})
+```
+
+---
+
+## 3. Search results page
+
+**File:** `src/pages/search.astro`
+
+A static Astro page. All search logic runs client-side.
+
+### Behaviour
+
+- On load: read `?q=` from `window.location.search`; pre-fill the input; run search
+- Live update: as the user types, re-run search and update the result list; update URL with `history.replaceState` (bookmarkable, no page reload)
+- Same Fuse instance and config as navbar component (index fetched fresh on this page load)
+
+### Result display
+
+Results grouped into three sections rendered in order:
+
+1. **Runners** — `runner` records
+2. **Races** — `race-detail` and `race-results` records together
+3. **Pages** — `year` and `standings` records
+
+Each result is a plain link showing the label. The type (`race-detail`, `race-results`, etc.) is shown as a small badge.
+
+### States
+
+| State | Display |
+|---|---|
+| Query < 3 chars | "Type at least 3 characters to search" |
+| No results | "No results for '{query}'" |
+| Results ≤ 50 | "{n} results for '{query}'" |
+| Results > 50 | "Showing 50 of {n} results — try a more specific search" |
+
+---
+
+## 4. Dependency
+
+Add `fuse.js` to `package.json` dependencies. No other new packages. `astro-fuse` is not used.
+
+---
+
+## Files changed / created
+
+| File | Change |
+|---|---|
+| `src/pages/road-gp/[year]/[raceId].astro` | Restrict `getStaticPaths()` to `currentYear` only |
+| `src/pages/search-index.json.ts` | New — build-time search index endpoint |
+| `src/components/SearchBox.astro` | New — navbar search input + dropdown |
+| `src/components/Layout.astro` | Add `<SearchBox />` to navbar |
+| `src/pages/search.astro` | New — full search results page |
+| `package.json` | Add `fuse.js` dependency |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "interclub",
       "version": "0.0.1",
       "dependencies": {
-        "astro": "^6.1.9"
+        "astro": "^6.1.9",
+        "fuse.js": "^7.3.0"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.4",
@@ -2812,6 +2813,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/github-slugger": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "astro": "^6.1.9"
+    "astro": "^6.1.9",
+    "fuse.js": "^7.3.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.4",

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css';
+import SearchBox from './SearchBox.astro';
 
 interface Props {
   title: string;
@@ -42,6 +43,7 @@ function isActive(path: string): boolean {
             href={`${base}/contact/`}
             class={`btn btn-ghost btn-sm ${isActive('/contact') ? 'btn-active' : ''}`}
           >Contact</a>
+          <SearchBox />
         </div>
       </div>
     </header>

--- a/src/components/SearchBox.astro
+++ b/src/components/SearchBox.astro
@@ -49,7 +49,10 @@
     const items = results.slice(0, 8).map(r =>
       `<li><a href="${escapeHtml(r.url)}" class="flex items-center gap-2 px-3 py-2 hover:bg-base-200 text-sm">` +
       `<span class="badge badge-ghost badge-sm shrink-0">${escapeHtml(typeLabel(r.type))}</span>` +
-      `<span class="truncate">${escapeHtml(r.label)}</span></a></li>`
+      `<span class="min-w-0 flex flex-col">` +
+      `<span class="truncate">${escapeHtml(r.label)}</span>` +
+      (r.subtitle ? `<span class="text-xs text-base-content/50 truncate">${escapeHtml(r.subtitle)}</span>` : '') +
+      `</span></a></li>`
     ).join('')
     const footer =
       `<li class="border-t border-base-200">` +

--- a/src/components/SearchBox.astro
+++ b/src/components/SearchBox.astro
@@ -18,31 +18,24 @@
 
 <script>
   import Fuse from 'fuse.js'
-  import { createFuse, loadIndex, runSearch } from '../lib/search-client'
+  import { createFuse, loadIndex, runSearch, typeLabel } from '../lib/search-client'
   import type { SearchRecord } from '../lib/search-client'
 
   const input = document.getElementById('search-input') as HTMLInputElement
   const dropdown = document.getElementById('search-dropdown') as HTMLUListElement
   const base = import.meta.env.BASE_URL.replace(/\/$/, '')
 
-  let fuseInstance: Fuse<SearchRecord> | null = null
+  let fusePromise: Promise<Fuse<SearchRecord>> | null = null
 
   async function ensureFuse(): Promise<Fuse<SearchRecord>> {
-    if (fuseInstance) return fuseInstance
-    const records = await loadIndex()
-    fuseInstance = createFuse(records)
-    return fuseInstance
+    if (!fusePromise) {
+      fusePromise = loadIndex().then(records => createFuse(records))
+    }
+    return fusePromise
   }
 
-  function typeLabel(type: SearchRecord['type']): string {
-    const labels: Record<SearchRecord['type'], string> = {
-      'runner': 'Runner',
-      'race-detail': 'Race',
-      'race-results': 'Results',
-      'year': 'Archive',
-      'standings': 'Standings',
-    }
-    return labels[type]
+  function escapeHtml(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
   }
 
   function renderDropdown(results: SearchRecord[], query: string): void {
@@ -52,8 +45,8 @@
     }
     const items = results.slice(0, 8).map(r =>
       `<li><a href="${r.url}" class="flex items-center gap-2 px-3 py-2 hover:bg-base-200 text-sm">` +
-      `<span class="badge badge-ghost badge-sm shrink-0">${typeLabel(r.type)}</span>` +
-      `<span class="truncate">${r.label}</span></a></li>`
+      `<span class="badge badge-ghost badge-sm shrink-0">${escapeHtml(typeLabel(r.type))}</span>` +
+      `<span class="truncate">${escapeHtml(r.label)}</span></a></li>`
     ).join('')
     const footer =
       `<li class="border-t border-base-200">` +

--- a/src/components/SearchBox.astro
+++ b/src/components/SearchBox.astro
@@ -1,0 +1,93 @@
+---
+// src/components/SearchBox.astro
+---
+
+<div class="relative" id="search-box">
+  <input
+    id="search-input"
+    type="search"
+    placeholder="Search…"
+    autocomplete="off"
+    class="input input-bordered input-sm w-32 sm:w-44 transition-all focus:w-44 sm:focus:w-56"
+  />
+  <ul
+    id="search-dropdown"
+    class="hidden absolute right-0 top-full mt-1 w-72 bg-base-100 rounded-box shadow-lg border border-base-200 z-50 overflow-hidden"
+  ></ul>
+</div>
+
+<script>
+  import Fuse from 'fuse.js'
+  import { createFuse, loadIndex, runSearch } from '../lib/search-client'
+  import type { SearchRecord } from '../lib/search-client'
+
+  const input = document.getElementById('search-input') as HTMLInputElement
+  const dropdown = document.getElementById('search-dropdown') as HTMLUListElement
+  const base = import.meta.env.BASE_URL.replace(/\/$/, '')
+
+  let fuseInstance: Fuse<SearchRecord> | null = null
+
+  async function ensureFuse(): Promise<Fuse<SearchRecord>> {
+    if (fuseInstance) return fuseInstance
+    const records = await loadIndex()
+    fuseInstance = createFuse(records)
+    return fuseInstance
+  }
+
+  function typeLabel(type: SearchRecord['type']): string {
+    const labels: Record<SearchRecord['type'], string> = {
+      'runner': 'Runner',
+      'race-detail': 'Race',
+      'race-results': 'Results',
+      'year': 'Archive',
+      'standings': 'Standings',
+    }
+    return labels[type]
+  }
+
+  function renderDropdown(results: SearchRecord[], query: string): void {
+    if (results.length === 0) {
+      dropdown.classList.add('hidden')
+      return
+    }
+    const items = results.slice(0, 8).map(r =>
+      `<li><a href="${r.url}" class="flex items-center gap-2 px-3 py-2 hover:bg-base-200 text-sm">` +
+      `<span class="badge badge-ghost badge-sm shrink-0">${typeLabel(r.type)}</span>` +
+      `<span class="truncate">${r.label}</span></a></li>`
+    ).join('')
+    const footer =
+      `<li class="border-t border-base-200">` +
+      `<a href="${base}/search?q=${encodeURIComponent(query)}" class="block px-3 py-2 text-sm text-primary hover:bg-base-200">` +
+      `See all results →</a></li>`
+    dropdown.innerHTML = items + footer
+    dropdown.classList.remove('hidden')
+  }
+
+  async function handleQuery(query: string): Promise<void> {
+    if (query.trim().length < 3) {
+      dropdown.classList.add('hidden')
+      return
+    }
+    const fuse = await ensureFuse()
+    renderDropdown(runSearch(fuse, query, 8), query)
+  }
+
+  input.addEventListener('focus', () => handleQuery(input.value))
+  input.addEventListener('input', () => handleQuery(input.value))
+
+  input.addEventListener('keydown', (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      dropdown.classList.add('hidden')
+      input.blur()
+    }
+    if (e.key === 'Enter' && input.value.trim().length >= 3) {
+      window.location.href = `${base}/search?q=${encodeURIComponent(input.value.trim())}`
+    }
+  })
+
+  document.addEventListener('click', (e: MouseEvent) => {
+    if (!document.getElementById('search-box')?.contains(e.target as Node)) {
+      dropdown.classList.add('hidden')
+    }
+  })
+</script>

--- a/src/components/SearchBox.astro
+++ b/src/components/SearchBox.astro
@@ -18,7 +18,7 @@
 
 <script>
   import Fuse from 'fuse.js'
-  import { createFuse, loadIndex, runSearch, typeLabel } from '../lib/search-client'
+  import { createFuse, loadIndex, runSearch } from '../lib/search-client'
   import type { SearchRecord } from '../lib/search-client'
 
   const input = document.getElementById('search-input') as HTMLInputElement
@@ -48,7 +48,6 @@
     }
     const items = results.slice(0, 8).map(r =>
       `<li><a href="${escapeHtml(r.url)}" class="flex items-center gap-2 px-3 py-2 hover:bg-base-200 text-sm">` +
-      `<span class="badge badge-ghost badge-sm shrink-0">${escapeHtml(typeLabel(r.type))}</span>` +
       `<span class="min-w-0 flex flex-col">` +
       `<span class="truncate">${escapeHtml(r.label)}</span>` +
       (r.subtitle ? `<span class="text-xs text-base-content/50 truncate">${escapeHtml(r.subtitle)}</span>` : '') +

--- a/src/components/SearchBox.astro
+++ b/src/components/SearchBox.astro
@@ -29,7 +29,10 @@
 
   async function ensureFuse(): Promise<Fuse<SearchRecord>> {
     if (!fusePromise) {
-      fusePromise = loadIndex().then(records => createFuse(records))
+      fusePromise = loadIndex().then(records => createFuse(records)).catch(err => {
+        fusePromise = null
+        throw err
+      })
     }
     return fusePromise
   }
@@ -44,7 +47,7 @@
       return
     }
     const items = results.slice(0, 8).map(r =>
-      `<li><a href="${r.url}" class="flex items-center gap-2 px-3 py-2 hover:bg-base-200 text-sm">` +
+      `<li><a href="${escapeHtml(r.url)}" class="flex items-center gap-2 px-3 py-2 hover:bg-base-200 text-sm">` +
       `<span class="badge badge-ghost badge-sm shrink-0">${escapeHtml(typeLabel(r.type))}</span>` +
       `<span class="truncate">${escapeHtml(r.label)}</span></a></li>`
     ).join('')

--- a/src/lib/runners.ts
+++ b/src/lib/runners.ts
@@ -146,7 +146,7 @@ function getAwardsForRunner(year: number, series: Series, seriesLocalId: number)
   return found;
 }
 
-function resolveClubName(clubId: string): string {
+export function resolveClubName(clubId: string): string {
   // allClubFiles is at module level (Vite requires import.meta.glob at module scope)
   for (const clubs of Object.values(allClubFiles)) {
     const club = clubs.default.find(c => c.id === clubId);

--- a/src/lib/search-client.ts
+++ b/src/lib/search-client.ts
@@ -20,3 +20,14 @@ export async function loadIndex(): Promise<SearchRecord[]> {
   const res = await fetch(`${import.meta.env.BASE_URL}search-index.json`)
   return res.json()
 }
+
+export function typeLabel(type: SearchRecord['type']): string {
+  const labels: Record<SearchRecord['type'], string> = {
+    'runner': 'Runner',
+    'race-detail': 'Race',
+    'race-results': 'Results',
+    'year': 'Archive',
+    'standings': 'Standings',
+  }
+  return labels[type]
+}

--- a/src/lib/search-client.ts
+++ b/src/lib/search-client.ts
@@ -5,6 +5,7 @@ export type SearchRecord = {
   type: 'runner' | 'race-detail' | 'race-results' | 'year' | 'standings'
   label: string
   url: string
+  subtitle?: string
 }
 
 export function createFuse(records: SearchRecord[]): Fuse<SearchRecord> {

--- a/src/lib/search-client.ts
+++ b/src/lib/search-client.ts
@@ -1,0 +1,22 @@
+// src/lib/search-client.ts
+import Fuse from 'fuse.js'
+
+export type SearchRecord = {
+  type: 'runner' | 'race-detail' | 'race-results' | 'year' | 'standings'
+  label: string
+  url: string
+}
+
+export function createFuse(records: SearchRecord[]): Fuse<SearchRecord> {
+  return new Fuse(records, { keys: ['label'], threshold: 0.3 })
+}
+
+export function runSearch(fuse: Fuse<SearchRecord>, query: string, limit = 50): SearchRecord[] {
+  if (query.trim().length < 3) return []
+  return fuse.search(query).slice(0, limit).map(r => r.item)
+}
+
+export async function loadIndex(): Promise<SearchRecord[]> {
+  const res = await fetch(`${import.meta.env.BASE_URL}search-index.json`)
+  return res.json()
+}

--- a/src/pages/road-gp/[year]/[raceId].astro
+++ b/src/pages/road-gp/[year]/[raceId].astro
@@ -8,20 +8,18 @@ import { siteUrl } from '../../../lib/url';
 import type { Race } from '../../../lib/types';
 
 export async function getStaticPaths() {
+  const currentYear = getCurrentYear();
   const allYears = getAvailableYears('road-gp');
-  return allYears.flatMap(year =>
-    getRaces(year, 'road-gp').map(race => {
-      // race ids are stable across years (each club hosts the same race annually)
-      const pastResults = allYears
-        .filter(y => y < year && hasResults(y, 'road-gp', race.id))
-        .sort((a, b) => b - a)
-        .map(y => ({ year: y, url: siteUrl(`/road-gp/${y}/${race.id}/results/`) }));
-      return {
-        params: { year: String(year), raceId: race.id },
-        props: { race, year, pastResults },
-      };
-    })
-  );
+  return getRaces(currentYear, 'road-gp').map(race => {
+    const pastResults = allYears
+      .filter(y => y < currentYear && hasResults(y, 'road-gp', race.id))
+      .sort((a, b) => b - a)
+      .map(y => ({ year: y, url: siteUrl(`/road-gp/${y}/${race.id}/results/`) }));
+    return {
+      params: { year: String(currentYear), raceId: race.id },
+      props: { race, year: currentYear, pastResults },
+    };
+  });
 }
 
 interface Props {

--- a/src/pages/search-index.json.ts
+++ b/src/pages/search-index.json.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro'
-import { getGlobalRunners, runnerSlug } from '../lib/runners'
+import { getGlobalRunners, runnerSlug, resolveClubName } from '../lib/runners'
 import { getAvailableYears, getRaces, getCurrentYear } from '../lib/data'
 import { hasResults, hasTeamStandings, hasIndividualStandings } from '../lib/results'
 import { siteUrl } from '../lib/url'
@@ -17,6 +17,7 @@ export const GET: APIRoute = () => {
       type: 'runner',
       label: `${runner.firstName} ${runner.lastName}`,
       url: siteUrl(`/runners/${runnerSlug(runner)}/`),
+      subtitle: resolveClubName(runner.club),
     })
   }
 

--- a/src/pages/search-index.json.ts
+++ b/src/pages/search-index.json.ts
@@ -13,11 +13,12 @@ export const GET: APIRoute = () => {
 
   // Runners
   for (const runner of getGlobalRunners()) {
+    const details = [runner.sex, runner.ageCategory].filter(Boolean).join(' ')
     records.push({
       type: 'runner',
       label: `${runner.firstName} ${runner.lastName}`,
       url: siteUrl(`/runners/${runnerSlug(runner)}/`),
-      subtitle: resolveClubName(runner.club),
+      subtitle: details ? `${resolveClubName(runner.club)} · ${details}` : resolveClubName(runner.club),
     })
   }
 

--- a/src/pages/search-index.json.ts
+++ b/src/pages/search-index.json.ts
@@ -1,0 +1,111 @@
+import type { APIRoute } from 'astro'
+import { getGlobalRunners, runnerSlug } from '../lib/runners'
+import { getAvailableYears, getRaces, getCurrentYear } from '../lib/data'
+import { hasResults, hasTeamStandings, hasIndividualStandings } from '../lib/results'
+import { siteUrl } from '../lib/url'
+import type { SearchRecord } from '../lib/search-client'
+
+export const GET: APIRoute = () => {
+  const records: SearchRecord[] = []
+  const currentYear = getCurrentYear()
+  const allRoadYears = getAvailableYears('road-gp')
+  const allFellYears = getAvailableYears('fell')
+
+  // Runners
+  for (const runner of getGlobalRunners()) {
+    records.push({
+      type: 'runner',
+      label: `${runner.firstName} ${runner.lastName}`,
+      url: siteUrl(`/runners/${runnerSlug(runner)}/`),
+    })
+  }
+
+  // Current year race detail pages (road-gp only — fell has no detail pages)
+  for (const race of getRaces(currentYear, 'road-gp')) {
+    records.push({
+      type: 'race-detail',
+      label: race.name,
+      url: siteUrl(`/road-gp/${currentYear}/${race.id}/`),
+    })
+  }
+
+  // Race results — all years, road-gp
+  for (const year of allRoadYears) {
+    for (const race of getRaces(year, 'road-gp')) {
+      if (hasResults(year, 'road-gp', race.id)) {
+        records.push({
+          type: 'race-results',
+          label: `${race.name} Results ${year}`,
+          url: siteUrl(`/road-gp/${year}/${race.id}/results/`),
+        })
+      }
+    }
+  }
+
+  // Race results — all years, fell
+  for (const year of allFellYears) {
+    for (const race of getRaces(year, 'fell')) {
+      if (hasResults(year, 'fell', race.id)) {
+        records.push({
+          type: 'race-results',
+          label: `${race.name} Results ${year}`,
+          url: siteUrl(`/fell/${year}/${race.id}/results/`),
+        })
+      }
+    }
+  }
+
+  // Year archive pages — past years only
+  for (const year of allRoadYears.filter(y => y < currentYear)) {
+    records.push({
+      type: 'year',
+      label: `Road GP ${year}`,
+      url: siteUrl(`/road-gp/${year}/`),
+    })
+  }
+  for (const year of allFellYears.filter(y => y < currentYear)) {
+    records.push({
+      type: 'year',
+      label: `Fell Championship ${year}`,
+      url: siteUrl(`/fell/${year}/`),
+    })
+  }
+
+  // Standings pages (any year, both series)
+  for (const year of allRoadYears) {
+    if (hasIndividualStandings(year, 'road-gp')) {
+      records.push({
+        type: 'standings',
+        label: `Road GP ${year} Individual Standings`,
+        url: siteUrl(`/road-gp/${year}/individual-standings/`),
+      })
+    }
+    if (hasTeamStandings(year, 'road-gp')) {
+      records.push({
+        type: 'standings',
+        label: `Road GP ${year} Team Standings`,
+        url: siteUrl(`/road-gp/${year}/team-standings/`),
+      })
+    }
+  }
+  for (const year of allFellYears) {
+    if (hasIndividualStandings(year, 'fell')) {
+      records.push({
+        type: 'standings',
+        label: `Fell Championship ${year} Individual Standings`,
+        url: siteUrl(`/fell/${year}/individual-standings/`),
+      })
+    }
+    if (hasTeamStandings(year, 'fell')) {
+      records.push({
+        type: 'standings',
+        label: `Fell Championship ${year} Team Standings`,
+        url: siteUrl(`/fell/${year}/team-standings/`),
+      })
+    }
+  }
+
+  return new Response(JSON.stringify(records), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/src/pages/search-index.json.ts
+++ b/src/pages/search-index.json.ts
@@ -13,7 +13,7 @@ export const GET: APIRoute = () => {
 
   // Runners
   for (const runner of getGlobalRunners()) {
-    const details = [runner.sex, runner.ageCategory].filter(Boolean).join(' ')
+    const details = [runner.sex, runner.ageCategory].filter(Boolean).join('')
     records.push({
       type: 'runner',
       label: `${runner.firstName} ${runner.lastName}`,

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -51,7 +51,10 @@ import Layout from '../components/Layout.astro';
 
   async function ensureFuse(): Promise<Fuse<SearchRecord>> {
     if (!fusePromise) {
-      fusePromise = loadIndex().then(records => createFuse(records))
+      fusePromise = loadIndex().then(records => createFuse(records)).catch(err => {
+        fusePromise = null
+        throw err
+      })
     }
     return fusePromise
   }
@@ -69,7 +72,7 @@ import Layout from '../components/Layout.astro';
       return
     }
     list.innerHTML = items.map(r =>
-      `<li><a href="${r.url}" class="flex items-center gap-2 py-1.5 hover:text-primary text-sm">` +
+      `<li><a href="${escapeHtml(r.url)}" class="flex items-center gap-2 py-1.5 hover:text-primary text-sm">` +
       (showBadge ? `<span class="badge badge-ghost badge-sm shrink-0">${escapeHtml(typeLabel(r.type))}</span>` : '') +
       `<span>${escapeHtml(r.label)}</span></a></li>`
     ).join('')

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -26,6 +26,11 @@ import Layout from '../components/Layout.astro';
     <ul id="list-races" class="flex flex-col gap-1"></ul>
   </div>
 
+  <div id="results-standings" class="mb-8 hidden">
+    <h2 class="text-lg font-semibold mb-3">Standings</h2>
+    <ul id="list-standings" class="flex flex-col gap-1"></ul>
+  </div>
+
   <div id="results-pages" class="mb-8 hidden">
     <h2 class="text-lg font-semibold mb-3">Pages</h2>
     <ul id="list-pages" class="flex flex-col gap-1"></ul>
@@ -83,10 +88,12 @@ import Layout from '../components/Layout.astro';
   function displayResults(results: SearchRecord[], query: string, total: number): void {
     const runners = results.filter(r => r.type === 'runner')
     const races = results.filter(r => r.type === 'race-detail' || r.type === 'race-results')
-    const pages = results.filter(r => r.type === 'year' || r.type === 'standings')
+    const standings = results.filter(r => r.type === 'standings')
+    const pages = results.filter(r => r.type === 'year')
 
     renderSection('results-runners', 'list-runners', runners)
     renderSection('results-races', 'list-races', races)
+    renderSection('results-standings', 'list-standings', standings)
     renderSection('results-pages', 'list-pages', pages)
 
     if (results.length === 0) {
@@ -99,7 +106,7 @@ import Layout from '../components/Layout.astro';
   }
 
   function clearResults(): void {
-    for (const id of ['results-runners', 'results-races', 'results-pages']) {
+    for (const id of ['results-runners', 'results-races', 'results-standings', 'results-pages']) {
       document.getElementById(id)!.classList.add('hidden')
     }
   }

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,0 +1,130 @@
+---
+// src/pages/search.astro
+import Layout from '../components/Layout.astro';
+---
+
+<Layout title="Search">
+  <h1 class="text-2xl font-bold mb-4">Search</h1>
+
+  <input
+    id="search-input"
+    type="search"
+    placeholder="Search runners, races, history…"
+    autocomplete="off"
+    class="input input-bordered w-full mb-3"
+  />
+
+  <p id="search-status" class="text-sm text-base-content/60 mb-6">Type at least 3 characters to search.</p>
+
+  <div id="results-runners" class="mb-8 hidden">
+    <h2 class="text-lg font-semibold mb-3">Runners</h2>
+    <ul id="list-runners" class="flex flex-col gap-1"></ul>
+  </div>
+
+  <div id="results-races" class="mb-8 hidden">
+    <h2 class="text-lg font-semibold mb-3">Races</h2>
+    <ul id="list-races" class="flex flex-col gap-1"></ul>
+  </div>
+
+  <div id="results-pages" class="mb-8 hidden">
+    <h2 class="text-lg font-semibold mb-3">Pages</h2>
+    <ul id="list-pages" class="flex flex-col gap-1"></ul>
+  </div>
+</Layout>
+
+<script>
+  import Fuse from 'fuse.js'
+  import { createFuse, loadIndex, runSearch, typeLabel } from '../lib/search-client'
+  import type { SearchRecord } from '../lib/search-client'
+
+  const LIMIT = 50
+
+  const input = document.getElementById('search-input') as HTMLInputElement
+  const status = document.getElementById('search-status') as HTMLParagraphElement
+  const base = import.meta.env.BASE_URL.replace(/\/$/, '')
+
+  let fusePromise: Promise<Fuse<SearchRecord>> | null = null
+
+  function escapeHtml(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+  }
+
+  async function ensureFuse(): Promise<Fuse<SearchRecord>> {
+    if (!fusePromise) {
+      fusePromise = loadIndex().then(records => createFuse(records))
+    }
+    return fusePromise
+  }
+
+  function renderSection(
+    sectionId: string,
+    listId: string,
+    items: SearchRecord[],
+    showBadge: boolean
+  ): void {
+    const section = document.getElementById(sectionId)!
+    const list = document.getElementById(listId)!
+    if (items.length === 0) {
+      section.classList.add('hidden')
+      return
+    }
+    list.innerHTML = items.map(r =>
+      `<li><a href="${r.url}" class="flex items-center gap-2 py-1.5 hover:text-primary text-sm">` +
+      (showBadge ? `<span class="badge badge-ghost badge-sm shrink-0">${escapeHtml(typeLabel(r.type))}</span>` : '') +
+      `<span>${escapeHtml(r.label)}</span></a></li>`
+    ).join('')
+    section.classList.remove('hidden')
+  }
+
+  function displayResults(results: SearchRecord[], query: string, total: number): void {
+    const runners = results.filter(r => r.type === 'runner')
+    const races = results.filter(r => r.type === 'race-detail' || r.type === 'race-results')
+    const pages = results.filter(r => r.type === 'year' || r.type === 'standings')
+
+    renderSection('results-runners', 'list-runners', runners, false)
+    renderSection('results-races', 'list-races', races, true)
+    renderSection('results-pages', 'list-pages', pages, true)
+
+    if (results.length === 0) {
+      status.textContent = `No results for "${query}".`
+    } else if (total > LIMIT) {
+      status.textContent = `Showing ${LIMIT} of ${total} results — try a more specific search.`
+    } else {
+      status.textContent = `${results.length} result${results.length === 1 ? '' : 's'} for "${query}".`
+    }
+  }
+
+  function clearResults(): void {
+    for (const id of ['results-runners', 'results-races', 'results-pages']) {
+      document.getElementById(id)!.classList.add('hidden')
+    }
+  }
+
+  async function search(query: string): Promise<void> {
+    if (query.trim().length < 3) {
+      clearResults()
+      status.textContent = 'Type at least 3 characters to search.'
+      return
+    }
+    if (!fusePromise) {
+      status.textContent = 'Loading…'
+    }
+    const fuse = await ensureFuse()
+    const allResults = fuse.search(query)
+    const limited = allResults.slice(0, LIMIT).map(r => r.item)
+    displayResults(limited, query, allResults.length)
+  }
+
+  // On load: read ?q= from URL and run search
+  const params = new URLSearchParams(window.location.search)
+  const initialQuery = params.get('q') ?? ''
+  input.value = initialQuery
+  if (initialQuery) search(initialQuery)
+
+  // Live updates
+  input.addEventListener('input', () => {
+    const q = input.value.trim()
+    history.replaceState(null, '', q ? `${base}/search?q=${encodeURIComponent(q)}` : `${base}/search`)
+    search(q)
+  })
+</script>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -32,7 +32,7 @@ import Layout from '../components/Layout.astro';
   </div>
 
   <div id="results-pages" class="mb-8 hidden">
-    <h2 class="text-lg font-semibold mb-3">Pages</h2>
+    <h2 class="text-lg font-semibold mb-3">Series</h2>
     <ul id="list-pages" class="flex flex-col gap-1"></ul>
   </div>
 </Layout>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -74,7 +74,10 @@ import Layout from '../components/Layout.astro';
     list.innerHTML = items.map(r =>
       `<li><a href="${escapeHtml(r.url)}" class="flex items-center gap-2 py-1.5 hover:text-primary text-sm">` +
       (showBadge ? `<span class="badge badge-ghost badge-sm shrink-0">${escapeHtml(typeLabel(r.type))}</span>` : '') +
-      `<span>${escapeHtml(r.label)}</span></a></li>`
+      `<span class="flex flex-col">` +
+      `<span>${escapeHtml(r.label)}</span>` +
+      (r.subtitle ? `<span class="text-xs text-base-content/50">${escapeHtml(r.subtitle)}</span>` : '') +
+      `</span></a></li>`
     ).join('')
     section.classList.remove('hidden')
   }

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -34,7 +34,7 @@ import Layout from '../components/Layout.astro';
 
 <script>
   import Fuse from 'fuse.js'
-  import { createFuse, loadIndex, typeLabel } from '../lib/search-client'
+  import { createFuse, loadIndex } from '../lib/search-client'
   import type { SearchRecord } from '../lib/search-client'
 
   const LIMIT = 50
@@ -63,7 +63,6 @@ import Layout from '../components/Layout.astro';
     sectionId: string,
     listId: string,
     items: SearchRecord[],
-    showBadge: boolean
   ): void {
     const section = document.getElementById(sectionId)!
     const list = document.getElementById(listId)!
@@ -73,7 +72,6 @@ import Layout from '../components/Layout.astro';
     }
     list.innerHTML = items.map(r =>
       `<li><a href="${escapeHtml(r.url)}" class="flex items-center gap-2 py-1.5 hover:text-primary text-sm">` +
-      (showBadge ? `<span class="badge badge-ghost badge-sm shrink-0">${escapeHtml(typeLabel(r.type))}</span>` : '') +
       `<span class="flex flex-col">` +
       `<span>${escapeHtml(r.label)}</span>` +
       (r.subtitle ? `<span class="text-xs text-base-content/50">${escapeHtml(r.subtitle)}</span>` : '') +
@@ -87,9 +85,9 @@ import Layout from '../components/Layout.astro';
     const races = results.filter(r => r.type === 'race-detail' || r.type === 'race-results')
     const pages = results.filter(r => r.type === 'year' || r.type === 'standings')
 
-    renderSection('results-runners', 'list-runners', runners, false)
-    renderSection('results-races', 'list-races', races, true)
-    renderSection('results-pages', 'list-pages', pages, true)
+    renderSection('results-runners', 'list-runners', runners)
+    renderSection('results-races', 'list-races', races)
+    renderSection('results-pages', 'list-pages', pages)
 
     if (results.length === 0) {
       status.textContent = `No results for "${query}".`

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -7,7 +7,7 @@ import Layout from '../components/Layout.astro';
   <h1 class="text-2xl font-bold mb-4">Search</h1>
 
   <input
-    id="search-input"
+    id="search-page-input"
     type="search"
     placeholder="Search runners, races, history…"
     autocomplete="off"
@@ -34,12 +34,12 @@ import Layout from '../components/Layout.astro';
 
 <script>
   import Fuse from 'fuse.js'
-  import { createFuse, loadIndex, runSearch, typeLabel } from '../lib/search-client'
+  import { createFuse, loadIndex, typeLabel } from '../lib/search-client'
   import type { SearchRecord } from '../lib/search-client'
 
   const LIMIT = 50
 
-  const input = document.getElementById('search-input') as HTMLInputElement
+  const input = document.getElementById('search-page-input') as HTMLInputElement
   const status = document.getElementById('search-status') as HTMLParagraphElement
   const base = import.meta.env.BASE_URL.replace(/\/$/, '')
 

--- a/tests/search-client.test.ts
+++ b/tests/search-client.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { createFuse, runSearch, type SearchRecord } from '../src/lib/search-client'
+
+const records: SearchRecord[] = [
+  { type: 'runner', label: 'Steve Smith', url: '/runners/1-steve-smith/' },
+  { type: 'runner', label: 'Sarah Jones', url: '/runners/2-sarah-jones/' },
+  { type: 'runner', label: 'Alan Smithson', url: '/runners/3-alan-smithson/' },
+  { type: 'race-results', label: 'Preston Inter Club Results 2012', url: '/road-gp/2012/preston/results/' },
+  { type: 'year', label: 'Road GP 2012', url: '/road-gp/2012/' },
+]
+
+describe('runSearch', () => {
+  const fuse = createFuse(records)
+
+  it('returns empty array for query shorter than 3 characters', () => {
+    expect(runSearch(fuse, '')).toEqual([])
+    expect(runSearch(fuse, 'st')).toEqual([])
+    expect(runSearch(fuse, '  ')).toEqual([])
+  })
+
+  it('finds a runner by surname', () => {
+    const results = runSearch(fuse, 'smith')
+    const labels = results.map(r => r.label)
+    expect(labels).toContain('Steve Smith')
+  })
+
+  it('finds a race by partial name', () => {
+    const results = runSearch(fuse, 'preston')
+    const labels = results.map(r => r.label)
+    expect(labels.some(l => l.includes('Preston'))).toBe(true)
+  })
+
+  it('respects the limit', () => {
+    const manyRecords: SearchRecord[] = Array.from({ length: 100 }, (_, i) => ({
+      type: 'runner' as const,
+      label: `Runner ${String(i).padStart(3, '0')} Smith`,
+      url: `/runners/${i}/`,
+    }))
+    const bigFuse = createFuse(manyRecords)
+    const results = runSearch(bigFuse, 'smith', 10)
+    expect(results.length).toBeLessThanOrEqual(10)
+  })
+
+  it('returns at most 50 results by default', () => {
+    const manyRecords: SearchRecord[] = Array.from({ length: 200 }, (_, i) => ({
+      type: 'runner' as const,
+      label: `Runner ${String(i).padStart(3, '0')} Smith`,
+      url: `/runners/${i}/`,
+    }))
+    const bigFuse = createFuse(manyRecords)
+    expect(runSearch(bigFuse, 'smith').length).toBeLessThanOrEqual(50)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a navbar search box with live dropdown (top 8 results, min 3 chars) and a full `/search` results page grouped into Runners / Races / Pages
- Generates a build-time `search-index.json` covering runners, current-year race detail pages, race results (all years, both series), year archives, and standings pages
- Restricts road-gp race detail pages to the current year only (historical races are accessible via their results pages)

## Test Plan

- [ ] Navbar search input is visible on every page
- [ ] Typing 3+ characters shows a dropdown with fuzzy-matched results
- [ ] Pressing Enter or "See all results →" navigates to `/search?q=…`
- [ ] Search results page groups results under Runners / Races / Pages with type badges
- [ ] Typing in the search page updates results live and updates the URL
- [ ] Navigating to a past-year race path like `/road-gp/2025/wesham/` returns 404 (detail pages restricted to current year)
- [ ] Current-year race detail pages still exist at `/road-gp/2026/{raceId}/`
- [ ] `npm test` passes (74 tests)
- [ ] `npm run build` produces `dist/search-index.json`