### PR TITLE
fix: correct search-index.json URL construction

### DIFF
--- a/src/lib/search-client.ts
+++ b/src/lib/search-client.ts
@@ -18,7 +18,8 @@ export function runSearch(fuse: Fuse<SearchRecord>, query: string, limit = 50): 
 }
 
 export async function loadIndex(): Promise<SearchRecord[]> {
-  const res = await fetch(`${import.meta.env.BASE_URL}search-index.json`)
+  const base = import.meta.env.BASE_URL.replace(/\/$/, '')
+  const res = await fetch(`${base}/search-index.json`)
   return res.json()
 }
 


### PR DESCRIPTION
## Summary

- `BASE_URL` is `/InterClub` (no trailing slash per Astro config), so the previous fetch URL was built as `/InterClubsearch-index.json` — concatenating base and filename with no separator
- Strip any trailing slash from `BASE_URL` and add an explicit `/`, producing the correct `/InterClub/search-index.json`
- Consistent with the same pattern already used in `Layout.astro`, `SearchBox.astro`, `url.ts`, and `search.astro`

## Test plan

- [ ] Deploy to GitHub Pages and confirm search loads results (no 404 on `search-index.json`)
- [ ] Confirm the fetch URL in devtools network tab is `/InterClub/search-index.json`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)