### PR TITLE
feat: remove DaisyUI — migrate to native Tailwind CSS v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.4",
-        "daisyui": "^5.5.19",
         "tailwindcss": "^4.2.4",
         "vitest": "^4.1.5"
       },
@@ -2491,16 +2490,6 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
-    },
-    "node_modules/daisyui": {
-      "version": "5.5.19",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.19.tgz",
-      "integrity": "sha512-pbFAkl1VCEh/MPCeclKL61I/MqRIFFhNU7yiXoDDRapXN4/qNCoMxeCCswyxEEhqL5eiTTfwHvucFtOE71C9sA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
-      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.4",
-    "daisyui": "^5.5.19",
     "tailwindcss": "^4.2.4",
     "vitest": "^4.1.5"
   }

--- a/src/components/AwardsHistoryIndividuals.astro
+++ b/src/components/AwardsHistoryIndividuals.astro
@@ -15,7 +15,7 @@ const groups = [
 ---
 
 {groups.length === 0 ? (
-  <p class="text-base-content/60">No individual awards recorded.</p>
+  <p class="text-content/60">No individual awards recorded.</p>
 ) : (
   <div>
     <div role="tablist" class="tabs tabs-border mb-2">
@@ -54,7 +54,7 @@ const groups = [
             class={j > 0 ? 'hidden' : ''}
           >
             {cat.rows.length === 0 ? (
-              <p class="text-base-content/60">No awards recorded.</p>
+              <p class="text-content/60">No awards recorded.</p>
             ) : (
               <div class="overflow-x-auto">
                 <table class="table table-sm w-full">
@@ -82,7 +82,7 @@ const groups = [
                                   ) : (
                                     <span class="font-medium">{entry.name}</span>
                                   )}
-                                  <span class="text-base-content/50 ml-1">({entry.clubName})</span>
+                                  <span class="text-content/50 ml-1">({entry.clubName})</span>
                                 </span>
                               ) : <span>—</span>}
                             </td>

--- a/src/components/HistoryRaceList.astro
+++ b/src/components/HistoryRaceList.astro
@@ -52,7 +52,7 @@ const {
   )}
 
   {races.length > 0 && (
-    <div class="divide-y divide-base-200">
+    <div class="divide-y divide-line">
       {races.map(race => {
         const resultsUrl = hasResults(year, series, race.id)
           ? siteUrl(`/${series}/${year}/${race.id}/results/`)
@@ -62,7 +62,7 @@ const {
           : null;
         return (
           <div class="flex items-baseline gap-4 py-3">
-            <span class="text-sm text-base-content/50 w-28 shrink-0">
+            <span class="text-sm text-content/50 w-28 shrink-0">
               {formatRaceDate(race.date)}
             </span>
             <span class="flex-1 font-medium">{race.name}</span>
@@ -74,7 +74,7 @@ const {
                 <a href={teamResultsUrl} class="link link-hover">Team Results</a>
               )}
               {!resultsUrl && !teamResultsUrl && (
-                <span class="text-base-content/30">—</span>
+                <span class="text-content/30">—</span>
               )}
             </div>
           </div>
@@ -83,7 +83,7 @@ const {
     </div>
   )}
 
-  {note && <p class="text-base-content/60 italic text-sm mt-2">{note}</p>}
+  {note && <p class="text-content/60 italic text-sm mt-2">{note}</p>}
 
   {awards && (
     <div class="mt-8">

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -17,20 +17,18 @@ function isActive(path: string): boolean {
 ---
 
 <!doctype html>
-<html lang="en" data-theme="light">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title} — Inter Club</title>
     <link rel="icon" type="image/svg+xml" href={`${base}/favicon.svg`} />
   </head>
-  <body class="min-h-screen bg-base-200 flex flex-col">
-    <header class="bg-base-100 shadow-sm">
-      <div class="navbar max-w-4xl mx-auto px-4">
-        <div class="navbar-start">
-          <a href={`${base}/`} class="btn btn-ghost text-lg font-bold tracking-tight">Inter Club</a>
-        </div>
-        <div class="navbar-end gap-1">
+  <body class="min-h-screen bg-canvas flex flex-col">
+    <header class="bg-surface shadow-sm">
+      <div class="flex items-center justify-between max-w-4xl mx-auto px-4 h-14">
+        <a href={`${base}/`} class="btn btn-ghost text-lg font-bold tracking-tight">Inter Club</a>
+        <div class="flex items-center gap-1">
           <a
             href={`${base}/road-gp/`}
             class={`btn btn-ghost btn-sm ${isActive('/road-gp') ? 'btn-active' : ''}`}
@@ -52,7 +50,7 @@ function isActive(path: string): boolean {
       <slot />
     </main>
 
-    <footer class="footer footer-center p-4 bg-base-100 text-base-content/60 text-sm mt-8">
+    <footer class="flex justify-center p-4 bg-surface text-content/60 text-sm mt-8">
       <p>Inter Club Running Competition · Lancashire</p>
     </footer>
   </body>

--- a/src/components/RaceCard.astro
+++ b/src/components/RaceCard.astro
@@ -20,7 +20,7 @@ const href = isFell
   : siteUrl(`/${series}/${year}/${id}/`);
 const isExternal = isFell && !!detailsUrl;
 
-const cardClasses = "card bg-base-100 shadow-sm border border-base-200 no-underline";
+const cardClasses = "card shadow-sm no-underline";
 const linkClasses = `${cardClasses} hover:shadow-md transition-shadow`;
 ---
 
@@ -36,10 +36,10 @@ const linkClasses = `${cardClasses} hover:shadow-md transition-shadow`;
       </figure>
     )}
     <div class="card-body gap-1 py-4">
-      <p class="text-xs text-base-content/50 uppercase tracking-wide font-medium">{formattedDate}</p>
+      <p class="text-xs text-content/50 uppercase tracking-wide font-medium">{formattedDate}</p>
       <h2 class="card-title text-base font-bold">{name}</h2>
       {(location || distance) && (
-        <p class="text-sm text-base-content/70">
+        <p class="text-sm text-content/70">
           {location}{location && distance && ' · '}{distance}
         </p>
       )}
@@ -66,10 +66,10 @@ const linkClasses = `${cardClasses} hover:shadow-md transition-shadow`;
       </figure>
     )}
     <div class="card-body gap-1 py-4">
-      <p class="text-xs text-base-content/50 uppercase tracking-wide font-medium">{formattedDate}</p>
+      <p class="text-xs text-content/50 uppercase tracking-wide font-medium">{formattedDate}</p>
       <h2 class="card-title text-base font-bold">{name}</h2>
       {(location || distance) && (
-        <p class="text-sm text-base-content/70">
+        <p class="text-sm text-content/70">
           {location}{location && distance && ' · '}{distance}
         </p>
       )}

--- a/src/components/RaceList.astro
+++ b/src/components/RaceList.astro
@@ -52,7 +52,7 @@ const { races, year, series, availableYears, currentYear, seriesBasePath, series
   {awards && <SeriesAwards awards={awards} />}
 
   {races.length === 0 ? (
-    <p class="text-base-content/60">No races found for {year}.</p>
+    <p class="text-content/60">No races found for {year}.</p>
   ) : (
     <div class="flex flex-col gap-4">
       {races.map(race => (

--- a/src/components/SearchBox.astro
+++ b/src/components/SearchBox.astro
@@ -8,11 +8,11 @@
     type="search"
     placeholder="Search…"
     autocomplete="off"
-    class="input input-bordered input-sm w-32 sm:w-44 transition-all focus:w-44 sm:focus:w-56"
+    class="input input-sm w-32 sm:w-44 transition-all focus:w-44 sm:focus:w-56"
   />
   <ul
     id="search-dropdown"
-    class="hidden absolute right-0 top-full mt-1 w-72 bg-base-100 rounded-box shadow-lg border border-base-200 z-50 overflow-hidden"
+    class="hidden absolute right-0 top-full mt-1 w-72 bg-surface rounded-xl shadow-lg border border-line z-50 overflow-hidden"
   ></ul>
 </div>
 
@@ -47,15 +47,15 @@
       return
     }
     const items = results.slice(0, 8).map(r =>
-      `<li><a href="${escapeHtml(r.url)}" class="flex items-center gap-2 px-3 py-2 hover:bg-base-200 text-sm">` +
+      `<li><a href="${escapeHtml(r.url)}" class="flex items-center gap-2 px-3 py-2 hover:bg-canvas text-sm">` +
       `<span class="min-w-0 flex flex-col">` +
       `<span class="truncate">${escapeHtml(r.label)}</span>` +
-      (r.subtitle ? `<span class="text-xs text-base-content/50 truncate">${escapeHtml(r.subtitle)}</span>` : '') +
+      (r.subtitle ? `<span class="text-xs text-content/50 truncate">${escapeHtml(r.subtitle)}</span>` : '') +
       `</span></a></li>`
     ).join('')
     const footer =
-      `<li class="border-t border-base-200">` +
-      `<a href="${base}/search?q=${encodeURIComponent(query)}" class="block px-3 py-2 text-sm text-primary hover:bg-base-200">` +
+      `<li class="border-t border-line">` +
+      `<a href="${base}/search?q=${encodeURIComponent(query)}" class="block px-3 py-2 text-sm text-amber hover:bg-canvas">` +
       `See all results →</a></li>`
     dropdown.innerHTML = items + footer
     dropdown.classList.remove('hidden')

--- a/src/components/SeriesAwards.astro
+++ b/src/components/SeriesAwards.astro
@@ -23,13 +23,13 @@ function positionLabel(pos: number): string {
 const hasMF = awards.maleAwards.length > 0 || awards.femaleAwards.length > 0;
 ---
 
-<div class="card bg-base-200 mb-6">
+<div class="card bg-canvas mb-6">
   <div class="card-body p-4 gap-4">
     <h2 class="card-title text-base">🏆 Series Winners</h2>
 
     {awards.teamAwards.length > 0 && (
       <div>
-        <p class="text-xs uppercase tracking-wider text-base-content/50 mb-2">Team</p>
+        <p class="text-xs uppercase tracking-wider text-content/50 mb-2">Team</p>
         <div class="flex flex-wrap gap-2">
           {awards.teamAwards.map(ta => (
             <span class="badge badge-lg gap-1 font-normal">
@@ -43,13 +43,13 @@ const hasMF = awards.maleAwards.length > 0 || awards.femaleAwards.length > 0;
 
     {(awards.overallAwards.length > 0 || hasMF) && (
       <div>
-        <p class="text-xs uppercase tracking-wider text-base-content/50 mb-2">Individual</p>
+        <p class="text-xs uppercase tracking-wider text-content/50 mb-2">Individual</p>
 
         {awards.overallAwards.length > 0 && (
           <div class="flex flex-col gap-2 mb-3">
             {awards.overallAwards.map(cat => (
-              <div class="bg-base-100 rounded-lg p-3">
-                <p class="text-xs text-base-content/50 mb-1">{cat.categoryName}</p>
+              <div class="bg-surface rounded-lg p-3">
+                <p class="text-xs text-content/50 mb-1">{cat.categoryName}</p>
                 <div class="flex flex-col gap-1">
                   {cat.awards.map(a => (
                     <div class="flex items-baseline gap-2 text-sm">
@@ -57,7 +57,7 @@ const hasMF = awards.maleAwards.length > 0 || awards.femaleAwards.length > 0;
                       {a.runnerUrl
                         ? <a href={a.runnerUrl} class="font-medium link link-hover">{a.name}</a>
                         : <span class="font-medium">{a.name}</span>}
-                      <span class="text-base-content/50 text-xs">{a.clubName}</span>
+                      <span class="text-content/50 text-xs">{a.clubName}</span>
                     </div>
                   ))}
                 </div>
@@ -70,8 +70,8 @@ const hasMF = awards.maleAwards.length > 0 || awards.femaleAwards.length > 0;
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
             <div class="flex flex-col gap-2">
               {awards.maleAwards.map(cat => (
-                <div class="bg-base-100 rounded-lg p-3">
-                  <p class="text-xs text-base-content/50 mb-1">{cat.categoryName}</p>
+                <div class="bg-surface rounded-lg p-3">
+                  <p class="text-xs text-content/50 mb-1">{cat.categoryName}</p>
                   <div class="flex flex-col gap-1">
                     {cat.awards.map(a => (
                       <div class="flex items-baseline gap-2 text-sm">
@@ -79,7 +79,7 @@ const hasMF = awards.maleAwards.length > 0 || awards.femaleAwards.length > 0;
                         {a.runnerUrl
                         ? <a href={a.runnerUrl} class="font-medium link link-hover">{a.name}</a>
                         : <span class="font-medium">{a.name}</span>}
-                        <span class="text-base-content/50 text-xs">{a.clubName}</span>
+                        <span class="text-content/50 text-xs">{a.clubName}</span>
                       </div>
                     ))}
                   </div>
@@ -88,8 +88,8 @@ const hasMF = awards.maleAwards.length > 0 || awards.femaleAwards.length > 0;
             </div>
             <div class="flex flex-col gap-2">
               {awards.femaleAwards.map(cat => (
-                <div class="bg-base-100 rounded-lg p-3">
-                  <p class="text-xs text-base-content/50 mb-1">{cat.categoryName}</p>
+                <div class="bg-surface rounded-lg p-3">
+                  <p class="text-xs text-content/50 mb-1">{cat.categoryName}</p>
                   <div class="flex flex-col gap-1">
                     {cat.awards.map(a => (
                       <div class="flex items-baseline gap-2 text-sm">
@@ -97,7 +97,7 @@ const hasMF = awards.maleAwards.length > 0 || awards.femaleAwards.length > 0;
                         {a.runnerUrl
                         ? <a href={a.runnerUrl} class="font-medium link link-hover">{a.name}</a>
                         : <span class="font-medium">{a.name}</span>}
-                        <span class="text-base-content/50 text-xs">{a.clubName}</span>
+                        <span class="text-content/50 text-xs">{a.clubName}</span>
                       </div>
                     ))}
                   </div>

--- a/src/components/SeriesAwards.astro
+++ b/src/components/SeriesAwards.astro
@@ -33,7 +33,7 @@ const hasMF = awards.maleAwards.length > 0 || awards.femaleAwards.length > 0;
         <div class="flex flex-wrap gap-2">
           {awards.teamAwards.map(ta => (
             <span class="badge badge-lg gap-1 font-normal">
-              🏆 <span class="text-base-content/60">{ta.categoryName}:</span>
+              🏆 <span class="text-content/60">{ta.categoryName}:</span>
               <span class="font-semibold">{ta.clubName}</span>
             </span>
           ))}

--- a/src/components/YearFilter.astro
+++ b/src/components/YearFilter.astro
@@ -17,9 +17,9 @@ function yearUrl(year: number): string {
 ---
 
 <div class="flex items-center gap-2">
-  <span class="text-sm text-base-content/60">Season:</span>
+  <span class="text-sm text-content/60">Season:</span>
   <select
-    class="select select-bordered select-sm"
+    class="select select-sm"
     onchange="window.location.href = this.value"
     aria-label="Select season year"
   >

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -6,7 +6,7 @@ import { siteUrl } from '../lib/url';
 <Layout title="Contact">
   <div class="max-w-lg mx-auto">
     <h1 class="text-2xl font-bold mb-2">Contact</h1>
-    <p class="text-base-content/70 mb-8">
+    <p class="text-content/70 mb-8">
       Use this form to report result corrections or send a general enquiry.
     </p>
 
@@ -20,7 +20,7 @@ import { siteUrl } from '../lib/url';
           type="text"
           name="name"
           required
-          class="input input-bordered w-full"
+          class="input w-full"
         />
       </div>
 
@@ -33,7 +33,7 @@ import { siteUrl } from '../lib/url';
           type="email"
           name="email"
           required
-          class="input input-bordered w-full"
+          class="input w-full"
         />
       </div>
 
@@ -46,7 +46,7 @@ import { siteUrl } from '../lib/url';
           name="message"
           required
           rows="6"
-          class="textarea textarea-bordered w-full"
+          class="textarea w-full"
         ></textarea>
       </div>
 

--- a/src/pages/contact/thank-you.astro
+++ b/src/pages/contact/thank-you.astro
@@ -6,7 +6,7 @@ import { siteUrl } from '../../lib/url';
 <Layout title="Message Sent">
   <div class="max-w-lg mx-auto text-center py-16">
     <h1 class="text-2xl font-bold mb-4">Thanks for getting in touch</h1>
-    <p class="text-base-content/70 mb-8">We'll get back to you soon.</p>
+    <p class="text-content/70 mb-8">We'll get back to you soon.</p>
     <a href={siteUrl('/')} class="btn btn-primary">Back to home</a>
   </div>
 </Layout>

--- a/src/pages/fell/[year]/[raceId]/results.astro
+++ b/src/pages/fell/[year]/[raceId]/results.astro
@@ -43,22 +43,22 @@ const showTeamResults = hasTeamResults(year, 'fell', raceId);
         <span class="badge badge-warning badge-lg">Provisional</span>
       )}
     </div>
-    {race && <p class="text-sm text-base-content/60 mt-1">{year}</p>}
+    {race && <p class="text-sm text-content/60 mt-1">{year}</p>}
   </div>
 
   <!-- Filter bar -->
-  <div class="bg-base-100 border border-base-200 rounded-lg p-3 mb-4 flex flex-col sm:flex-row gap-2 sm:items-center flex-wrap">
+  <div class="bg-surface border border-line rounded-lg p-3 mb-4 flex flex-col sm:flex-row gap-2 sm:items-center flex-wrap">
     <input
       id="filter-name"
       type="search"
       placeholder="Search name or number…"
-      class="input input-bordered input-sm w-full sm:w-40"
+      class="input input-sm w-full sm:w-40"
     />
-    <select id="filter-club" class="select select-bordered select-sm w-full sm:w-auto">
+    <select id="filter-club" class="select select-sm w-full sm:w-auto">
       <option value="">All Clubs</option>
       {clubs.map(c => <option value={c.id}>{c.name}</option>)}
     </select>
-    <select id="filter-cat" class="select select-bordered select-sm w-full sm:w-auto">
+    <select id="filter-cat" class="select select-sm w-full sm:w-auto">
       <option value="">All Categories</option>
       {(config.ageCategories ?? []).map(cat => <option value={cat}>{cat}</option>)}
     </select>

--- a/src/pages/fell/[year]/[raceId]/team-results.astro
+++ b/src/pages/fell/[year]/[raceId]/team-results.astro
@@ -38,12 +38,12 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
         <span class="badge badge-warning badge-lg">Provisional</span>
       )}
     </div>
-    {race && <p class="text-sm text-base-content/60 mt-1">{year}</p>}
+    {race && <p class="text-sm text-content/60 mt-1">{year}</p>}
   </div>
 
   <!-- Category tabs -->
   <div class="overflow-x-auto -mx-4 px-4 mb-1">
-    <div class="flex border-b border-base-200 min-w-max" role="tablist">
+    <div class="flex border-b border-line min-w-max" role="tablist">
       {teamResults.categories.map((cat, i) => {
         const label = categoryById[cat.id]?.name ?? cat.id;
         return (
@@ -51,8 +51,8 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
             class:list={[
               'tab-btn px-4 py-2 text-sm border-b-2 -mb-px whitespace-nowrap transition-colors',
               i === 0
-                ? 'border-primary font-medium'
-                : 'border-transparent text-base-content/50 hover:text-base-content',
+                ? 'border-amber font-medium'
+                : 'border-transparent text-content/50 hover:text-content',
             ]}
             data-target={`cat-panel-${i}`}
             role="tab"
@@ -71,7 +71,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
     return (
       <div id={`cat-panel-${i}`} class:list={['pt-3', i > 0 && 'hidden']} role="tabpanel">
         {catConfig && (
-          <p class="text-xs text-base-content/40 mb-3">
+          <p class="text-xs text-content/40 mb-3">
             {catConfig.scorerCount} scorers · lower score wins
           </p>
         )}
@@ -79,29 +79,29 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
           const club = clubById[clubResult.club];
           const clubName = club?.name ?? clubResult.club;
           return (
-            <div class="border-b border-base-200 py-3 sm:grid sm:grid-cols-2 sm:gap-x-8 sm:items-start last:border-0">
+            <div class="border-b border-line py-3 sm:grid sm:grid-cols-2 sm:gap-x-8 sm:items-start last:border-0">
               <div class="flex items-baseline gap-2">
-                <span class="w-5 shrink-0 text-sm text-base-content/40 tabular-nums">
+                <span class="w-5 shrink-0 text-sm text-content/40 tabular-nums">
                   {clubResult.position}
                 </span>
                 <span class="font-semibold">{clubName}</span>
                 <span class="ml-auto text-sm">
-                  <strong class="text-base-content/70">{clubResult.points}</strong>
-                  <span class="text-base-content/40"> {clubResult.points === 1 ? 'pt' : 'pts'}</span>
+                  <strong class="text-content/70">{clubResult.points}</strong>
+                  <span class="text-content/40"> {clubResult.points === 1 ? 'pt' : 'pts'}</span>
                 </span>
               </div>
               <details class="scorer-details mt-1 sm:mt-0">
-                <summary class="sm:hidden list-none cursor-pointer select-none text-xs text-base-content/40 py-1">
+                <summary class="sm:hidden list-none cursor-pointer select-none text-xs text-content/40 py-1">
                   Show scorers
                 </summary>
                 <ul class="mt-1">
                   {clubResult.scorers.map(scorer => (
                     <li class="flex justify-between py-0.5 text-sm">
-                      <span class="text-base-content/70">{scorer.name || '–'}</span>
-                      <span class="tabular-nums text-base-content/50">{scorer.position}</span>
+                      <span class="text-content/70">{scorer.name || '–'}</span>
+                      <span class="tabular-nums text-content/50">{scorer.position}</span>
                     </li>
                   ))}
-                  <li class="flex justify-between pt-1.5 mt-1 border-t border-base-200 text-sm font-semibold">
+                  <li class="flex justify-between pt-1.5 mt-1 border-t border-line text-sm font-semibold">
                     <span>Total</span>
                     <span class="tabular-nums">{clubResult.total}</span>
                   </li>
@@ -122,10 +122,10 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
       const targetId = btn.dataset.target!;
       tabs.forEach(t => {
         const active = t === btn;
-        t.classList.toggle('border-primary', active);
+        t.classList.toggle('border-amber', active);
         t.classList.toggle('font-medium', active);
         t.classList.toggle('border-transparent', !active);
-        t.classList.toggle('text-base-content/50', !active);
+        t.classList.toggle('text-content/50', !active);
         t.setAttribute('aria-selected', active ? 'true' : 'false');
       });
       document.querySelectorAll<HTMLElement>('[id^="cat-panel-"]').forEach(panel => {

--- a/src/pages/fell/[year]/individual-standings.astro
+++ b/src/pages/fell/[year]/individual-standings.astro
@@ -41,15 +41,15 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
         <span class="badge badge-warning badge-lg">Provisional</span>
       )}
     </div>
-    <p class="text-sm text-base-content/60 mt-1">{year} Inter Club Fell Championship</p>
+    <p class="text-sm text-content/60 mt-1">{year} Inter Club Fell Championship</p>
     {standings.maxCountingRaces && (
-      <p class="text-sm text-base-content/60 mt-0.5">Best {standings.maxCountingRaces} races count</p>
+      <p class="text-sm text-content/60 mt-0.5">Best {standings.maxCountingRaces} races count</p>
     )}
   </div>
 
   <!-- Category tabs -->
   <div class="overflow-x-auto -mx-4 px-4 mb-1">
-    <div class="flex border-b border-base-200 min-w-max" role="tablist">
+    <div class="flex border-b border-line min-w-max" role="tablist">
       {standings.categories.map((cat, i) => {
         const label = resolveIndividualCategoryName(cat.id, cat.sex, cat.ageCategory, cat.name);
         return (
@@ -57,8 +57,8 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
             class:list={[
               'tab-btn px-4 py-2 text-sm border-b-2 -mb-px whitespace-nowrap transition-colors',
               i === 0
-                ? 'border-primary font-medium'
-                : 'border-transparent text-base-content/50 hover:text-base-content',
+                ? 'border-amber font-medium'
+                : 'border-transparent text-content/50 hover:text-content',
             ]}
             data-target={`cat-panel-${i}`}
             role="tab"
@@ -97,11 +97,11 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
         <div class="hidden sm:block overflow-x-auto">
           <table class="w-full border-collapse text-sm">
             <thead>
-              <tr class="border-b border-base-200">
-                <th class="text-left py-2 pr-3 text-base-content/40 font-medium w-8">#</th>
-                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Name</th>
-                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Club</th>
-                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Cat</th>
+              <tr class="border-b border-line">
+                <th class="text-left py-2 pr-3 text-content/40 font-medium w-8">#</th>
+                <th class="text-left py-2 pr-4 text-content/40 font-medium">Name</th>
+                <th class="text-left py-2 pr-4 text-content/40 font-medium">Club</th>
+                <th class="text-left py-2 pr-4 text-content/40 font-medium">Cat</th>
                 {standings.races.map(raceId => {
                   const race = raceById[raceId];
                   const label = race?.shortName ?? raceId;
@@ -109,13 +109,13 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                   return (
                     <th class="text-right py-2 px-2 font-medium whitespace-nowrap">
                       {href
-                        ? <a href={href} class="text-primary hover:underline">{label}</a>
-                        : <span class="text-base-content/20">{label}</span>
+                        ? <a href={href} class="text-amber hover:underline">{label}</a>
+                        : <span class="text-content/20">{label}</span>
                       }
                     </th>
                   );
                 })}
-                <th class="text-right py-2 pl-4 text-base-content/40 font-medium">Total</th>
+                <th class="text-right py-2 pl-4 text-content/40 font-medium">Total</th>
               </tr>
             </thead>
             <tbody>
@@ -126,25 +126,25 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                 const catLabel = `${effectiveSex}${effectiveAgeCategory}`;
                 return (
                   <tr
-                    class="border-b border-base-200/50 last:border-0 hover:bg-base-200/30"
+                    class="border-b border-line/50 last:border-0 hover:bg-canvas/30"
                     data-sex={runner.sex ?? cat.sex}
                     data-age-cat={runner.ageCategory ?? cat.ageCategory}
                   >
-                    <td class="py-2.5 pr-3 text-base-content/40 tabular-nums">{runner.position}</td>
+                    <td class="py-2.5 pr-3 text-content/40 tabular-nums">{runner.position}</td>
                     <td class="py-2.5 pr-4 font-semibold">
                       {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]
                         ? <a href={runnerUrlMap[runner.seriesRunnerId]} class="link link-hover">{runner.name}</a>
                         : runner.name}
                     </td>
                     <td class="py-2.5 pr-4">{clubName}</td>
-                    <td class="py-2.5 pr-4 text-base-content/60 text-xs tabular-nums">{catLabel}</td>
+                    <td class="py-2.5 pr-4 text-content/60 text-xs tabular-nums">{catLabel}</td>
                     {standings.races.map(raceId => {
                       const result = runner.results[raceId];
                       if (!result) return <td class="py-2.5 px-2" />;
                       return (
                         <td class:list={[
                           'py-2.5 px-2 text-right tabular-nums',
-                          !result.counting && 'text-base-content/30',
+                          !result.counting && 'text-content/30',
                         ]}>
                           <span class:list={[!result.counting && 'line-through']}>
                             {result.points}
@@ -153,7 +153,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                       );
                     })}
                     <td class="py-2.5 pl-4 text-right">
-                      <strong class="text-base-content/80">{runner.total}</strong>
+                      <strong class="text-content/80">{runner.total}</strong>
                     </td>
                   </tr>
                 );
@@ -165,7 +165,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
         <!-- Mobile view -->
         <div class="sm:hidden">
           <!-- Race key -->
-          <div class="flex flex-wrap gap-x-3 gap-y-1 py-3 border-b border-base-200 mb-1 text-xs text-base-content/40">
+          <div class="flex flex-wrap gap-x-3 gap-y-1 py-3 border-b border-line mb-1 text-xs text-content/40">
             {standings.races.map(raceId => {
               const race = raceById[raceId];
               const label = race?.shortName ?? raceId;
@@ -173,7 +173,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
               return (
                 <span>
                   {href
-                    ? <a href={href} class="text-primary">{label}</a>
+                    ? <a href={href} class="text-amber">{label}</a>
                     : label
                   }
                   {' = '}{race?.name ?? raceId}
@@ -190,7 +190,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
             const detailId = `detail-${i}-${runnerIdx}`;
             return (
               <div
-                class="runner-card border-b border-base-200 last:border-0"
+                class="runner-card border-b border-line last:border-0"
                 data-sex={runner.sex ?? cat.sex}
                 data-age-cat={runner.ageCategory ?? cat.ageCategory}
               >
@@ -199,17 +199,17 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                   data-target={detailId}
                   aria-expanded="false"
                 >
-                  <span class="w-6 shrink-0 text-sm text-base-content/40 tabular-nums">{runner.position}</span>
+                  <span class="w-6 shrink-0 text-sm text-content/40 tabular-nums">{runner.position}</span>
                   <span class="flex-1 font-semibold">
                     {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]
                       ? <a href={runnerUrlMap[runner.seriesRunnerId]} class="link link-hover">{runner.name}</a>
                       : runner.name}
                   </span>
-                  <strong class="text-base-content/80">{runner.total}</strong>
-                  <span class="chevron text-base-content/30 text-xs ml-1 transition-transform">▾</span>
+                  <strong class="text-content/80">{runner.total}</strong>
+                  <span class="chevron text-content/30 text-xs ml-1 transition-transform">▾</span>
                 </button>
                 <div id={detailId} class="hidden pb-3 pl-8">
-                  <p class="text-sm text-base-content/60 mb-1.5">
+                  <p class="text-sm text-content/60 mb-1.5">
                     {clubName} · <span class="font-mono text-xs">{catLabel}</span>
                   </p>
                   <div class="flex flex-wrap gap-1.5">
@@ -221,14 +221,14 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                       return (
                         <div class:list={[
                           'rounded px-2.5 py-1 text-center text-sm min-w-[44px]',
-                          result.counting ? 'bg-base-200' : 'bg-base-200/40',
+                          result.counting ? 'bg-canvas' : 'bg-canvas/40',
                         ]}>
                           {href
-                            ? <a href={href} class:list={['block text-[10px] mb-0.5', result.counting ? 'text-primary' : 'text-base-content/30']}>{label}</a>
-                            : <span class:list={['block text-[10px] mb-0.5', result.counting ? 'text-base-content/40' : 'text-base-content/20']}>{label}</span>
+                            ? <a href={href} class:list={['block text-[10px] mb-0.5', result.counting ? 'text-amber' : 'text-content/30']}>{label}</a>
+                            : <span class:list={['block text-[10px] mb-0.5', result.counting ? 'text-content/40' : 'text-content/20']}>{label}</span>
                           }
                           <span class:list={[
-                            result.counting ? 'font-semibold' : 'text-base-content/30 line-through',
+                            result.counting ? 'font-semibold' : 'text-content/30 line-through',
                           ]}>{result.points}</span>
                         </div>
                       );
@@ -253,10 +253,10 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
       const targetId = btn.dataset.target!;
       tabs.forEach(t => {
         const active = t === btn;
-        t.classList.toggle('border-primary', active);
+        t.classList.toggle('border-amber', active);
         t.classList.toggle('font-medium', active);
         t.classList.toggle('border-transparent', !active);
-        t.classList.toggle('text-base-content/50', !active);
+        t.classList.toggle('text-content/50', !active);
         t.setAttribute('aria-selected', active ? 'true' : 'false');
       });
       document.querySelectorAll<HTMLElement>('[id^="cat-panel-"]').forEach(panel => {

--- a/src/pages/fell/[year]/team-standings.astro
+++ b/src/pages/fell/[year]/team-standings.astro
@@ -38,12 +38,12 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
         <span class="badge badge-warning badge-lg">Provisional</span>
       )}
     </div>
-    <p class="text-sm text-base-content/60 mt-1">{year} Inter Club Fell Championship</p>
+    <p class="text-sm text-content/60 mt-1">{year} Inter Club Fell Championship</p>
   </div>
 
   <!-- Category tabs -->
   <div class="overflow-x-auto -mx-4 px-4 mb-1">
-    <div class="flex border-b border-base-200 min-w-max" role="tablist">
+    <div class="flex border-b border-line min-w-max" role="tablist">
       {standings.categories.map((cat, i) => {
         const label = categoryById[cat.id]?.name ?? cat.id;
         return (
@@ -51,8 +51,8 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
             class:list={[
               'tab-btn px-4 py-2 text-sm border-b-2 -mb-px whitespace-nowrap transition-colors',
               i === 0
-                ? 'border-primary font-medium'
-                : 'border-transparent text-base-content/50 hover:text-base-content',
+                ? 'border-amber font-medium'
+                : 'border-transparent text-content/50 hover:text-content',
             ]}
             data-target={`cat-panel-${i}`}
             role="tab"
@@ -73,9 +73,9 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
       <div class="hidden sm:block overflow-x-auto">
         <table class="w-full border-collapse text-sm">
           <thead>
-            <tr class="border-b border-base-200">
-              <th class="text-left py-2 pr-3 text-base-content/40 font-medium w-8">#</th>
-              <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Club</th>
+            <tr class="border-b border-line">
+              <th class="text-left py-2 pr-3 text-content/40 font-medium w-8">#</th>
+              <th class="text-left py-2 pr-4 text-content/40 font-medium">Club</th>
               {standings.races.map(raceId => {
                 const race = raceById[raceId];
                 const label = race?.shortName ?? raceId;
@@ -85,31 +85,31 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
                 return (
                   <th class="text-right py-2 px-2 font-medium whitespace-nowrap">
                     {href
-                      ? <a href={href} class="text-primary hover:underline">{label}</a>
-                      : <span class="text-base-content/20">{label}</span>
+                      ? <a href={href} class="text-amber hover:underline">{label}</a>
+                      : <span class="text-content/20">{label}</span>
                     }
                   </th>
                 );
               })}
-              <th class="text-right py-2 pl-4 text-base-content/40 font-medium">Total</th>
+              <th class="text-right py-2 pl-4 text-content/40 font-medium">Total</th>
             </tr>
           </thead>
           <tbody>
             {cat.clubs.map(clubResult => {
               const clubName = clubById[clubResult.club]?.name ?? clubResult.club;
               return (
-                <tr class="border-b border-base-200/50 last:border-0 hover:bg-base-200/30">
-                  <td class="py-2.5 pr-3 text-base-content/40 tabular-nums">{clubResult.position}</td>
+                <tr class="border-b border-line/50 last:border-0 hover:bg-canvas/30">
+                  <td class="py-2.5 pr-3 text-content/40 tabular-nums">{clubResult.position}</td>
                   <td class="py-2.5 pr-4 font-semibold">{clubName}</td>
                   {clubResult.points.map(pts => (
-                    <td class:list={['py-2.5 px-2 text-right tabular-nums', pts === null && 'text-base-content/20']}>
+                    <td class:list={['py-2.5 px-2 text-right tabular-nums', pts === null && 'text-content/20']}>
                       {pts ?? '—'}
                     </td>
                   ))}
                   <td class="py-2.5 pl-4 text-right">
-                    <strong class="text-base-content/80">{clubResult.total}</strong>
+                    <strong class="text-content/80">{clubResult.total}</strong>
                     {clubResult.tiebreaker && (
-                      <span class="block text-xs text-base-content/40 mt-0.5">{clubResult.tiebreaker}</span>
+                      <span class="block text-xs text-content/40 mt-0.5">{clubResult.tiebreaker}</span>
                     )}
                   </td>
                 </tr>
@@ -121,7 +121,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
 
       <!-- Mobile view -->
       <div class="sm:hidden">
-        <div class="flex flex-wrap gap-x-3 gap-y-1 py-3 border-b border-base-200 mb-1 text-xs text-base-content/40">
+        <div class="flex flex-wrap gap-x-3 gap-y-1 py-3 border-b border-line mb-1 text-xs text-content/40">
           {standings.races.map(raceId => {
             const race = raceById[raceId];
             const label = race?.shortName ?? raceId;
@@ -131,7 +131,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
             return (
               <span>
                 {href
-                  ? <a href={href} class="text-primary">{label}</a>
+                  ? <a href={href} class="text-amber">{label}</a>
                   : label
                 }
                 {' = '}{race?.name ?? raceId}
@@ -144,16 +144,16 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
           const clubName = clubById[clubResult.club]?.name ?? clubResult.club;
           const detailId = `detail-${i}-${clubResult.club}`;
           return (
-            <div class="border-b border-base-200 last:border-0">
+            <div class="border-b border-line last:border-0">
               <button
                 class="standings-toggle w-full flex items-center gap-2 py-2.5 text-left"
                 data-target={detailId}
                 aria-expanded="false"
               >
-                <span class="w-6 shrink-0 text-sm text-base-content/40 tabular-nums">{clubResult.position}</span>
+                <span class="w-6 shrink-0 text-sm text-content/40 tabular-nums">{clubResult.position}</span>
                 <span class="flex-1 font-semibold">{clubName}</span>
-                <strong class="text-base-content/80">{clubResult.total}</strong>
-                <span class="chevron text-base-content/30 text-xs ml-1 transition-transform">▾</span>
+                <strong class="text-content/80">{clubResult.total}</strong>
+                <span class="chevron text-content/30 text-xs ml-1 transition-transform">▾</span>
               </button>
               <div id={detailId} class="hidden pb-3">
                 <div class="flex flex-wrap gap-1.5 pl-8">
@@ -168,19 +168,19 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
                     return (
                       <div class:list={[
                         'rounded px-2.5 py-1 text-center text-sm min-w-[44px]',
-                        isEmpty ? 'bg-base-200/40' : 'bg-base-200',
+                        isEmpty ? 'bg-canvas/40' : 'bg-canvas',
                       ]}>
                         {href
-                          ? <a href={href} class="block text-[10px] text-primary mb-0.5">{label}</a>
-                          : <span class:list={['block text-[10px] mb-0.5', isEmpty ? 'text-base-content/20' : 'text-base-content/40']}>{label}</span>
+                          ? <a href={href} class="block text-[10px] text-amber mb-0.5">{label}</a>
+                          : <span class:list={['block text-[10px] mb-0.5', isEmpty ? 'text-content/20' : 'text-content/40']}>{label}</span>
                         }
-                        <span class:list={[isEmpty ? 'text-base-content/20' : 'font-semibold']}>{pts ?? '—'}</span>
+                        <span class:list={[isEmpty ? 'text-content/20' : 'font-semibold']}>{pts ?? '—'}</span>
                       </div>
                     );
                   })}
                 </div>
                 {clubResult.tiebreaker && (
-                  <p class="pl-8 mt-1.5 text-xs text-base-content/40">{clubResult.tiebreaker}</p>
+                  <p class="pl-8 mt-1.5 text-xs text-content/40">{clubResult.tiebreaker}</p>
                 )}
               </div>
             </div>
@@ -199,10 +199,10 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
       const targetId = btn.dataset.target!;
       tabs.forEach(t => {
         const active = t === btn;
-        t.classList.toggle('border-primary', active);
+        t.classList.toggle('border-amber', active);
         t.classList.toggle('font-medium', active);
         t.classList.toggle('border-transparent', !active);
-        t.classList.toggle('text-base-content/50', !active);
+        t.classList.toggle('text-content/50', !active);
         t.setAttribute('aria-selected', active ? 'true' : 'false');
       });
       document.querySelectorAll<HTMLElement>('[id^="cat-panel-"]').forEach(panel => {

--- a/src/pages/fell/index.astro
+++ b/src/pages/fell/index.astro
@@ -15,17 +15,17 @@ const standingsUrl = hasTeamStandings(currentYear, 'fell')
 ---
 
 <Layout title="Fell Championship">
-  <p class="mb-6 text-base-content/80">
+  <p class="mb-6 text-content/80">
     The Inter Club Fell Championship is a series of four fell races held during the summer. Races
     run within pre-existing open events governed by FRA or BOFRA regulations, across varied fell
     terrain. Unlike the Road Grand Prix, races are not free — entry fees must be paid by each
     competitor.
   </p>
 
-  <div class="card bg-base-100 shadow-sm mb-6">
+  <div class="card shadow-sm mb-6">
     <div class="card-body gap-2 py-4">
       <h2 class="text-lg font-semibold">Key Rules</h2>
-      <ul class="list-disc list-inside space-y-1 text-sm text-base-content/80">
+      <ul class="list-disc list-inside space-y-1 text-sm text-content/80">
         <li>Competitors are responsible for their own safety on the fells and must obey all rules set by race organisers</li>
         <li>Additional mandatory kit and protective clothing may be required; failure to carry required kit risks disqualification</li>
       </ul>
@@ -43,7 +43,7 @@ const standingsUrl = hasTeamStandings(currentYear, 'fell')
     standingsUrl={standingsUrl}
   />
 
-  <div class="card bg-base-100 shadow-sm mt-6">
+  <div class="card shadow-sm mt-6">
     <div class="card-body gap-2 py-4">
       <h2 class="text-lg font-semibold">Team Categories</h2>
       <div class="overflow-x-auto">
@@ -67,10 +67,10 @@ const standingsUrl = hasTeamStandings(currentYear, 'fell')
     </div>
   </div>
 
-  <div class="card bg-base-100 shadow-sm mt-4">
+  <div class="card shadow-sm mt-4">
     <div class="card-body gap-2 py-4">
       <h2 class="text-lg font-semibold">Team Scoring</h2>
-      <ul class="list-disc list-inside space-y-1 text-sm text-base-content/80">
+      <ul class="list-disc list-inside space-y-1 text-sm text-content/80">
         <li>1st team 7 points, 2nd team 6 points … 7th team 1 point</li>
         <li>Incomplete teams still score and are ordered by number of finishing runners</li>
         <li>Where multiple clubs have the same number of finishers, normal scoring rules apply</li>
@@ -79,10 +79,10 @@ const standingsUrl = hasTeamStandings(currentYear, 'fell')
     </div>
   </div>
 
-  <div class="card bg-base-100 shadow-sm mt-4">
+  <div class="card shadow-sm mt-4">
     <div class="card-body gap-2 py-4">
       <h2 class="text-lg font-semibold">Individual Awards</h2>
-      <p class="text-sm text-base-content/80">
+      <p class="text-sm text-content/80">
         Individual standings are based on the lowest total positions from your best 3 of 4 races.
         Awards are presented to the 1st, 2nd, and 3rd place finishers overall, and to the top 2 in
         each veteran category. Awards are presented at the following season's buffet. Only one award

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -70,12 +70,12 @@ function isNext(races: Race[], race: Race): boolean {
     <div class="flex items-center justify-between mb-4">
       <h2 class="text-xl font-bold">Road Grand Prix</h2>
       {roadStandingsUrl && (
-        <a href={roadStandingsUrl} class="text-sm text-primary hover:underline">Standings →</a>
+        <a href={roadStandingsUrl} class="text-sm text-amber hover:underline">Standings →</a>
       )}
     </div>
 
     {heroRace && heroMode && (
-      <div class={`card shadow mb-4 ${heroMode === 'recent' ? 'bg-success text-success-content' : 'bg-primary text-primary-content'}`}>
+      <div class={`card shadow mb-4 ${heroMode === 'recent' ? 'bg-success text-white' : 'bg-amber text-white'}`}>
         <div class="card-body flex-row items-center justify-between flex-wrap gap-4 py-4">
           <div>
             <div class="text-xs uppercase tracking-wide opacity-70 mb-1">{heroLabel}</div>
@@ -86,11 +86,11 @@ function isNext(races: Race[], race: Race): boolean {
             </p>
           </div>
           {heroMode === 'recent' ? (
-            <a href={siteUrl(`/road-gp/${currentYear}/${heroRace.id}/results`)} class={`btn btn-sm border-0 shrink-0 bg-white text-success hover:bg-base-200`}>
+            <a href={siteUrl(`/road-gp/${currentYear}/${heroRace.id}/results`)} class={`btn btn-sm border-0 shrink-0 bg-white text-success hover:bg-canvas`}>
               View results →
             </a>
           ) : (
-            <a href={siteUrl(`/road-gp/${currentYear}/${heroRace.id}`)} class={`btn btn-sm border-0 shrink-0 bg-white text-primary hover:bg-base-200`}>
+            <a href={siteUrl(`/road-gp/${currentYear}/${heroRace.id}`)} class={`btn btn-sm border-0 shrink-0 bg-white text-amber hover:bg-canvas`}>
               Race info →
             </a>
           )}
@@ -99,14 +99,14 @@ function isNext(races: Race[], race: Race): boolean {
     )}
 
     <div class="overflow-x-auto">
-      <table class="table table-sm bg-base-100 rounded-box shadow-sm w-full">
+      <table class="table table-sm bg-surface rounded-xl shadow-sm w-full">
         <tbody>
           {roadRaces.map(race => {
             const past = isPast(race);
             const next = isNext(roadRaces, race);
             return (
-              <tr class:list={[{ 'opacity-40': past, 'bg-primary/5': next }]}>
-                <td class:list={['text-sm w-28', { 'text-base-content/70': past }]}>
+              <tr class:list={[{ 'opacity-40': past, 'bg-amber/5': next }]}>
+                <td class:list={['text-sm w-28', { 'text-content/70': past }]}>
                   {formatRaceDate(race.date)}
                 </td>
                 <td class:list={['text-sm', { 'font-bold': next }]}>
@@ -134,19 +134,19 @@ function isNext(races: Race[], race: Race): boolean {
     <div class="flex items-center justify-between mb-4">
       <h2 class="text-xl font-bold">Fell Championship</h2>
       {fellStandingsUrl && (
-        <a href={fellStandingsUrl} class="text-sm text-primary hover:underline">Standings →</a>
+        <a href={fellStandingsUrl} class="text-sm text-amber hover:underline">Standings →</a>
       )}
     </div>
 
     <div class="overflow-x-auto">
-      <table class="table table-sm bg-base-100 rounded-box shadow-sm w-full">
+      <table class="table table-sm bg-surface rounded-xl shadow-sm w-full">
         <tbody>
           {fellRaces.map(race => {
             const past = isPast(race);
             const next = isNext(fellRaces, race);
             return (
-              <tr class:list={[{ 'opacity-40': past, 'bg-primary/5': next }]}>
-                <td class:list={['text-sm w-28', { 'text-base-content/70': past }]}>
+              <tr class:list={[{ 'opacity-40': past, 'bg-amber/5': next }]}>
+                <td class:list={['text-sm w-28', { 'text-content/70': past }]}>
                   {formatRaceDate(race.date)}
                 </td>
                 <td class:list={['text-sm', { 'font-bold': next }]}>

--- a/src/pages/road-gp/[year]/[raceId].astro
+++ b/src/pages/road-gp/[year]/[raceId].astro
@@ -49,7 +49,7 @@ const hasRouteText = !!(routeDescription || (courseRecords && courseRecords.leng
     <a href={backUrl} class="btn btn-ghost btn-sm gap-1 -ml-3">← Road Grand Prix</a>
   </div>
 
-  <div class="card bg-base-100 shadow-sm border border-base-200">
+  <div class="card shadow-sm">
     {image && (
       <figure>
         <img src={siteUrl(`/images/${image}`)} alt={name} class="w-full h-56 object-cover" />
@@ -58,9 +58,9 @@ const hasRouteText = !!(routeDescription || (courseRecords && courseRecords.leng
     <div class="card-body gap-4">
 
       <!-- Header -->
-      <p class="text-sm text-base-content/50 uppercase tracking-wide font-medium">{formattedDate}</p>
+      <p class="text-sm text-content/50 uppercase tracking-wide font-medium">{formattedDate}</p>
       <h1 class="text-2xl font-bold">{name}</h1>
-      {location && <p class="text-base-content/70">{location}</p>}
+      {location && <p class="text-content/70">{location}</p>}
       {(distance || ascent) && (
         <div class="flex flex-wrap gap-2">
           {distance && <span class="badge badge-outline">{distance}</span>}
@@ -77,14 +77,14 @@ const hasRouteText = !!(routeDescription || (courseRecords && courseRecords.leng
               <dl class="flex flex-col gap-3">
                 {startAddress && (
                   <div>
-                    <dt class="text-xs text-base-content/50 uppercase tracking-wide mb-1">Start location</dt>
+                    <dt class="text-xs text-content/50 uppercase tracking-wide mb-1">Start location</dt>
                     <dd class="font-medium">{startAddress}</dd>
                   </div>
                 )}
                 {parking && (
                   <div>
-                    <dt class="text-xs text-base-content/50 uppercase tracking-wide mb-1">Parking</dt>
-                    <dd class="text-base-content/80">{parking}</dd>
+                    <dt class="text-xs text-content/50 uppercase tracking-wide mb-1">Parking</dt>
+                    <dd class="text-content/80">{parking}</dd>
                   </div>
                 )}
               </dl>
@@ -116,11 +116,11 @@ const hasRouteText = !!(routeDescription || (courseRecords && courseRecords.leng
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div class="flex flex-col gap-3">
                 {routeDescription && (
-                  <p class="text-base-content/80">{routeDescription}</p>
+                  <p class="text-content/80">{routeDescription}</p>
                 )}
                 {courseRecords && courseRecords.length > 0 && (
                   <div>
-                    <p class="text-xs text-base-content/50 uppercase tracking-wide mb-2">Course Records</p>
+                    <p class="text-xs text-content/50 uppercase tracking-wide mb-2">Course Records</p>
                     <div class="flex flex-col gap-1">
                       {courseRecords.map(record => (
                         <div class="flex items-center gap-2 text-sm">
@@ -128,8 +128,8 @@ const hasRouteText = !!(routeDescription || (courseRecords && courseRecords.leng
                             {record.sex === 'M' ? 'Men' : 'Women'}
                           </span>
                           <span class="font-medium font-mono">{record.time}</span>
-                          <span class="text-base-content/70">{record.name}</span>
-                          <span class="text-base-content/50">({record.year})</span>
+                          <span class="text-content/70">{record.name}</span>
+                          <span class="text-content/50">({record.year})</span>
                         </div>
                       ))}
                     </div>
@@ -160,7 +160,7 @@ const hasRouteText = !!(routeDescription || (courseRecords && courseRecords.leng
       {postRaceVenue && (
         <>
           <div class="divider my-1 text-sm font-semibold">After the Race</div>
-          <p class="text-base-content/80">{postRaceVenue}</p>
+          <p class="text-content/80">{postRaceVenue}</p>
         </>
       )}
 
@@ -171,7 +171,7 @@ const hasRouteText = !!(routeDescription || (courseRecords && courseRecords.leng
           <div class="flex flex-wrap items-center gap-2">
             {pastResults.map((r, i) => (
               <>
-                {i > 0 && <span class="text-base-content/30">·</span>}
+                {i > 0 && <span class="text-content/30">·</span>}
                 <a href={r.url} class="link link-hover text-sm">{r.year}</a>
               </>
             ))}

--- a/src/pages/road-gp/[year]/[raceId]/results.astro
+++ b/src/pages/road-gp/[year]/[raceId]/results.astro
@@ -43,22 +43,22 @@ const showTeamResults = hasTeamResults(year, 'road-gp', raceId);
         <span class="badge badge-warning badge-lg">Provisional</span>
       )}
     </div>
-    {race && <p class="text-sm text-base-content/60 mt-1">{year}</p>}
+    {race && <p class="text-sm text-content/60 mt-1">{year}</p>}
   </div>
 
   <!-- Filter bar -->
-  <div class="bg-base-100 border border-base-200 rounded-lg p-3 mb-4 flex flex-col sm:flex-row gap-2 sm:items-center flex-wrap">
+  <div class="bg-surface border border-line rounded-lg p-3 mb-4 flex flex-col sm:flex-row gap-2 sm:items-center flex-wrap">
     <input
       id="filter-name"
       type="search"
       placeholder="Search name or number…"
-      class="input input-bordered input-sm w-full sm:w-40"
+      class="input input-sm w-full sm:w-40"
     />
-    <select id="filter-club" class="select select-bordered select-sm w-full sm:w-auto">
+    <select id="filter-club" class="select select-sm w-full sm:w-auto">
       <option value="">All Clubs</option>
       {clubs.map(c => <option value={c.id}>{c.name}</option>)}
     </select>
-    <select id="filter-cat" class="select select-bordered select-sm w-full sm:w-auto">
+    <select id="filter-cat" class="select select-sm w-full sm:w-auto">
       <option value="">All Categories</option>
       {(config.ageCategories ?? []).map(cat => <option value={cat}>{cat}</option>)}
     </select>

--- a/src/pages/road-gp/[year]/[raceId]/team-results.astro
+++ b/src/pages/road-gp/[year]/[raceId]/team-results.astro
@@ -38,12 +38,12 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
         <span class="badge badge-warning badge-lg">Provisional</span>
       )}
     </div>
-    {race && <p class="text-sm text-base-content/60 mt-1">{year}</p>}
+    {race && <p class="text-sm text-content/60 mt-1">{year}</p>}
   </div>
 
   <!-- Category tabs -->
   <div class="overflow-x-auto -mx-4 px-4 mb-1">
-    <div class="flex border-b border-base-200 min-w-max" role="tablist">
+    <div class="flex border-b border-line min-w-max" role="tablist">
       {teamResults.categories.map((cat, i) => {
         const label = categoryById[cat.id]?.name ?? cat.id;
         return (
@@ -51,8 +51,8 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
             class:list={[
               'tab-btn px-4 py-2 text-sm border-b-2 -mb-px whitespace-nowrap transition-colors',
               i === 0
-                ? 'border-primary font-medium'
-                : 'border-transparent text-base-content/50 hover:text-base-content',
+                ? 'border-amber font-medium'
+                : 'border-transparent text-content/50 hover:text-content',
             ]}
             data-target={`cat-panel-${i}`}
             role="tab"
@@ -71,7 +71,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
     return (
       <div id={`cat-panel-${i}`} class:list={['pt-3', i > 0 && 'hidden']} role="tabpanel">
         {catConfig && (
-          <p class="text-xs text-base-content/40 mb-3">
+          <p class="text-xs text-content/40 mb-3">
             {catConfig.scorerCount} scorers · lower score wins
           </p>
         )}
@@ -79,31 +79,31 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
           const club = clubById[clubResult.club];
           const clubName = club?.name ?? clubResult.club;
           return (
-            <div class="border-b border-base-200 py-3 sm:grid sm:grid-cols-2 sm:gap-x-8 sm:items-start last:border-0">
+            <div class="border-b border-line py-3 sm:grid sm:grid-cols-2 sm:gap-x-8 sm:items-start last:border-0">
               <!-- Club info: position | name | points -->
               <div class="flex items-baseline gap-2">
-                <span class="w-5 shrink-0 text-sm text-base-content/40 tabular-nums">
+                <span class="w-5 shrink-0 text-sm text-content/40 tabular-nums">
                   {clubResult.position}
                 </span>
                 <span class="font-semibold">{clubName}</span>
                 <span class="ml-auto text-sm">
-                  <strong class="text-base-content/70">{clubResult.points}</strong>
-                  <span class="text-base-content/40"> {clubResult.points === 1 ? 'pt' : 'pts'}</span>
+                  <strong class="text-content/70">{clubResult.points}</strong>
+                  <span class="text-content/40"> {clubResult.points === 1 ? 'pt' : 'pts'}</span>
                 </span>
               </div>
               <!-- Scorers: collapsible on mobile, always open on desktop -->
               <details class="scorer-details mt-1 sm:mt-0">
-                <summary class="sm:hidden list-none cursor-pointer select-none text-xs text-base-content/40 py-1">
+                <summary class="sm:hidden list-none cursor-pointer select-none text-xs text-content/40 py-1">
                   Show scorers
                 </summary>
                 <ul class="mt-1">
                   {clubResult.scorers.map(scorer => (
                     <li class="flex justify-between py-0.5 text-sm">
-                      <span class="text-base-content/70">{scorer.name || '–'}</span>
-                      <span class="tabular-nums text-base-content/50">{scorer.position}</span>
+                      <span class="text-content/70">{scorer.name || '–'}</span>
+                      <span class="tabular-nums text-content/50">{scorer.position}</span>
                     </li>
                   ))}
-                  <li class="flex justify-between pt-1.5 mt-1 border-t border-base-200 text-sm font-semibold">
+                  <li class="flex justify-between pt-1.5 mt-1 border-t border-line text-sm font-semibold">
                     <span>Total</span>
                     <span class="tabular-nums">{clubResult.total}</span>
                   </li>
@@ -125,10 +125,10 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
       const targetId = btn.dataset.target!;
       tabs.forEach(t => {
         const active = t === btn;
-        t.classList.toggle('border-primary', active);
+        t.classList.toggle('border-amber', active);
         t.classList.toggle('font-medium', active);
         t.classList.toggle('border-transparent', !active);
-        t.classList.toggle('text-base-content/50', !active);
+        t.classList.toggle('text-content/50', !active);
         t.setAttribute('aria-selected', active ? 'true' : 'false');
       });
       document.querySelectorAll<HTMLElement>('[id^="cat-panel-"]').forEach(panel => {

--- a/src/pages/road-gp/[year]/individual-standings.astro
+++ b/src/pages/road-gp/[year]/individual-standings.astro
@@ -41,15 +41,15 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
         <span class="badge badge-warning badge-lg">Provisional</span>
       )}
     </div>
-    <p class="text-sm text-base-content/60 mt-1">{year} Inter Club Road Grand Prix</p>
+    <p class="text-sm text-content/60 mt-1">{year} Inter Club Road Grand Prix</p>
     {standings.maxCountingRaces && (
-      <p class="text-sm text-base-content/60 mt-0.5">Best {standings.maxCountingRaces} races count</p>
+      <p class="text-sm text-content/60 mt-0.5">Best {standings.maxCountingRaces} races count</p>
     )}
   </div>
 
   <!-- Category tabs -->
   <div class="overflow-x-auto -mx-4 px-4 mb-1">
-    <div class="flex border-b border-base-200 min-w-max" role="tablist">
+    <div class="flex border-b border-line min-w-max" role="tablist">
       {standings.categories.map((cat, i) => {
         const label = resolveIndividualCategoryName(cat.id, cat.sex, cat.ageCategory, cat.name);
         return (
@@ -57,8 +57,8 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
             class:list={[
               'tab-btn px-4 py-2 text-sm border-b-2 -mb-px whitespace-nowrap transition-colors',
               i === 0
-                ? 'border-primary font-medium'
-                : 'border-transparent text-base-content/50 hover:text-base-content',
+                ? 'border-amber font-medium'
+                : 'border-transparent text-content/50 hover:text-content',
             ]}
             data-target={`cat-panel-${i}`}
             role="tab"
@@ -97,11 +97,11 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
         <div class="hidden sm:block overflow-x-auto">
           <table class="w-full border-collapse text-sm">
             <thead>
-              <tr class="border-b border-base-200">
-                <th class="text-left py-2 pr-3 text-base-content/40 font-medium w-8">#</th>
-                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Name</th>
-                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Club</th>
-                <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Cat</th>
+              <tr class="border-b border-line">
+                <th class="text-left py-2 pr-3 text-content/40 font-medium w-8">#</th>
+                <th class="text-left py-2 pr-4 text-content/40 font-medium">Name</th>
+                <th class="text-left py-2 pr-4 text-content/40 font-medium">Club</th>
+                <th class="text-left py-2 pr-4 text-content/40 font-medium">Cat</th>
                 {standings.races.map(raceId => {
                   const race = raceById[raceId];
                   const label = race?.shortName ?? raceId;
@@ -109,13 +109,13 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                   return (
                     <th class="text-right py-2 px-2 font-medium whitespace-nowrap">
                       {href
-                        ? <a href={href} class="text-primary hover:underline">{label}</a>
-                        : <span class="text-base-content/20">{label}</span>
+                        ? <a href={href} class="text-amber hover:underline">{label}</a>
+                        : <span class="text-content/20">{label}</span>
                       }
                     </th>
                   );
                 })}
-                <th class="text-right py-2 pl-4 text-base-content/40 font-medium">Total</th>
+                <th class="text-right py-2 pl-4 text-content/40 font-medium">Total</th>
               </tr>
             </thead>
             <tbody>
@@ -126,25 +126,25 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                 const catLabel = `${effectiveSex}${effectiveAgeCategory}`;
                 return (
                   <tr
-                    class="border-b border-base-200/50 last:border-0 hover:bg-base-200/30"
+                    class="border-b border-line/50 last:border-0 hover:bg-canvas/30"
                     data-sex={runner.sex ?? cat.sex}
                     data-age-cat={runner.ageCategory ?? cat.ageCategory}
                   >
-                    <td class="py-2.5 pr-3 text-base-content/40 tabular-nums">{runner.position}</td>
+                    <td class="py-2.5 pr-3 text-content/40 tabular-nums">{runner.position}</td>
                     <td class="py-2.5 pr-4 font-semibold">
                       {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]
                         ? <a href={runnerUrlMap[runner.seriesRunnerId]} class="link link-hover">{runner.name}</a>
                         : runner.name}
                     </td>
                     <td class="py-2.5 pr-4">{clubName}</td>
-                    <td class="py-2.5 pr-4 text-base-content/60 text-xs tabular-nums">{catLabel}</td>
+                    <td class="py-2.5 pr-4 text-content/60 text-xs tabular-nums">{catLabel}</td>
                     {standings.races.map(raceId => {
                       const result = runner.results[raceId];
                       if (!result) return <td class="py-2.5 px-2" />;
                       return (
                         <td class:list={[
                           'py-2.5 px-2 text-right tabular-nums',
-                          !result.counting && 'text-base-content/30',
+                          !result.counting && 'text-content/30',
                         ]}>
                           <span class:list={[!result.counting && 'line-through']}>
                             {result.points}
@@ -153,7 +153,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                       );
                     })}
                     <td class="py-2.5 pl-4 text-right">
-                      <strong class="text-base-content/80">{runner.total}</strong>
+                      <strong class="text-content/80">{runner.total}</strong>
                     </td>
                   </tr>
                 );
@@ -165,7 +165,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
         <!-- Mobile view -->
         <div class="sm:hidden">
           <!-- Race key -->
-          <div class="flex flex-wrap gap-x-3 gap-y-1 py-3 border-b border-base-200 mb-1 text-xs text-base-content/40">
+          <div class="flex flex-wrap gap-x-3 gap-y-1 py-3 border-b border-line mb-1 text-xs text-content/40">
             {standings.races.map(raceId => {
               const race = raceById[raceId];
               const label = race?.shortName ?? raceId;
@@ -173,7 +173,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
               return (
                 <span>
                   {href
-                    ? <a href={href} class="text-primary">{label}</a>
+                    ? <a href={href} class="text-amber">{label}</a>
                     : label
                   }
                   {' = '}{race?.name ?? raceId}
@@ -190,7 +190,7 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
             const detailId = `detail-${i}-${runnerIdx}`;
             return (
               <div
-                class="runner-card border-b border-base-200 last:border-0"
+                class="runner-card border-b border-line last:border-0"
                 data-sex={runner.sex ?? cat.sex}
                 data-age-cat={runner.ageCategory ?? cat.ageCategory}
               >
@@ -199,17 +199,17 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                   data-target={detailId}
                   aria-expanded="false"
                 >
-                  <span class="w-6 shrink-0 text-sm text-base-content/40 tabular-nums">{runner.position}</span>
+                  <span class="w-6 shrink-0 text-sm text-content/40 tabular-nums">{runner.position}</span>
                   <span class="flex-1 font-semibold">
                     {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]
                       ? <a href={runnerUrlMap[runner.seriesRunnerId]} class="link link-hover">{runner.name}</a>
                       : runner.name}
                   </span>
-                  <strong class="text-base-content/80">{runner.total}</strong>
-                  <span class="chevron text-base-content/30 text-xs ml-1 transition-transform">▾</span>
+                  <strong class="text-content/80">{runner.total}</strong>
+                  <span class="chevron text-content/30 text-xs ml-1 transition-transform">▾</span>
                 </button>
                 <div id={detailId} class="hidden pb-3 pl-8">
-                  <p class="text-sm text-base-content/60 mb-1.5">
+                  <p class="text-sm text-content/60 mb-1.5">
                     {clubName} · <span class="font-mono text-xs">{catLabel}</span>
                   </p>
                   <div class="flex flex-wrap gap-1.5">
@@ -221,14 +221,14 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
                       return (
                         <div class:list={[
                           'rounded px-2.5 py-1 text-center text-sm min-w-[44px]',
-                          result.counting ? 'bg-base-200' : 'bg-base-200/40',
+                          result.counting ? 'bg-canvas' : 'bg-canvas/40',
                         ]}>
                           {href
-                            ? <a href={href} class:list={['block text-[10px] mb-0.5', result.counting ? 'text-primary' : 'text-base-content/30']}>{label}</a>
-                            : <span class:list={['block text-[10px] mb-0.5', result.counting ? 'text-base-content/40' : 'text-base-content/20']}>{label}</span>
+                            ? <a href={href} class:list={['block text-[10px] mb-0.5', result.counting ? 'text-amber' : 'text-content/30']}>{label}</a>
+                            : <span class:list={['block text-[10px] mb-0.5', result.counting ? 'text-content/40' : 'text-content/20']}>{label}</span>
                           }
                           <span class:list={[
-                            result.counting ? 'font-semibold' : 'text-base-content/30 line-through',
+                            result.counting ? 'font-semibold' : 'text-content/30 line-through',
                           ]}>{result.points}</span>
                         </div>
                       );
@@ -253,10 +253,10 @@ const clubById = Object.fromEntries(clubs.map(c => [c.id, c]));
       const targetId = btn.dataset.target!;
       tabs.forEach(t => {
         const active = t === btn;
-        t.classList.toggle('border-primary', active);
+        t.classList.toggle('border-amber', active);
         t.classList.toggle('font-medium', active);
         t.classList.toggle('border-transparent', !active);
-        t.classList.toggle('text-base-content/50', !active);
+        t.classList.toggle('text-content/50', !active);
         t.setAttribute('aria-selected', active ? 'true' : 'false');
       });
       document.querySelectorAll<HTMLElement>('[id^="cat-panel-"]').forEach(panel => {

--- a/src/pages/road-gp/[year]/team-standings.astro
+++ b/src/pages/road-gp/[year]/team-standings.astro
@@ -38,12 +38,12 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
         <span class="badge badge-warning badge-lg">Provisional</span>
       )}
     </div>
-    <p class="text-sm text-base-content/60 mt-1">{year} Inter Club Road Grand Prix</p>
+    <p class="text-sm text-content/60 mt-1">{year} Inter Club Road Grand Prix</p>
   </div>
 
   <!-- Category tabs -->
   <div class="overflow-x-auto -mx-4 px-4 mb-1">
-    <div class="flex border-b border-base-200 min-w-max" role="tablist">
+    <div class="flex border-b border-line min-w-max" role="tablist">
       {standings.categories.map((cat, i) => {
         const label = categoryById[cat.id]?.name ?? cat.id;
         return (
@@ -51,8 +51,8 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
             class:list={[
               'tab-btn px-4 py-2 text-sm border-b-2 -mb-px whitespace-nowrap transition-colors',
               i === 0
-                ? 'border-primary font-medium'
-                : 'border-transparent text-base-content/50 hover:text-base-content',
+                ? 'border-amber font-medium'
+                : 'border-transparent text-content/50 hover:text-content',
             ]}
             data-target={`cat-panel-${i}`}
             role="tab"
@@ -73,9 +73,9 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
       <div class="hidden sm:block overflow-x-auto">
         <table class="w-full border-collapse text-sm">
           <thead>
-            <tr class="border-b border-base-200">
-              <th class="text-left py-2 pr-3 text-base-content/40 font-medium w-8">#</th>
-              <th class="text-left py-2 pr-4 text-base-content/40 font-medium">Club</th>
+            <tr class="border-b border-line">
+              <th class="text-left py-2 pr-3 text-content/40 font-medium w-8">#</th>
+              <th class="text-left py-2 pr-4 text-content/40 font-medium">Club</th>
               {standings.races.map(raceId => {
                 const race = raceById[raceId];
                 const label = race?.shortName ?? raceId;
@@ -85,31 +85,31 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
                 return (
                   <th class="text-right py-2 px-2 font-medium whitespace-nowrap">
                     {href
-                      ? <a href={href} class="text-primary hover:underline">{label}</a>
-                      : <span class="text-base-content/20">{label}</span>
+                      ? <a href={href} class="text-amber hover:underline">{label}</a>
+                      : <span class="text-content/20">{label}</span>
                     }
                   </th>
                 );
               })}
-              <th class="text-right py-2 pl-4 text-base-content/40 font-medium">Total</th>
+              <th class="text-right py-2 pl-4 text-content/40 font-medium">Total</th>
             </tr>
           </thead>
           <tbody>
             {cat.clubs.map(clubResult => {
               const clubName = clubById[clubResult.club]?.name ?? clubResult.club;
               return (
-                <tr class="border-b border-base-200/50 last:border-0 hover:bg-base-200/30">
-                  <td class="py-2.5 pr-3 text-base-content/40 tabular-nums">{clubResult.position}</td>
+                <tr class="border-b border-line/50 last:border-0 hover:bg-canvas/30">
+                  <td class="py-2.5 pr-3 text-content/40 tabular-nums">{clubResult.position}</td>
                   <td class="py-2.5 pr-4 font-semibold">{clubName}</td>
                   {clubResult.points.map(pts => (
-                    <td class:list={['py-2.5 px-2 text-right tabular-nums', pts === null && 'text-base-content/20']}>
+                    <td class:list={['py-2.5 px-2 text-right tabular-nums', pts === null && 'text-content/20']}>
                       {pts ?? '—'}
                     </td>
                   ))}
                   <td class="py-2.5 pl-4 text-right">
-                    <strong class="text-base-content/80">{clubResult.total}</strong>
+                    <strong class="text-content/80">{clubResult.total}</strong>
                     {clubResult.tiebreaker && (
-                      <span class="block text-xs text-base-content/40 mt-0.5">{clubResult.tiebreaker}</span>
+                      <span class="block text-xs text-content/40 mt-0.5">{clubResult.tiebreaker}</span>
                     )}
                   </td>
                 </tr>
@@ -122,7 +122,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
       <!-- Mobile view (below sm) -->
       <div class="sm:hidden">
         <!-- Race legend -->
-        <div class="flex flex-wrap gap-x-3 gap-y-1 py-3 border-b border-base-200 mb-1 text-xs text-base-content/40">
+        <div class="flex flex-wrap gap-x-3 gap-y-1 py-3 border-b border-line mb-1 text-xs text-content/40">
           {standings.races.map(raceId => {
             const race = raceById[raceId];
             const label = race?.shortName ?? raceId;
@@ -132,7 +132,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
             return (
               <span>
                 {href
-                  ? <a href={href} class="text-primary">{label}</a>
+                  ? <a href={href} class="text-amber">{label}</a>
                   : label
                 }
                 {' = '}{race?.name ?? raceId}
@@ -146,16 +146,16 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
           const clubName = clubById[clubResult.club]?.name ?? clubResult.club;
           const detailId = `detail-${i}-${clubResult.club}`;
           return (
-            <div class="border-b border-base-200 last:border-0">
+            <div class="border-b border-line last:border-0">
               <button
                 class="standings-toggle w-full flex items-center gap-2 py-2.5 text-left"
                 data-target={detailId}
                 aria-expanded="false"
               >
-                <span class="w-6 shrink-0 text-sm text-base-content/40 tabular-nums">{clubResult.position}</span>
+                <span class="w-6 shrink-0 text-sm text-content/40 tabular-nums">{clubResult.position}</span>
                 <span class="flex-1 font-semibold">{clubName}</span>
-                <strong class="text-base-content/80">{clubResult.total}</strong>
-                <span class="chevron text-base-content/30 text-xs ml-1 transition-transform">▾</span>
+                <strong class="text-content/80">{clubResult.total}</strong>
+                <span class="chevron text-content/30 text-xs ml-1 transition-transform">▾</span>
               </button>
               <div id={detailId} class="hidden pb-3">
                 <div class="flex flex-wrap gap-1.5 pl-8">
@@ -170,19 +170,19 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
                     return (
                       <div class:list={[
                         'rounded px-2.5 py-1 text-center text-sm min-w-[44px]',
-                        isEmpty ? 'bg-base-200/40' : 'bg-base-200',
+                        isEmpty ? 'bg-canvas/40' : 'bg-canvas',
                       ]}>
                         {href
-                          ? <a href={href} class="block text-[10px] text-primary mb-0.5">{label}</a>
-                          : <span class:list={['block text-[10px] mb-0.5', isEmpty ? 'text-base-content/20' : 'text-base-content/40']}>{label}</span>
+                          ? <a href={href} class="block text-[10px] text-amber mb-0.5">{label}</a>
+                          : <span class:list={['block text-[10px] mb-0.5', isEmpty ? 'text-content/20' : 'text-content/40']}>{label}</span>
                         }
-                        <span class:list={[isEmpty ? 'text-base-content/20' : 'font-semibold']}>{pts ?? '—'}</span>
+                        <span class:list={[isEmpty ? 'text-content/20' : 'font-semibold']}>{pts ?? '—'}</span>
                       </div>
                     );
                   })}
                 </div>
                 {clubResult.tiebreaker && (
-                  <p class="pl-8 mt-1.5 text-xs text-base-content/40">{clubResult.tiebreaker}</p>
+                  <p class="pl-8 mt-1.5 text-xs text-content/40">{clubResult.tiebreaker}</p>
                 )}
               </div>
             </div>
@@ -202,10 +202,10 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
       const targetId = btn.dataset.target!;
       tabs.forEach(t => {
         const active = t === btn;
-        t.classList.toggle('border-primary', active);
+        t.classList.toggle('border-amber', active);
         t.classList.toggle('font-medium', active);
         t.classList.toggle('border-transparent', !active);
-        t.classList.toggle('text-base-content/50', !active);
+        t.classList.toggle('text-content/50', !active);
         t.setAttribute('aria-selected', active ? 'true' : 'false');
       });
       document.querySelectorAll<HTMLElement>('[id^="cat-panel-"]').forEach(panel => {

--- a/src/pages/road-gp/index.astro
+++ b/src/pages/road-gp/index.astro
@@ -15,17 +15,17 @@ const standingsUrl = hasTeamStandings(currentYear, 'road-gp')
 ---
 
 <Layout title="Road Grand Prix">
-  <p class="mb-6 text-base-content/80">
+  <p class="mb-6 text-content/80">
     The Inter Club Road Grand Prix is a series of seven races of between four and five miles, held
     midweek from April to September. Races are free to enter and run in a spirit of fun as well as
     being quite competitive. Each host club provides a complimentary buffet after their event. Race
     numbers are assigned before the season and remain valid throughout.
   </p>
 
-  <div class="card bg-base-100 shadow-sm mb-6">
+  <div class="card shadow-sm mb-6">
     <div class="card-body gap-2 py-4">
       <h2 class="text-lg font-semibold">Key Rules</h2>
-      <ul class="list-disc list-inside space-y-1 text-sm text-base-content/80">
+      <ul class="list-disc list-inside space-y-1 text-sm text-content/80">
         <li>No headphones or similar devices are permitted in IC Road races</li>
         <li>Minimum age is 15 on the day of competition</li>
         <li>Club members only — no guest runners</li>
@@ -46,7 +46,7 @@ const standingsUrl = hasTeamStandings(currentYear, 'road-gp')
     standingsUrl={standingsUrl}
   />
 
-  <div class="card bg-base-100 shadow-sm mt-6">
+  <div class="card shadow-sm mt-6">
     <div class="card-body gap-2 py-4">
       <h2 class="text-lg font-semibold">Team Categories</h2>
       <div class="overflow-x-auto">
@@ -71,10 +71,10 @@ const standingsUrl = hasTeamStandings(currentYear, 'road-gp')
     </div>
   </div>
 
-  <div class="card bg-base-100 shadow-sm mt-4">
+  <div class="card shadow-sm mt-4">
     <div class="card-body gap-2 py-4">
       <h2 class="text-lg font-semibold">Team Scoring</h2>
-      <ul class="list-disc list-inside space-y-1 text-sm text-base-content/80">
+      <ul class="list-disc list-inside space-y-1 text-sm text-content/80">
         <li>1st team 7 points, 2nd team 6 points … 7th team 1 point</li>
         <li>Incomplete teams still score and are ordered by number of finishing runners</li>
         <li>Where multiple clubs have the same number of finishers, normal scoring rules apply</li>
@@ -83,10 +83,10 @@ const standingsUrl = hasTeamStandings(currentYear, 'road-gp')
     </div>
   </div>
 
-  <div class="card bg-base-100 shadow-sm mt-4">
+  <div class="card shadow-sm mt-4">
     <div class="card-body gap-2 py-4">
       <h2 class="text-lg font-semibold">Individual Awards</h2>
-      <p class="text-sm text-base-content/80">
+      <p class="text-sm text-content/80">
         Individual standings are based on the lowest total positions from your best 4 of 7 races.
         Awards are presented to the 1st, 2nd, and 3rd place finishers overall, and to the top 2 in
         each veteran category. Awards are presented at the following season's buffet. Only one award

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -37,27 +37,27 @@ function positionLabel(pos: number): string {
 
 <Layout title={title}>
   <h1 class="text-2xl font-bold mb-1">{title}</h1>
-  <p class="text-sm text-base-content/60 mb-4">
+  <p class="text-sm text-content/60 mb-4">
     {runner.sex === 'M' ? 'Men' : 'Women'} &middot; {runner.ageCategory}
   </p>
 
   <!-- Stats panel -->
-  <div class={`bg-base-100 border border-base-200 rounded-lg p-4 mb-6 grid gap-6 ${hasAwards ? 'grid-cols-2' : 'grid-cols-1'}`}>
+  <div class={`bg-surface border border-line rounded-lg p-4 mb-6 grid gap-6 ${hasAwards ? 'grid-cols-2' : 'grid-cols-1'}`}>
     <div>
-      <h2 class="text-xs font-bold uppercase tracking-wider text-base-content/50 mb-2">Competed for</h2>
+      <h2 class="text-xs font-bold uppercase tracking-wider text-content/50 mb-2">Competed for</h2>
       {clubHistory.map(ch => (
         <div class="flex justify-between gap-4 text-sm mb-1">
           <span class="font-medium">{ch.clubName}</span>
-          <span class="text-base-content/60">{ch.yearRanges}</span>
+          <span class="text-content/60">{ch.yearRanges}</span>
         </div>
       ))}
     </div>
     {hasAwards && (
       <div>
-        <h2 class="text-xs font-bold uppercase tracking-wider text-base-content/50 mb-2">Awards</h2>
+        <h2 class="text-xs font-bold uppercase tracking-wider text-content/50 mb-2">Awards</h2>
         {awardSummary.roadGp.length > 0 && (
           <div class="mb-3">
-            <div class="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-1">Road GP</div>
+            <div class="text-xs font-bold uppercase tracking-wider text-content/40 mb-1">Road GP</div>
             {awardSummary.roadGp.map(a => (
               <div class="text-sm">{a.categoryName} &mdash; {positionLabel(a.position)}{a.count > 1 ? ` ×${a.count}` : ''}</div>
             ))}
@@ -65,7 +65,7 @@ function positionLabel(pos: number): string {
         )}
         {awardSummary.fell.length > 0 && (
           <div>
-            <div class="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-1">Fell</div>
+            <div class="text-xs font-bold uppercase tracking-wider text-content/40 mb-1">Fell</div>
             {awardSummary.fell.map(a => (
               <div class="text-sm">{a.categoryName} &mdash; {positionLabel(a.position)}{a.count > 1 ? ` ×${a.count}` : ''}</div>
             ))}
@@ -76,17 +76,17 @@ function positionLabel(pos: number): string {
   </div>
 
   <!-- Filter bar -->
-  <div class="bg-base-100 border border-base-200 rounded-lg p-3 mb-6 flex flex-wrap gap-2 items-center">
+  <div class="bg-surface border border-line rounded-lg p-3 mb-6 flex flex-wrap gap-2 items-center">
     <div class="flex gap-1">
       <button class="btn btn-sm btn-active" data-series-filter="all">All</button>
       <button class="btn btn-sm btn-ghost" data-series-filter="road-gp">Road GP</button>
       <button class="btn btn-sm btn-ghost" data-series-filter="fell">Fell</button>
     </div>
-    <select id="filter-year" class="select select-bordered select-sm">
+    <select id="filter-year" class="select select-sm">
       <option value="">All Years</option>
       {allYears.map(y => <option value={String(y)}>{y}</option>)}
     </select>
-    <select id="filter-race" class="select select-bordered select-sm">
+    <select id="filter-race" class="select select-sm">
       <option value="">All Races</option>
     </select>
   </div>
@@ -95,11 +95,11 @@ function positionLabel(pos: number): string {
   <div id="profile-content">
     {yearBlocks.map(block => (
       <div data-year={String(block.year)} class="mb-8">
-        <h2 class="text-lg font-bold text-primary border-b border-base-200 pb-1 mb-4">{block.year}</h2>
+        <h2 class="text-lg font-bold text-amber border-b border-line pb-1 mb-4">{block.year}</h2>
 
         {block.roadGp && (
           <div data-series="road-gp" class="mb-5">
-            <h3 class="text-xs font-bold uppercase tracking-wider text-base-content/50 mb-2">Road GP</h3>
+            <h3 class="text-xs font-bold uppercase tracking-wider text-content/50 mb-2">Road GP</h3>
             {block.roadGp.awards.map(award => (
               <a href={siteUrl(`/road-gp/${block.year}/`)} class="inline-flex items-center gap-1 text-sm text-success hover:underline mb-2">
                 🏆 {award.categoryName} — {positionLabel(award.position)}
@@ -109,7 +109,7 @@ function positionLabel(pos: number): string {
               <tbody>
                 {block.roadGp.races.map(race => (
                   <tr data-race-id={race.raceId} data-race-name={race.raceName}>
-                    <td class="text-base-content/50 text-xs w-12 tabular-nums">{formatDateShort(race.date)}</td>
+                    <td class="text-content/50 text-xs w-12 tabular-nums">{formatDateShort(race.date)}</td>
                     <td>
                       {race.hasResults
                         ? <a href={siteUrl(`/road-gp/${block.year}/${race.raceId}/results`)} class="link link-hover">{race.raceName}</a>
@@ -125,7 +125,7 @@ function positionLabel(pos: number): string {
 
         {block.fell && (
           <div data-series="fell" class="mb-5">
-            <h3 class="text-xs font-bold uppercase tracking-wider text-base-content/50 mb-2">Fell</h3>
+            <h3 class="text-xs font-bold uppercase tracking-wider text-content/50 mb-2">Fell</h3>
             {block.fell.awards.map(award => (
               <a href={siteUrl(`/fell/${block.year}/`)} class="inline-flex items-center gap-1 text-sm text-success hover:underline mb-2">
                 🏆 {award.categoryName} — {positionLabel(award.position)}
@@ -135,7 +135,7 @@ function positionLabel(pos: number): string {
               <tbody>
                 {block.fell.races.map(race => (
                   <tr data-race-id={race.raceId} data-race-name={race.raceName}>
-                    <td class="text-base-content/50 text-xs w-12 tabular-nums">{formatDateShort(race.date)}</td>
+                    <td class="text-content/50 text-xs w-12 tabular-nums">{formatDateShort(race.date)}</td>
                     <td>
                       {race.hasResults
                         ? <a href={siteUrl(`/fell/${block.year}/${race.raceId}/results`)} class="link link-hover">{race.raceName}</a>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -11,10 +11,10 @@ import Layout from '../components/Layout.astro';
     type="search"
     placeholder="Search runners, races, history…"
     autocomplete="off"
-    class="input input-bordered w-full mb-3"
+    class="input w-full mb-3"
   />
 
-  <p id="search-status" class="text-sm text-base-content/60 mb-6">Type at least 3 characters to search.</p>
+  <p id="search-status" class="text-sm text-content/60 mb-6">Type at least 3 characters to search.</p>
 
   <div id="results-runners" class="mb-8 hidden">
     <h2 class="text-lg font-semibold mb-3">Runners</h2>
@@ -76,10 +76,10 @@ import Layout from '../components/Layout.astro';
       return
     }
     list.innerHTML = items.map(r =>
-      `<li><a href="${escapeHtml(r.url)}" class="flex items-center gap-2 py-1.5 hover:text-primary text-sm">` +
+      `<li><a href="${escapeHtml(r.url)}" class="flex items-center gap-2 py-1.5 hover:text-amber text-sm">` +
       `<span class="flex flex-col">` +
       `<span>${escapeHtml(r.label)}</span>` +
-      (r.subtitle ? `<span class="text-xs text-base-content/50">${escapeHtml(r.subtitle)}</span>` : '') +
+      (r.subtitle ? `<span class="text-xs text-content/50">${escapeHtml(r.subtitle)}</span>` : '') +
       `</span></a></li>`
     ).join('')
     section.classList.remove('hidden')

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,154 @@
 @import "tailwindcss";
-@plugin "daisyui" {
-  themes: light;
+
+/* ── Design tokens ── */
+@theme {
+  --color-surface:    #ffffff;
+  --color-canvas:     oklch(97% 0.006 250);
+  --color-line:       oklch(91% 0.006 250);
+  --color-content:    oklch(18% 0.01 250);
+  --color-muted:      oklch(52% 0.01 250);
+  --color-amber:      oklch(72% 0.18 60);
+  --color-amber-bg:   oklch(97% 0.04 60);
+  --color-teal:       oklch(58% 0.14 195);
+  --color-success:    oklch(58% 0.16 145);
 }
+
+/* ── Base ── */
+*, *::before, *::after { box-sizing: border-box; }
+body { color: oklch(18% 0.01 250); }
+
+/* ── Buttons ── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.25;
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background-color 0.15s, border-color 0.15s, opacity 0.15s;
+  background: transparent;
+}
+.btn:disabled { opacity: 0.5; cursor: not-allowed; pointer-events: none; }
+.btn-sm  { padding: 0.25rem 0.625rem; font-size: 0.8125rem; }
+.btn-xs  { padding: 0.125rem 0.5rem;  font-size: 0.75rem;   border-radius: 0.375rem; }
+.btn-ghost   { background: transparent; }
+.btn-ghost:hover { background: var(--color-canvas); }
+.btn-outline { border-color: var(--color-line); color: oklch(18% 0.01 250); }
+.btn-outline:hover { background: var(--color-canvas); }
+.btn-primary { background: var(--color-amber); color: #fff; border-color: var(--color-amber); }
+.btn-primary:hover { opacity: 0.88; }
+.btn-active  { background: var(--color-amber); color: #fff; border-color: var(--color-amber); }
+
+/* ── Badges ── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border: 1px solid transparent;
+}
+.badge-lg  { padding: 0.25rem 0.75rem;   font-size: 0.875rem;  }
+.badge-sm  { padding: 0.0625rem 0.375rem; font-size: 0.6875rem; }
+.badge-xs  { padding: 0.0625rem 0.375rem; font-size: 0.625rem;  }
+.badge-warning   { background: oklch(92% 0.12 60);  color: oklch(35% 0.12 60);  }
+.badge-primary   { background: var(--color-amber-bg); color: var(--color-amber); }
+.badge-outline   { background: transparent; border-color: currentColor; }
+.badge-info      { background: oklch(92% 0.08 220); color: oklch(40% 0.12 220); }
+.badge-secondary { background: oklch(93% 0.05 300); color: oklch(40% 0.12 300); }
+
+/* ── Cards ── */
+.card {
+  background: var(--color-surface);
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-line);
+  overflow: hidden;
+}
+.card-body   { padding: 1rem; display: flex; flex-direction: column; }
+.card-title  { font-size: 1rem; font-weight: 700; }
+.card-actions { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+
+/* ── Tables ── */
+.table { width: 100%; border-collapse: collapse; }
+.table th,
+.table td {
+  padding: 0.625rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-line);
+}
+.table thead th { font-size: 0.8125rem; font-weight: 600; }
+.table tbody tr:last-child td { border-bottom: none; }
+.table-sm th,
+.table-sm td { padding: 0.4375rem 0.75rem; font-size: 0.8125rem; }
+.table .hover:hover td { background: var(--color-canvas); }
+
+/* ── Form inputs ── */
+.input, .select, .textarea {
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-line);
+  background: var(--color-surface);
+  color: oklch(18% 0.01 250);
+  font-size: 0.875rem;
+  outline: none;
+  padding: 0.375rem 0.625rem;
+}
+.textarea { padding: 0.5rem 0.625rem; }
+.input:focus,
+.select:focus,
+.textarea:focus {
+  border-color: var(--color-amber);
+  box-shadow: 0 0 0 3px oklch(72% 0.18 60 / 0.15);
+}
+.input-sm,
+.select-sm { padding: 0.1875rem 0.5rem; font-size: 0.8125rem; }
+
+/* ── Links ── */
+.link        { text-decoration: underline; }
+.link-hover  { text-decoration: none; }
+.link-hover:hover { text-decoration: underline; }
+.link-primary { color: var(--color-amber); }
+
+/* ── Divider ── */
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.divider::before,
+.divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--color-line);
+}
+
+/* ── Tabs (used in AwardsHistoryIndividuals) ── */
+.tabs { display: flex; }
+.tabs-border { border-bottom: 1px solid var(--color-line); }
+.tab {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  color: oklch(18% 0.01 250 / 0.5);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+.tab-active {
+  color: oklch(18% 0.01 250);
+  border-bottom-color: var(--color-amber);
+}
+
+/* ── Label (contact form) ── */
+.label      { display: block; margin-bottom: 0.25rem; }
+.label-text { font-size: 0.875rem; font-weight: 500; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,7 +15,7 @@
 
 /* ── Base ── */
 *, *::before, *::after { box-sizing: border-box; }
-body { color: oklch(18% 0.01 250); }
+body { color: var(--color-content); }
 
 /* ── Buttons ── */
 .btn {
@@ -38,9 +38,8 @@ body { color: oklch(18% 0.01 250); }
 .btn:disabled { opacity: 0.5; cursor: not-allowed; pointer-events: none; }
 .btn-sm  { padding: 0.25rem 0.625rem; font-size: 0.8125rem; }
 .btn-xs  { padding: 0.125rem 0.5rem;  font-size: 0.75rem;   border-radius: 0.375rem; }
-.btn-ghost   { background: transparent; }
 .btn-ghost:hover { background: var(--color-canvas); }
-.btn-outline { border-color: var(--color-line); color: oklch(18% 0.01 250); }
+.btn-outline { border-color: var(--color-line); color: var(--color-content); }
 .btn-outline:hover { background: var(--color-canvas); }
 .btn-primary { background: var(--color-amber); color: #fff; border-color: var(--color-amber); }
 .btn-primary:hover { opacity: 0.88; }
@@ -95,7 +94,7 @@ body { color: oklch(18% 0.01 250); }
   border-radius: 0.375rem;
   border: 1px solid var(--color-line);
   background: var(--color-surface);
-  color: oklch(18% 0.01 250);
+  color: var(--color-content);
   font-size: 0.875rem;
   outline: none;
   padding: 0.375rem 0.625rem;
@@ -145,7 +144,7 @@ body { color: oklch(18% 0.01 250); }
   margin-bottom: -1px;
 }
 .tab-active {
-  color: oklch(18% 0.01 250);
+  color: var(--color-content);
   border-bottom-color: var(--color-amber);
 }
 


### PR DESCRIPTION
## Summary

- Removes the DaisyUI v5 plugin entirely and replaces all DaisyUI-specific patterns with native Tailwind CSS v4 utilities and minimal custom CSS
- Adds a `@theme` block to `src/styles/global.css` defining design tokens (`--color-surface`, `--color-canvas`, `--color-line`, `--color-content`, `--color-amber`, `--color-teal`, `--color-success`, etc.) so Tailwind auto-generates `bg-X`, `text-X`, `border-X` utilities
- Re-implements DaisyUI component classes (`.btn`, `.badge`, `.card`, `.table`, `.input`, `.select`, `.textarea`, `.link`, `.divider`, `.tabs`, `.tab`, `.label`) as plain CSS in `global.css`
- Updates every template and JS toggle across the site to use the new token names

## Token mapping

| Old (DaisyUI) | New |
|---|---|
| `bg-base-100` | `bg-surface` |
| `bg-base-200` | `bg-canvas` |
| `border-base-200` | `border-line` |
| `text-base-content` (any opacity) | `text-content` |
| `text-primary` | `text-amber` |
| `border-primary` (JS toggle) | `border-amber` |
| `rounded-box` | `rounded-xl` |
| `*-bordered` suffix on inputs | removed (border now in base class) |

DaisyUI component class names (`.btn`, `.card`, etc.) are **kept unchanged** — they are re-defined as custom CSS so templates don't need updating for those.

## Files changed

- `src/styles/global.css` — full rewrite: DaisyUI plugin removed, `@theme` tokens added, component CSS added
- `src/components/Layout.astro` — navbar/footer DaisyUI classes replaced with flex utilities; `data-theme` removed
- `src/components/` — token swaps in RaceCard, RaceList, HistoryRaceList, YearFilter, SeriesAwards, SearchBox (including JS string templates), AwardsHistoryIndividuals
- `src/pages/` — token swaps across all pages; JS tab/filter toggles updated in results, team-results, individual-standings, team-standings, and runner profile pages
- `package.json` — `daisyui` removed from devDependencies

## Test plan

- [x] `npm run build` — 1285 pages built, zero errors
- [x] `npm test` — 74/74 tests passing
- [x] No remaining DaisyUI tokens in `src/` (`grep -rn "base-100\|base-200\|base-content\|text-primary\b\|rounded-box\|@plugin.*daisyui\|data-theme" src/` returns nothing)
- [ ] Visual review: nav, cards, tables, buttons, badges, forms, tabs all render correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)