### PR TITLE
feat: unified dark PageHeader component for race results and runner profiles

### DIFF
--- a/src/components/IndividualResultsLayout.astro
+++ b/src/components/IndividualResultsLayout.astro
@@ -2,6 +2,7 @@
 // src/components/IndividualResultsLayout.astro
 import Layout from './Layout.astro';
 import ChipBar from './ChipBar.astro';
+import PageHeader from './PageHeader.astro';
 import { getRace, getRaces } from '../lib/data';
 import { hasTeamResults } from '../lib/results';
 import { siteUrl } from '../lib/url';
@@ -80,14 +81,11 @@ const clubTurnout = [...clubCountMap.entries()]
   .sort((a, b) => b.count - a.count);
 const maxClubCount = clubTurnout.reduce((m, c) => Math.max(m, c.count), 1);
 
-const eyebrow = [
-  raceNumber != null ? `Race ${raceNumber}` : null,
-  race?.date ? formatRaceDate(race.date) : null,
+const raceMeta = [
+  race?.date ? formatRaceDate(race.date, race?.time) : null,
   race?.location ?? null,
   race?.distance ?? null,
-].filter(Boolean).join(' · ');
-
-const metaLine = [race?.location ?? null, race?.distance ?? null].filter(Boolean).join(' · ');
+].filter(Boolean) as string[];
 
 const showTeamResults = hasTeamResults(year, series, raceId);
 
@@ -103,67 +101,29 @@ const showSexToggle = hasMale && hasFemale;
 
 <Layout title={`${title} — Results`}>
 
-  <!-- ════ HERO: light surface header ════ -->
-  <div slot="hero" class="bg-surface border-b border-line">
-    <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-4 pb-4">
-
-      <a href={siteUrl(`/${series}/${year}`)} class="block text-[12px] text-muted hover:text-content transition-colors mb-2">
-        ← {seriesLabel} {year}
-      </a>
-
-      <div class="lg:flex lg:items-end lg:justify-between lg:gap-6">
-
-        <div class="flex-1 min-w-0">
-          {eyebrow && (
-            <p class="font-head text-[10px] font-bold tracking-[0.14em] uppercase text-muted mb-1">{eyebrow}</p>
-          )}
-
-          <div class="flex items-center gap-2 flex-wrap mb-1">
-            <h1 class="font-head text-[22px] lg:text-[30px] font-extrabold tracking-tight leading-[1.1]">{title}</h1>
-            {provisional && (
-              <span class="font-head text-[10px] font-bold tracking-[0.08em] uppercase bg-[oklch(88%_0.12_60)] text-[oklch(35%_0.12_60)] px-2 py-0.5 rounded-full">
-                Provisional
-              </span>
-            )}
-          </div>
-
-          {metaLine && <p class="text-[13px] text-muted lg:hidden">{metaLine}</p>}
-
-          {raceNumber != null && raceTotal > 1 && (
-            <div class="hidden lg:flex items-center gap-3 mt-2">
-              <span class="font-mono text-[11px] text-muted tracking-[0.04em]">Race {raceNumber} of {raceTotal}</span>
-              <div class="flex gap-[3px]">
-                {Array.from({ length: raceTotal }, (_, i) => (
-                  <span
-                    class="h-[4px] w-[14px] rounded-[2px]"
-                    style={`background: ${i < raceNumber ? 'var(--color-amber)' : 'var(--color-line)'}`}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-
-      </div>
-    </div>
-
-    <div class="border-t border-line">
-      <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 flex">
+  <!-- ════ HERO ════ -->
+  <PageHeader
+    slot="hero"
+    eyebrow={raceNumber != null ? `Race ${raceNumber}${raceTotal > 1 ? ` of ${raceTotal}` : ''}` : undefined}
+    title={title}
+    subtitleParts={raceMeta}
+    provisional={provisional}
+  >
+    <div class="flex">
+      <a
+        href={siteUrl(`/${series}/${year}/${raceId}/results`)}
+        class="flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 -mb-px text-center md:text-left border-amber text-hdr-text"
+      >Individual</a>
+      {showTeamResults ? (
         <a
-          href={siteUrl(`/${series}/${year}/${raceId}/results`)}
-          class="flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 -mb-px text-center md:text-left border-amber text-content"
-        >Individual</a>
-        {showTeamResults ? (
-          <a
-            href={siteUrl(`/${series}/${year}/${raceId}/team-results`)}
-            class="flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 -mb-px text-center md:text-left border-transparent text-muted hover:text-content transition-colors"
-          >Team</a>
-        ) : (
-          <span class="flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 border-transparent text-muted/40 cursor-not-allowed text-center md:text-left">Team</span>
-        )}
-      </div>
+          href={siteUrl(`/${series}/${year}/${raceId}/team-results`)}
+          class="flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 -mb-px text-center md:text-left border-transparent text-hdr-muted hover:text-hdr-text transition-colors"
+        >Team</a>
+      ) : (
+        <span class="flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 border-transparent text-hdr-muted/40 cursor-not-allowed text-center md:text-left">Team</span>
+      )}
     </div>
-  </div>
+  </PageHeader>
 
   <!-- ════ CHIP-BAR: [Full +] team category chips (mobile + tablet) ════ -->
   {(teamCategories.length > 0 || showFullChip) && (

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -1,0 +1,75 @@
+---
+// src/components/PageHeader.astro
+//
+// Shared dark hero header for race results and runner profile pages.
+// Renders the full-bleed bg-hdr-dark band with:
+//   - an optional amber eyebrow line
+//   - a bold h1 (with optional Provisional badge)
+//   - an optional muted mono subtitle row (items separated by 1px lines)
+//   - an optional tab strip via the default slot (separator line is handled here)
+//
+// Usage:
+//   <PageHeader slot="hero" eyebrow="Race 1 of 7" title={title} subtitleParts={raceMeta}>
+//     <!-- tab strip (optional) -->
+//     <div class="flex">
+//       <a class="...tab-active...">Individual</a>
+//       <a class="...tab-inactive...">Team</a>
+//     </div>
+//   </PageHeader>
+
+export interface Props {
+  /** Amber label rendered above the title (e.g. "Race 1 of 7" or a club name). */
+  eyebrow?: string;
+  /** Main page heading. */
+  title: string;
+  /** Optional metadata items rendered as a muted mono row with 1 px separators. */
+  subtitleParts?: string[];
+  /** When true, shows a "Provisional" badge inline with the title. */
+  provisional?: boolean;
+}
+
+const { eyebrow, title, subtitleParts = [], provisional = false } = Astro.props;
+const hasTabStrip = Astro.slots.has('default');
+---
+
+<div class="bg-hdr-dark text-hdr-text">
+  <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-4 pb-4">
+
+    {eyebrow && (
+      <p class="font-head text-[11px] font-bold tracking-[0.14em] uppercase text-amber mb-1.5">
+        {eyebrow}
+      </p>
+    )}
+
+    <div class="flex items-center gap-2.5 flex-wrap mb-1">
+      <h1 class="font-head text-[28px] lg:text-[38px] font-extrabold tracking-tight leading-[1.1]">
+        {title}
+      </h1>
+      {provisional && (
+        <span class="font-head text-[10px] font-bold tracking-[0.08em] uppercase bg-[oklch(88%_0.12_60)] text-[oklch(35%_0.12_60)] px-2 py-0.5 rounded-full">
+          Provisional
+        </span>
+      )}
+    </div>
+
+    {subtitleParts.length > 0 && (
+      <div class="flex items-center flex-wrap gap-x-2.5 gap-y-0.5 font-mono text-[12px] text-hdr-muted mt-1">
+        {subtitleParts.map((part, i) => (
+          <>
+            {i > 0 && <span class="w-px h-[11px] bg-white/20 self-center flex-shrink-0" />}
+            <span>{part}</span>
+          </>
+        ))}
+      </div>
+    )}
+
+  </div>
+
+  {hasTabStrip && (
+    <div class="border-t border-white/10">
+      <div class="max-w-4xl xl:max-w-5xl mx-auto px-4">
+        <slot />
+      </div>
+    </div>
+  )}
+</div>

--- a/src/components/TeamResultsLayout.astro
+++ b/src/components/TeamResultsLayout.astro
@@ -8,10 +8,11 @@
 //   Desktop (lg+)   — sticky sidebar + selected category pane with collapsible cards
 import Layout from './Layout.astro';
 import ChipBar from './ChipBar.astro';
+import PageHeader from './PageHeader.astro';
 import TeamClubCard from './TeamClubCard.astro';
-import { getRace } from '../lib/data';
+import { getRace, getRaces } from '../lib/data';
 import { siteUrl } from '../lib/url';
-import { getSeriesLabel, getSeriesLongLabel } from '../lib/format';
+import { formatRaceDate } from '../lib/format';
 import type { Club, Series, SeriesConfig, TeamResults } from '../lib/types';
 
 export interface Props {
@@ -29,8 +30,16 @@ const { series, year, raceId, teamResults, provisional, clubs, config, runnerUrl
 
 const race = getRace(year, series, raceId);
 const title = race?.name ?? raceId;
-const seriesLabel = getSeriesLabel(series);
-const seriesLong  = getSeriesLongLabel(series);
+const allRaces   = getRaces(year, series);
+const raceIndex  = allRaces.findIndex(r => r.id === raceId);
+const raceNumber = raceIndex >= 0 ? raceIndex + 1 : null;
+const raceTotal  = allRaces.length;
+
+const raceMeta = [
+  race?.date ? formatRaceDate(race.date, race?.time) : null,
+  race?.location ?? null,
+  race?.distance ?? null,
+].filter(Boolean) as string[];
 
 const clubById     = Object.fromEntries(clubs.map(c => [c.id, c]));
 const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [c.id, c]));
@@ -39,39 +48,24 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
 <Layout title={`${title} — Team Results`}>
 
   <!-- ── Full-width race header (hero slot) ── -->
-  <div slot="hero" class="bg-surface">
-    <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-8 pb-5">
-      <div class="mb-5">
-        <a href={siteUrl(`/${series}/${year}`)} class="btn btn-ghost btn-sm gap-1 -ml-3">← {seriesLabel} {year}</a>
-      </div>
-      <p class="font-head text-[10px] font-bold tracking-[0.14em] uppercase text-muted mb-1">Race Results</p>
-      <div class="flex items-center gap-3 flex-wrap">
-        <h1 class="font-head text-[28px] lg:text-[32px] font-extrabold tracking-tight leading-none">{title}</h1>
-        {provisional && (
-          <span class="badge badge-warning">Provisional</span>
-        )}
-      </div>
-      <p class="text-sm text-muted mt-2">{year} Inter Club {seriesLong}</p>
+  <PageHeader
+    slot="hero"
+    eyebrow={raceNumber != null ? `Race ${raceNumber}${raceTotal > 1 ? ` of ${raceTotal}` : ''}` : undefined}
+    title={title}
+    subtitleParts={raceMeta}
+    provisional={provisional}
+  >
+    <div class="flex">
+      <a
+        href={siteUrl(`/${series}/${year}/${raceId}/results`)}
+        class="flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 -mb-px text-center md:text-left border-transparent text-hdr-muted hover:text-hdr-text transition-colors"
+      >Individual</a>
+      <a
+        href={siteUrl(`/${series}/${year}/${raceId}/team-results`)}
+        class="flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 -mb-px text-center md:text-left border-amber text-hdr-text transition-colors"
+      >Team</a>
     </div>
-
-    <div class="border-b border-line" />
-
-    <!-- Individual / Team tab strip -->
-    <div class="border-b border-line">
-      <div class="max-w-4xl xl:max-w-5xl mx-auto px-4">
-        <div class="flex">
-          <a
-            href={siteUrl(`/${series}/${year}/${raceId}/results`)}
-            class="flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 -mb-px text-center md:text-left border-transparent text-muted hover:text-content transition-colors"
-          >Individual</a>
-          <a
-            href={siteUrl(`/${series}/${year}/${raceId}/team-results`)}
-            class="flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 -mb-px text-center md:text-left border-amber text-content transition-colors"
-          >Team</a>
-        </div>
-      </div>
-    </div>
-  </div>
+  </PageHeader>
 
   <!-- ── Category chip bar (mobile + tablet, hidden on desktop) ── -->
   <ChipBar

--- a/src/pages/road-gp/[year]/[raceId].astro
+++ b/src/pages/road-gp/[year]/[raceId].astro
@@ -55,33 +55,27 @@ const hasStats = !!(mRecord || fRecord);
   <div slot="hero" class="bg-content text-white">
     <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 py-5 md:py-7">
 
-      <a href={backUrl} class="text-[11px] text-white/50 hover:text-white/80 transition-colors mb-4 inline-block">
-        ← Road Grand Prix
+      <a href={backUrl} class="text-[12px] text-white/50 hover:text-white/80 transition-colors mb-3 inline-block">
+        ← Road Grand Prix {year}
       </a>
 
-      <div class="font-head text-[10px] font-bold tracking-[0.14em] uppercase text-amber mb-2">
+      <div class="font-head text-[11px] font-bold tracking-[0.14em] uppercase text-amber mb-1.5">
         Road Grand Prix · Race {raceIndex} of {totalRaces}
       </div>
 
       <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between sm:gap-6">
         <div>
-          <h1 class="font-head text-[clamp(1.75rem,5vw,2.5rem)] font-extrabold tracking-tight leading-none mb-2">
+          <h1 class="font-head text-[clamp(1.75rem,5vw,2.5rem)] font-extrabold tracking-tight leading-none mb-1.5">
             {name}
           </h1>
-          <p class="font-mono text-sm text-white/60 mb-1">{formattedDate}</p>
-          {location && <p class="text-sm text-white/60 mb-3">{location}</p>}
-          {(distance || ascent) && (
-            <div class="flex gap-2 flex-wrap">
-              {distance && (
-                <span class="font-mono text-[11px] font-medium border border-white/20 rounded-full px-3 py-0.5 text-white">
-                  {distance}
-                </span>
-              )}
-              {ascent && (
-                <span class="font-mono text-[11px] font-medium border border-white/20 rounded-full px-3 py-0.5 text-white/70">
-                  ↑ {ascent}
-                </span>
-              )}
+          {(formattedDate || location || distance || ascent) && (
+            <div class="flex items-center flex-wrap gap-x-2.5 gap-y-1 font-mono text-[12px] text-white/55 mt-1">
+              {formattedDate && <span>{formattedDate}</span>}
+              {formattedDate && location && <span class="w-px h-[11px] bg-white/25 self-center flex-shrink-0" />}
+              {location && <span>{location}</span>}
+              {(distance || ascent) && (formattedDate || location) && <span class="w-px h-[11px] bg-white/25 self-center flex-shrink-0" />}
+              {distance && <span class="border border-white/25 rounded-full px-2.5 py-0.5">{distance}</span>}
+              {ascent && <span class="border border-white/25 rounded-full px-2.5 py-0.5">↑ {ascent}</span>}
             </div>
           )}
         </div>

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../../components/Layout.astro';
+import PageHeader from '../../components/PageHeader.astro';
 import { getRunnerProfileStaticPaths, resolveClubName } from '../../lib/runners';
 import { siteUrl } from '../../lib/url';
 import type { GlobalRunner, RunnerYearBlock, RunnerClubHistory, RunnerAwardSummary } from '../../lib/types';
@@ -17,7 +18,6 @@ interface Props {
 
 const { runner, clubHistory, awardSummary, yearBlocks } = Astro.props;
 const title = `${runner.firstName} ${runner.lastName}`;
-const initials = `${runner.firstName[0] ?? ''}${runner.lastName[0] ?? ''}`.toUpperCase();
 const sexLabel = runner.sex === 'M' ? 'Men' : 'Women';
 const currentClubName = resolveClubName(runner.club);
 
@@ -43,37 +43,12 @@ function positionLabel(pos: number): string {
 <Layout title={title}>
 
   <!-- ── Dark hero ── -->
-  <div slot="hero" class="bg-hdr-dark text-hdr-text">
-    <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 pt-4 pb-6">
-
-      <p class="font-mono text-xs text-hdr-muted mb-4 tracking-wide">← Runners</p>
-
-      <!-- Identity row -->
-      <div class="flex items-center gap-4 sm:gap-6">
-        <!-- Initials avatar -->
-        <div
-          class="size-14 sm:size-20 shrink-0 rounded-full bg-amber flex items-center justify-center font-head font-extrabold text-xl sm:text-3xl tracking-tight select-none"
-          style="color: oklch(18% 0.02 250)"
-          aria-hidden="true"
-        >
-          {initials}
-        </div>
-
-        <div class="min-w-0">
-          <p class="font-head font-bold text-xs uppercase tracking-widest text-amber mb-1">
-            {currentClubName}
-          </p>
-          <h1 class="font-head font-extrabold text-4xl sm:text-5xl tracking-tight leading-none">
-            {title}
-          </h1>
-          <p class="font-mono text-xs text-hdr-muted mt-2 tracking-wider uppercase">
-            {sexLabel} · {runner.ageCategory}
-          </p>
-        </div>
-      </div>
-
-    </div>
-  </div>
+  <PageHeader
+    slot="hero"
+    eyebrow={currentClubName}
+    title={title}
+    subtitleParts={[sexLabel, runner.ageCategory]}
+  />
 
   <!-- ── Body: sidebar + main ── -->
   <div class="md:grid md:grid-cols-[220px_1fr] md:gap-7 lg:grid-cols-[260px_1fr]">


### PR DESCRIPTION
## Summary

- Introduces a shared `PageHeader.astro` component with `eyebrow`, `title`, `subtitleParts`, `provisional`, and a default slot for tab strips
- Migrates `IndividualResultsLayout`, `TeamResultsLayout`, and the runner profile page (`runners/[slug].astro`) to use it — all three now share identical dark-header styling
- Standardises the meta row (date · location · distance) to use 1 px visual separator lines throughout
- Removes breadcrumb back-links and race-progress dots from result page headers
- Removes the initials avatar and `← Runners` nav from the runner profile header
- Race detail page (`[raceId].astro`) gets a unified meta row to match

## What reviewers should know

All styling for the dark hero band now lives in one file (`src/components/PageHeader.astro`). Future changes to eyebrow colour, title size, subtitle formatting, or tab strip separator only need to be made once.

The `subtitleParts` prop accepts a `string[]`; the component renders items separated by 1 px white/20 vertical lines. Passing a single-element array (runner profile: `[sexLabel, ageCategory]`) renders two items with one separator.

## Test plan

- [ ] Individual results page: dark header, amber eyebrow, large title, meta row, Individual/Team tabs
- [ ] Team results page: same structure with Team tab active
- [ ] Runner profile: dark header, amber club name, large name, muted sex · category — no avatar, no back-nav
- [ ] Provisional badge displays correctly on provisional results
- [ ] `npm run build` passes (1314 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)