### PR TITLE
fix: merge runner profile results when competing for multiple clubs

### DIFF
--- a/src/lib/runners.ts
+++ b/src/lib/runners.ts
@@ -215,13 +215,21 @@ export function getRunnerProfileStaticPaths() {
     const slug = runnerSlug(runner);
     const entries = globalToSeries.get(runner.id) ?? [];
 
-    // Group into year blocks
+    // Group into year blocks; merge races/awards when a runner has multiple series entries
+    // (e.g. competed for two clubs in the same year/series)
     const byYear = new Map<number, RunnerYearBlock>();
     for (const { year, series, seriesLocalId } of entries) {
       const block = byYear.get(year) ?? { year };
+      const existing = series === 'road-gp' ? block.roadGp : block.fell;
       const yearSeries: RunnerYearSeries = {
-        races: getRacesForRunner(year, series, seriesLocalId),
-        awards: getAwardsForRunner(year, series, seriesLocalId),
+        races: [
+          ...(existing?.races ?? []),
+          ...getRacesForRunner(year, series, seriesLocalId),
+        ].sort((a, b) => a.date.localeCompare(b.date)),
+        awards: [
+          ...(existing?.awards ?? []),
+          ...getAwardsForRunner(year, series, seriesLocalId),
+        ],
       };
       if (series === 'road-gp') block.roadGp = yearSeries;
       else block.fell = yearSeries;


### PR DESCRIPTION
## Summary

Fixes #121 — Sarah Hargreaves' 2025 Fell Championship profile was showing only her Waddington result (blackpool) and omitting her three red-rose results.

## Root Cause

`getRunnerProfileStaticPaths` in `src/lib/runners.ts` built year blocks by iterating over a runner's series entries. When a runner has two entries for the same year and series (valid when competing for different clubs in the same season), the second entry's `yearSeries` object silently overwrote the first. Only the last-processed entry's races and awards survived.

## Fix

Before assigning to `block.fell`/`block.roadGp`, read any existing `yearSeries` for that slot and spread its races and awards into the new one. Races are re-sorted by date after merging.

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] `/runners/10620-sarah-hargreaves/` shows all four 2025 Fell races across both clubs