### PR TITLE
fix: stop accordion toggling when runner name link is clicked on mobile

### DIFF
--- a/src/components/MobileAccordionCard.astro
+++ b/src/components/MobileAccordionCard.astro
@@ -56,6 +56,9 @@ const { detailId, position, podiumAccent, class: className, ...rest } = Astro.pr
 
 <script>
   document.querySelectorAll<HTMLButtonElement>('.accordion-toggle').forEach(btn => {
+    btn.querySelectorAll<HTMLAnchorElement>('a').forEach(link => {
+      link.addEventListener('click', e => e.stopPropagation());
+    });
     btn.addEventListener('click', () => {
       const detail = document.getElementById(btn.dataset.target!)!;
       const isOpen = !detail.classList.contains('hidden');


### PR DESCRIPTION
## Summary

- Clicking a linked runner name inside the mobile accordion card caused the accordion to briefly expand before navigating away
- Added `stopPropagation()` on click events for any `<a>` tags inside `.accordion-toggle` buttons in `MobileAccordionCard.astro`
- This prevents the button's toggle handler from firing when the user's intent is to follow the link

## Test plan

- [ ] On mobile (or narrow viewport <640px), open an individual standings page with linked runner names
- [ ] Tap a runner name link — it should navigate directly without the accordion expanding first
- [ ] Tapping the rest of the card row (position, score, chevron) should still expand/collapse as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)