### PR TITLE
feat: introduce xl breakpoint for wider sidebar+content layout

### DIFF
--- a/docs/superpowers/plans/2026-05-25-xl-breakpoint.md
+++ b/docs/superpowers/plans/2026-05-25-xl-breakpoint.md
@@ -1,0 +1,383 @@
+# xl Breakpoint Layout Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce the `xl` (1280px) breakpoint so the sidebar+content layout widens from 896px (`max-w-4xl`) to 1024px (`max-w-5xl`) at xl, and sidebar columns grow from 220px to 260px at xl.
+
+**Architecture:** Every page-level container currently uses `max-w-4xl mx-auto` as the universal width cap. Hero slots, chip-bars, and filter bars use the same class outside of `<main>` so they align. All sidebar grids are `lg:grid-cols-[220px_1fr]` (or the reversed variant for SeriesDetailLayout). Adding `xl:max-w-5xl` to each container and `xl:grid-cols-[260px_1fr]` to each sidebar grid is the full change — no JS, no new components, no new CSS custom properties.
+
+**Tech Stack:** Astro v6, Tailwind CSS v4 (utility classes only — no config changes needed)
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `src/components/Layout.astro` | `max-w-4xl` → `max-w-4xl xl:max-w-5xl` (nav + main, 2 places) |
+| `src/components/ChipBar.astro` | `max-w-4xl` → `max-w-4xl xl:max-w-5xl` (chip row wrapper) |
+| `src/components/StandingsHeader.astro` | `max-w-4xl` → `max-w-4xl xl:max-w-5xl` (back-link div + tab nav div, 2 places) |
+| `src/components/IndividualResultsLayout.astro` | `max-w-4xl` → `max-w-4xl xl:max-w-5xl` (3 places); add `xl:grid-cols-[260px_1fr]` to sidebar grid |
+| `src/components/IndividualStandingsLayout.astro` | `max-w-4xl` → `max-w-4xl xl:max-w-5xl` (filter bar); add `xl:grid-cols-[260px_1fr]` to sidebar grid |
+| `src/components/SeriesDetailLayout.astro` | `max-w-4xl` → `max-w-4xl xl:max-w-5xl` (hero div); add `xl:grid-cols-[1fr_260px]` to sidebar grid |
+| `src/components/TeamResultsLayout.astro` | `max-w-4xl` → `max-w-4xl xl:max-w-5xl` (hero div + tab nav div, 2 places); add `xl:grid-cols-[260px_1fr]` to sidebar grid |
+| `src/components/TeamStandingsLayout.astro` | Fix `200px` → `220px`; add `xl:grid-cols-[260px_1fr]` to sidebar grid |
+| `src/pages/runners/[slug].astro` | `max-w-4xl` → `max-w-4xl xl:max-w-5xl` (hero div only; sidebar already uses 260px at lg) |
+| `src/pages/road-gp/[year]/[raceId].astro` | `max-w-4xl` → `max-w-4xl xl:max-w-5xl` |
+| `src/pages/search.astro` | `max-w-4xl` → `max-w-4xl xl:max-w-5xl` |
+
+---
+
+## Task 1: Widen Layout.astro universal container
+
+**Files:**
+- Modify: `src/components/Layout.astro:36` and `:59`
+
+- [ ] **Step 1: Update nav container width**
+
+In `src/components/Layout.astro` line 36, change:
+```html
+<div class="flex items-center justify-between max-w-4xl mx-auto px-4 h-14">
+```
+to:
+```html
+<div class="flex items-center justify-between max-w-4xl xl:max-w-5xl mx-auto px-4 h-14">
+```
+
+- [ ] **Step 2: Update main container width**
+
+In `src/components/Layout.astro` line 59, change:
+```astro
+<main class={`flex-1 max-w-4xl mx-auto w-full px-4${noPad ? '' : hasHero ? ' pt-6 pb-8' : ' py-8'}`}>
+```
+to:
+```astro
+<main class={`flex-1 max-w-4xl xl:max-w-5xl mx-auto w-full px-4${noPad ? '' : hasHero ? ' pt-6 pb-8' : ' py-8'}`}>
+```
+
+- [ ] **Step 3: Commit**
+```bash
+git add src/components/Layout.astro
+git commit -m "feat: widen Layout container to max-w-5xl at xl breakpoint"
+```
+
+---
+
+## Task 2: Widen ChipBar and StandingsHeader containers
+
+These components render outside `<main>` via named slots, so they have their own `max-w-4xl` constraints that must match Layout's width.
+
+**Files:**
+- Modify: `src/components/ChipBar.astro:68`
+- Modify: `src/components/StandingsHeader.astro:24` and `:37`
+
+- [ ] **Step 1: Update ChipBar chip-row wrapper**
+
+In `src/components/ChipBar.astro` line 68, change:
+```html
+<div class="max-w-4xl mx-auto sm:flex sm:items-stretch">
+```
+to:
+```html
+<div class="max-w-4xl xl:max-w-5xl mx-auto sm:flex sm:items-stretch">
+```
+
+- [ ] **Step 2: Update StandingsHeader back-link container**
+
+In `src/components/StandingsHeader.astro` line 24, change:
+```html
+<div class="max-w-4xl mx-auto px-4 pt-8 pb-5">
+```
+to:
+```html
+<div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-8 pb-5">
+```
+
+- [ ] **Step 3: Update StandingsHeader tab-nav container**
+
+In `src/components/StandingsHeader.astro` line 37, change:
+```html
+<div class="max-w-4xl mx-auto px-4">
+```
+to:
+```html
+<div class="max-w-4xl xl:max-w-5xl mx-auto px-4">
+```
+
+- [ ] **Step 4: Commit**
+```bash
+git add src/components/ChipBar.astro src/components/StandingsHeader.astro
+git commit -m "feat: widen ChipBar and StandingsHeader containers at xl breakpoint"
+```
+
+---
+
+## Task 3: Update IndividualResultsLayout
+
+**Files:**
+- Modify: `src/components/IndividualResultsLayout.astro:104`, `:147`, `:181`, `:197`
+
+- [ ] **Step 1: Update hero section container (line 104)**
+
+Change:
+```html
+<div class="max-w-4xl mx-auto px-4 pt-4 pb-4">
+```
+to:
+```html
+<div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-4 pb-4">
+```
+
+- [ ] **Step 2: Update tab-nav container (line 147)**
+
+Change:
+```html
+<div class="max-w-4xl mx-auto px-4 flex">
+```
+to:
+```html
+<div class="max-w-4xl xl:max-w-5xl mx-auto px-4 flex">
+```
+
+- [ ] **Step 3: Update filter-bar container (line 181)**
+
+Change:
+```html
+<div class="flex gap-2 max-w-4xl mx-auto px-4 py-2.5">
+```
+to:
+```html
+<div class="flex gap-2 max-w-4xl xl:max-w-5xl mx-auto px-4 py-2.5">
+```
+
+- [ ] **Step 4: Add xl sidebar width (line 197)**
+
+Change:
+```html
+<div class="lg:grid lg:grid-cols-[220px_1fr] lg:gap-8 lg:items-start">
+```
+to:
+```html
+<div class="lg:grid lg:grid-cols-[220px_1fr] xl:grid-cols-[260px_1fr] lg:gap-8 lg:items-start">
+```
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/components/IndividualResultsLayout.astro
+git commit -m "feat: widen IndividualResultsLayout containers and sidebar at xl breakpoint"
+```
+
+---
+
+## Task 4: Update IndividualStandingsLayout
+
+**Files:**
+- Modify: `src/components/IndividualStandingsLayout.astro:147`, `:169`
+
+- [ ] **Step 1: Update filter-bar container (line 147)**
+
+Change:
+```html
+<div class="flex gap-2 max-w-4xl mx-auto px-4 py-2.5">
+```
+to:
+```html
+<div class="flex gap-2 max-w-4xl xl:max-w-5xl mx-auto px-4 py-2.5">
+```
+
+- [ ] **Step 2: Add xl sidebar width (line 169)**
+
+Change:
+```html
+<div class="lg:grid lg:grid-cols-[220px_1fr] lg:gap-8 lg:items-start">
+```
+to:
+```html
+<div class="lg:grid lg:grid-cols-[220px_1fr] xl:grid-cols-[260px_1fr] lg:gap-8 lg:items-start">
+```
+
+- [ ] **Step 3: Commit**
+```bash
+git add src/components/IndividualStandingsLayout.astro
+git commit -m "feat: widen IndividualStandingsLayout filter bar and sidebar at xl breakpoint"
+```
+
+---
+
+## Task 5: Update SeriesDetailLayout
+
+**Files:**
+- Modify: `src/components/SeriesDetailLayout.astro:68`, `:148`
+
+- [ ] **Step 1: Update hero container (line 68)**
+
+Change:
+```html
+<div class="max-w-4xl mx-auto px-4">
+```
+to:
+```html
+<div class="max-w-4xl xl:max-w-5xl mx-auto px-4">
+```
+
+- [ ] **Step 2: Add xl sidebar width — note sidebar is on the right in SeriesDetailLayout (line 148)**
+
+Change:
+```html
+<div class="lg:grid lg:grid-cols-[1fr_220px] lg:gap-8 lg:items-start">
+```
+to:
+```html
+<div class="lg:grid lg:grid-cols-[1fr_220px] xl:grid-cols-[1fr_260px] lg:gap-8 lg:items-start">
+```
+
+- [ ] **Step 3: Commit**
+```bash
+git add src/components/SeriesDetailLayout.astro
+git commit -m "feat: widen SeriesDetailLayout container and sidebar at xl breakpoint"
+```
+
+---
+
+## Task 6: Update TeamResultsLayout
+
+**Files:**
+- Modify: `src/components/TeamResultsLayout.astro:43`, `:61`, `:89`
+
+- [ ] **Step 1: Update hero back-link container (line 43)**
+
+Change:
+```html
+<div class="max-w-4xl mx-auto px-4 pt-8 pb-5">
+```
+to:
+```html
+<div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-8 pb-5">
+```
+
+- [ ] **Step 2: Update tab-nav container (line 61)**
+
+Change:
+```html
+<div class="max-w-4xl mx-auto px-4">
+```
+to:
+```html
+<div class="max-w-4xl xl:max-w-5xl mx-auto px-4">
+```
+
+- [ ] **Step 3: Add xl sidebar width (line 89)**
+
+Change:
+```html
+<div class="hidden lg:grid grid-cols-[220px_1fr] gap-8 items-start">
+```
+to:
+```html
+<div class="hidden lg:grid grid-cols-[220px_1fr] xl:grid-cols-[260px_1fr] gap-8 items-start">
+```
+
+- [ ] **Step 4: Commit**
+```bash
+git add src/components/TeamResultsLayout.astro
+git commit -m "feat: widen TeamResultsLayout containers and sidebar at xl breakpoint"
+```
+
+---
+
+## Task 7: Update TeamStandingsLayout (fix 200px inconsistency + add xl)
+
+**Files:**
+- Modify: `src/components/TeamStandingsLayout.astro:100`
+
+- [ ] **Step 1: Fix sidebar width from 200px to 220px and add xl width (line 100)**
+
+Change:
+```html
+<div class="hidden lg:grid grid-cols-[200px_1fr] gap-8 items-start">
+```
+to:
+```html
+<div class="hidden lg:grid grid-cols-[220px_1fr] xl:grid-cols-[260px_1fr] gap-8 items-start">
+```
+
+- [ ] **Step 2: Commit**
+```bash
+git add src/components/TeamStandingsLayout.astro
+git commit -m "fix: correct TeamStandingsLayout sidebar from 200px to 220px; add xl:260px"
+```
+
+---
+
+## Task 8: Update standalone page containers
+
+**Files:**
+- Modify: `src/pages/runners/[slug].astro:47`
+- Modify: `src/pages/road-gp/[year]/[raceId].astro:56`
+- Modify: `src/pages/search.astro:16`
+
+- [ ] **Step 1: Update runners hero container (line 47)**
+
+In `src/pages/runners/[slug].astro` line 47, change:
+```html
+<div class="max-w-4xl mx-auto px-4 pt-4 pb-6">
+```
+to:
+```html
+<div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-4 pb-6">
+```
+
+Note: The runner page sidebar grid at line 79 already uses `lg:grid-cols-[260px_1fr]`, so no sidebar grid change is needed there.
+
+- [ ] **Step 2: Update road-gp race detail page container (line 56)**
+
+In `src/pages/road-gp/[year]/[raceId].astro` line 56, change:
+```html
+<div class="max-w-4xl mx-auto px-4 py-5 md:py-7">
+```
+to:
+```html
+<div class="max-w-4xl xl:max-w-5xl mx-auto px-4 py-5 md:py-7">
+```
+
+- [ ] **Step 3: Update search page container (line 16)**
+
+In `src/pages/search.astro` line 16, change:
+```html
+<div class="max-w-4xl mx-auto px-4 pt-5 pb-7">
+```
+to:
+```html
+<div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-5 pb-7">
+```
+
+- [ ] **Step 4: Commit**
+```bash
+git add src/pages/runners/[slug].astro src/pages/road-gp/[year]/[raceId].astro src/pages/search.astro
+git commit -m "feat: widen standalone page containers at xl breakpoint"
+```
+
+---
+
+## Task 9: Verify build passes
+
+- [ ] **Step 1: Run the build**
+```bash
+npm run build
+```
+Expected: build completes with no TypeScript or Astro errors, output written to `dist/`.
+
+- [ ] **Step 2: Smoke-check at 1280px width**
+
+Start the preview server and open in a browser at 1280px viewport width:
+```bash
+npm run preview
+```
+Check:
+- Nav bar and footer widen to ~1024px content area
+- Sidebar on results/standings pages is visibly wider (260px vs 220px)
+- No horizontal scroll at 1280px
+- Layout at 1023px (just below lg) still shows mobile/chip-bar view correctly
+- Layout at 1279px (just below xl) still shows 220px sidebar
+
+- [ ] **Step 3: Commit if any last fixes were needed, otherwise done**

--- a/src/components/ChipBar.astro
+++ b/src/components/ChipBar.astro
@@ -65,7 +65,7 @@ const { items, defaultSex } = Astro.props;
     On tablet (sm+) with sex toggle: flex row — fixed sex section | scrollable chips.
     On mobile / no sex toggle: scroll area spans full width.
   -->
-  <div class="max-w-4xl mx-auto sm:flex sm:items-stretch">
+  <div class="max-w-4xl xl:max-w-5xl mx-auto sm:flex sm:items-stretch">
 
     <!--
       Tablet sex toggle: fixed left section, does NOT scroll with the chips.

--- a/src/components/IndividualResultsLayout.astro
+++ b/src/components/IndividualResultsLayout.astro
@@ -101,7 +101,7 @@ const showSexToggle = hasMale && hasFemale;
 
   <!-- ════ HERO: light surface header ════ -->
   <div slot="hero" class="bg-surface border-b border-line">
-    <div class="max-w-4xl mx-auto px-4 pt-4 pb-4">
+    <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-4 pb-4">
 
       <a href={siteUrl(`/${series}/${year}`)} class="block text-[12px] text-muted hover:text-content transition-colors mb-2">
         ← {seriesLabel} {year}
@@ -144,7 +144,7 @@ const showSexToggle = hasMale && hasFemale;
     </div>
 
     <div class="border-t border-line">
-      <div class="max-w-4xl mx-auto px-4 flex">
+      <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 flex">
         <a
           href={siteUrl(`/${series}/${year}/${raceId}/results`)}
           class="flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 -mb-px text-center md:text-left border-amber text-content"
@@ -178,7 +178,7 @@ const showSexToggle = hasMale && hasFemale;
 
   <!-- Filter bar: sits flush below the chip bar on mobile + tablet -->
   <div slot="chip-bar" class="lg:hidden bg-surface sm:bg-transparent border-b border-line sm:border-b-0 w-full">
-    <div class="flex gap-2 max-w-4xl mx-auto px-4 py-2.5">
+    <div class="flex gap-2 max-w-4xl xl:max-w-5xl mx-auto px-4 py-2.5">
       <input
         id="filter-name-mobile"
         type="search"
@@ -194,7 +194,7 @@ const showSexToggle = hasMale && hasFemale;
   </div>
 
   <!-- ════ MAIN: sidebar (desktop) + table ════ -->
-  <div class="lg:grid lg:grid-cols-[220px_1fr] lg:gap-8 lg:items-start">
+  <div class="lg:grid lg:grid-cols-[220px_1fr] xl:grid-cols-[260px_1fr] lg:gap-8 lg:items-start">
 
     <!-- Desktop sidebar -->
     <aside class="hidden lg:block lg:sticky lg:top-6 lg:self-start">

--- a/src/components/IndividualStandingsLayout.astro
+++ b/src/components/IndividualStandingsLayout.astro
@@ -144,7 +144,7 @@ const raceColWidth = standings.races.length >= 7 ? '3rem'
 
   <!-- Filter bar: sits flush below the chip bar on mobile + tablet -->
   <div slot="chip-bar" class="lg:hidden bg-surface sm:bg-transparent border-b border-line sm:border-b-0 w-full">
-    <div class="flex gap-2 max-w-4xl mx-auto px-4 py-2.5">
+    <div class="flex gap-2 max-w-4xl xl:max-w-5xl mx-auto px-4 py-2.5">
       <div class="flex-1 min-w-0">
         <input
           id="runner-search"
@@ -166,7 +166,7 @@ const raceColWidth = standings.races.length >= 7 ? '3rem'
   </div>
 
   <!-- ── Outer wrapper: 2-col grid at lg (sidebar | content) ──────────────── -->
-  <div class="lg:grid lg:grid-cols-[220px_1fr] lg:gap-8 lg:items-start">
+  <div class="lg:grid lg:grid-cols-[220px_1fr] xl:grid-cols-[260px_1fr] lg:gap-8 lg:items-start">
 
     <!-- ── Desktop sidebar (lg+ only) ───────────────────────────────────────── -->
     <aside class="hidden lg:block sticky top-6 self-start">

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -33,7 +33,7 @@ function isActive(path: string): boolean {
   </head>
   <body class="min-h-screen bg-canvas flex flex-col">
     <header class="bg-surface border-b border-line">
-      <div class="flex items-center justify-between max-w-4xl mx-auto px-4 h-14">
+      <div class="flex items-center justify-between max-w-4xl xl:max-w-5xl mx-auto px-4 h-14">
         <a href={`${base}/`} class="btn btn-ghost text-lg font-bold tracking-tight">Inter Club</a>
         <div class="flex items-center gap-1">
           <a
@@ -56,7 +56,7 @@ function isActive(path: string): boolean {
     <slot name="hero" />
     <slot name="chip-bar" />
 
-    <main class={`flex-1 max-w-4xl mx-auto w-full px-4${noPad ? '' : hasHero ? ' pt-6 pb-8' : ' py-8'}`}>
+    <main class={`flex-1 max-w-4xl xl:max-w-5xl mx-auto w-full px-4${noPad ? '' : hasHero ? ' pt-6 pb-8' : ' py-8'}`}>
       <slot />
     </main>
 

--- a/src/components/SeriesDetailLayout.astro
+++ b/src/components/SeriesDetailLayout.astro
@@ -65,7 +65,7 @@ const scoringRules = [
 
   <!-- ════ HERO ════ -->
   <div slot="hero" class="bg-surface border-b border-line">
-    <div class="max-w-4xl mx-auto px-4">
+    <div class="max-w-4xl xl:max-w-5xl mx-auto px-4">
 
       <!-- Mobile / Tablet -->
       <div class="lg:hidden py-5 md:py-6">
@@ -145,7 +145,7 @@ const scoringRules = [
   </div>
 
   <!-- Two-column on desktop: main + sticky sidebar -->
-  <div class="lg:grid lg:grid-cols-[1fr_220px] lg:gap-8 lg:items-start">
+  <div class="lg:grid lg:grid-cols-[1fr_220px] xl:grid-cols-[1fr_260px] lg:gap-8 lg:items-start">
 
     <!-- ── Main column ── -->
     <div>

--- a/src/components/StandingsHeader.astro
+++ b/src/components/StandingsHeader.astro
@@ -21,7 +21,7 @@ const { backHref, backLabel, activeTab, individualHref, teamHref } = Astro.props
 <div class="bg-surface">
 
   <!-- Back link + page-specific heading content -->
-  <div class="max-w-4xl mx-auto px-4 pt-8 pb-5">
+  <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-8 pb-5">
     <div class="mb-5">
       <a href={backHref} class="btn btn-ghost btn-sm gap-1 -ml-3">{backLabel}</a>
     </div>
@@ -34,7 +34,7 @@ const { backHref, backLabel, activeTab, individualHref, teamHref } = Astro.props
   <!-- Tab nav: border-b is on the full-width wrapper; -mb-px on each link
        pulls it down 1px so the active tab's border-b-2 overlaps the line -->
   <div class="border-b border-line">
-    <div class="max-w-4xl mx-auto px-4">
+    <div class="max-w-4xl xl:max-w-5xl mx-auto px-4">
       <div class="flex">
         <a
           href={individualHref}

--- a/src/components/TeamResultsLayout.astro
+++ b/src/components/TeamResultsLayout.astro
@@ -40,7 +40,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
 
   <!-- ── Full-width race header (hero slot) ── -->
   <div slot="hero" class="bg-surface">
-    <div class="max-w-4xl mx-auto px-4 pt-8 pb-5">
+    <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-8 pb-5">
       <div class="mb-5">
         <a href={siteUrl(`/${series}/${year}`)} class="btn btn-ghost btn-sm gap-1 -ml-3">← {seriesLabel} {year}</a>
       </div>
@@ -58,7 +58,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
 
     <!-- Individual / Team tab strip -->
     <div class="border-b border-line">
-      <div class="max-w-4xl mx-auto px-4">
+      <div class="max-w-4xl xl:max-w-5xl mx-auto px-4">
         <div class="flex">
           <a
             href={siteUrl(`/${series}/${year}/${raceId}/results`)}
@@ -86,7 +86,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
   <!-- ══════════════════════════════════════════════
        DESKTOP (lg+): sticky sidebar + main pane
   ══════════════════════════════════════════════ -->
-  <div class="hidden lg:grid grid-cols-[220px_1fr] gap-8 items-start">
+  <div class="hidden lg:grid grid-cols-[220px_1fr] xl:grid-cols-[260px_1fr] gap-8 items-start">
 
     <!-- Sticky sidebar -->
     <aside class="sticky top-6 self-start">

--- a/src/components/TeamStandingsLayout.astro
+++ b/src/components/TeamStandingsLayout.astro
@@ -97,7 +97,7 @@ const raceColWidth = races.length >= 7 ? '3rem'
   <!-- ══════════════════════════════════════════════
        DESKTOP (lg+): sticky sidebar + stacked tables
   ══════════════════════════════════════════════ -->
-  <div class="hidden lg:grid grid-cols-[200px_1fr] gap-8 items-start">
+  <div class="hidden lg:grid grid-cols-[220px_1fr] xl:grid-cols-[260px_1fr] gap-8 items-start">
 
     <!-- Sticky sidebar -->
     <aside class="sticky top-6 self-start">

--- a/src/pages/road-gp/[year]/[raceId].astro
+++ b/src/pages/road-gp/[year]/[raceId].astro
@@ -53,7 +53,7 @@ const hasStats = !!(mRecord || fRecord);
 <Layout title={name}>
   <!-- Dark editorial hero -->
   <div slot="hero" class="bg-content text-white">
-    <div class="max-w-4xl mx-auto px-4 py-5 md:py-7">
+    <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 py-5 md:py-7">
 
       <a href={backUrl} class="text-[11px] text-white/50 hover:text-white/80 transition-colors mb-4 inline-block">
         ← Road Grand Prix

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -44,7 +44,7 @@ function positionLabel(pos: number): string {
 
   <!-- ── Dark hero ── -->
   <div slot="hero" class="bg-hdr-dark text-hdr-text">
-    <div class="max-w-4xl mx-auto px-4 pt-4 pb-6">
+    <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-4 pb-6">
 
       <p class="font-mono text-xs text-hdr-muted mb-4 tracking-wide">← Runners</p>
 

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -13,7 +13,7 @@ const SECTIONS = [
 <Layout title="Search" noPad>
   <!-- Hero: shown when query ≥ 3 chars, renders full-width via named slot -->
   <div slot="hero" id="search-hero" class="hidden bg-surface border-b border-line">
-    <div class="max-w-4xl mx-auto px-4 pt-5 pb-7">
+    <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-5 pb-7">
       <PageLabel label="Search Results" />
       <h1 id="query-heading" class="font-head text-[clamp(2rem,5vw,3.5rem)] font-extrabold tracking-[-0.025em] leading-[1] text-content mb-2"></h1>
       <p id="match-count" class="text-[15px] leading-relaxed text-muted"></p>


### PR DESCRIPTION
## Summary

- Widens page containers from `max-w-4xl` (896px) to `max-w-5xl` (1024px) at the `xl` breakpoint (1280px+)
- Widens sidebar columns from 220px to 260px at `xl` on all results/standings pages
- Fixes a pre-existing inconsistency in `TeamStandingsLayout` where the sidebar was 200px instead of the standard 220px

## What changed

Every page-level container (`<main>`, nav, hero slots, chip-bars, filter bars) now uses `max-w-4xl xl:max-w-5xl`. All sidebar grid definitions have an added `xl:grid-cols-[260px_1fr]` (or `xl:grid-cols-[1fr_260px]` for SeriesDetailLayout where the sidebar is on the right).

**Files updated:**
- `src/components/Layout.astro` — nav + main containers
- `src/components/ChipBar.astro` — chip-row wrapper
- `src/components/StandingsHeader.astro` — back-link + tab-nav containers
- `src/components/IndividualResultsLayout.astro` — hero, tab-nav, filter-bar containers + sidebar grid
- `src/components/IndividualStandingsLayout.astro` — filter-bar container + sidebar grid
- `src/components/SeriesDetailLayout.astro` — hero container + sidebar grid
- `src/components/TeamResultsLayout.astro` — hero + tab-nav containers + sidebar grid
- `src/components/TeamStandingsLayout.astro` — sidebar grid (200px→220px fix + xl)
- `src/pages/runners/[slug].astro` — hero container
- `src/pages/road-gp/[year]/[raceId].astro` — content container
- `src/pages/search.astro` — content container

## Behaviour

- Below `lg` (1024px): no change — mobile/chip-bar layout unchanged
- At `lg` (1024px–1279px): same as before — 220px sidebar, 896px container
- At `xl` (1280px+): 260px sidebar, 1024px container

## Test plan

- [x] `npm run build` passes — 1314 pages built with no errors
- [ ] Smoke-check at 1280px viewport: nav/footer widen, sidebar visibly wider on results/standings pages, no horizontal scroll
- [ ] Verify at 1279px layout still matches current lg behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)