### PR TITLE
fix: run count excludes null results entries

### DIFF
--- a/src/components/IndividualStandingsLayout.astro
+++ b/src/components/IndividualStandingsLayout.astro
@@ -347,7 +347,7 @@ const raceColWidth = standings.races.length >= 7 ? '3rem'
                     <div slot="score" class="text-right shrink-0">
                       <div class="font-mono text-xl font-medium leading-none tabular-nums">{runner.total}</div>
                       <div class="font-head text-[9px] font-bold tracking-[0.12em] uppercase text-muted mt-0.5">
-                        {Object.keys(runner.results).length} run
+                        {Object.values(runner.results).filter(r => r !== null).length} run
                       </div>
                     </div>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -181,7 +181,7 @@ export interface IndividualStandingsRunner {
   sex?: string;          // 'M' or 'F'; optional when inherited from category
   ageCategory?: string;  // e.g. 'SEN', 'V40'; optional when inherited from category
   total: number;
-  results: Record<string, IndividualRaceResult>;  // keyed by race id; only races the runner entered
+  results: Record<string, IndividualRaceResult | null>;  // keyed by race id; null means the runner did not enter that race
   seriesRunnerId?: number;   // optional; links standing entry to a runner profile
 }
 


### PR DESCRIPTION
## Summary

- The mobile accordion card in `IndividualStandingsLayout` showed an incorrect run count for runners in series where `individual-standings.json` uses `null` values for races not entered (all race IDs are present as keys regardless of participation)
- `Object.keys(runner.results).length` counted every key including nulls, so a runner who entered 2 of 4 races would display "4 RUN" instead of "2 RUN"
- Fixed by using `Object.values(runner.results).filter(r => r !== null).length`
- Updated `IndividualStandingsRunner.results` type from `Record<string, IndividualRaceResult>` to `Record<string, IndividualRaceResult | null>` to reflect the actual data shape (all existing usages already handled null via optional chaining and falsy checks)

## Test plan

- [ ] Navigate to `/fell/2024/individual-standings` on mobile viewport
- [ ] Verify runners who only entered some races show their actual entry count (e.g. Darrell Pickering and Craig Walker show "2 RUN", not "4 RUN")
- [ ] Verify runners who entered all races still show the correct total (e.g. Alistair Palmer shows "4 RUN" for all 4 races)
- [ ] Check other years/series with individual standings render without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)