### PR TITLE
refactor: migrate race detail page header to shared PageHeader component

### DIFF
--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -4,7 +4,6 @@
 // Shared dark hero header used across all detail pages:
 //   race results, team results, individual/team standings, runner profiles.
 // Renders the full-bleed bg-hdr-dark band with:
-//   - an optional back link (e.g. "← Road GP 2026") above the eyebrow
 //   - an optional amber eyebrow line (e.g. "Road GP 2026 · Race 1 of 7")
 //   - a bold h1 (with optional Provisional badge)
 //   - an optional muted mono subtitle row (items separated by 1px lines)

--- a/src/pages/road-gp/[year]/[raceId].astro
+++ b/src/pages/road-gp/[year]/[raceId].astro
@@ -1,6 +1,7 @@
 ---
 // src/pages/road-gp/[year]/[raceId].astro
 import Layout from '../../../components/Layout.astro';
+import PageHeader from '../../../components/PageHeader.astro';
 import { getAvailableYears, getRaces, getCurrentYear } from '../../../lib/data';
 import { formatRaceDate } from '../../../lib/format';
 import { hasResults } from '../../../lib/results';
@@ -40,95 +41,24 @@ const {
   postRaceVenue,
 } = race;
 const formattedDate = formatRaceDate(date, time);
-const currentYear = getCurrentYear();
-const backUrl = year === currentYear ? siteUrl('/road-gp/') : siteUrl(`/road-gp/${year}/`);
-const resultsExist = hasResults(year, 'road-gp', race.id);
 const hasGettingHere = !!(startAddress || mapEmbedUrl || parking);
 const hasCourse = !!(routeDescription || routeImage || (courseRecords && courseRecords.length > 0));
-const mRecord = courseRecords?.find(r => r.sex === 'M');
-const fRecord = courseRecords?.find(r => r.sex === 'F');
-const hasStats = !!(mRecord || fRecord);
+
+const raceMeta = [
+  formattedDate || null,
+  location     || null,
+  distance     || null,
+  ascent       ? `↑ ${ascent}` : null,
+].filter(Boolean) as string[];
 ---
 
 <Layout title={name}>
-  <!-- Dark editorial hero -->
-  <div slot="hero" class="bg-content text-white">
-    <div class="max-w-4xl xl:max-w-5xl mx-auto px-4 py-5 md:py-7">
-
-      <a href={backUrl} class="text-[12px] text-white/50 hover:text-white/80 transition-colors mb-3 inline-block">
-        ← Road Grand Prix {year}
-      </a>
-
-      <div class="font-head text-[11px] font-bold tracking-[0.14em] uppercase text-amber mb-1.5">
-        Road Grand Prix · Race {raceIndex} of {totalRaces}
-      </div>
-
-      <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between sm:gap-6">
-        <div>
-          <h1 class="font-head text-[clamp(1.75rem,5vw,2.5rem)] font-extrabold tracking-tight leading-none mb-1.5">
-            {name}
-          </h1>
-          {(formattedDate || location || distance || ascent) && (
-            <div class="flex items-center flex-wrap gap-x-2.5 gap-y-1 font-mono text-[12px] text-white/55 mt-1">
-              {formattedDate && <span>{formattedDate}</span>}
-              {formattedDate && location && <span class="w-px h-[11px] bg-white/25 self-center flex-shrink-0" />}
-              {location && <span>{location}</span>}
-              {(distance || ascent) && (formattedDate || location) && <span class="w-px h-[11px] bg-white/25 self-center flex-shrink-0" />}
-              {distance && <span class="border border-white/25 rounded-full px-2.5 py-0.5">{distance}</span>}
-              {ascent && <span class="border border-white/25 rounded-full px-2.5 py-0.5">↑ {ascent}</span>}
-            </div>
-          )}
-        </div>
-
-        {(resultsExist || detailsUrl) && (
-          <div class="flex gap-2 mt-4 sm:mt-0 flex-shrink-0">
-            {resultsExist && (
-              <a
-                href={siteUrl(`/road-gp/${year}/${race.id}/results/`)}
-                class="btn btn-primary whitespace-nowrap"
-              >
-                View Results →
-              </a>
-            )}
-            {detailsUrl && (
-              <a
-                href={detailsUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="btn border-white/25 text-white hover:bg-white/10 whitespace-nowrap"
-              >
-                Race details ↗
-              </a>
-            )}
-          </div>
-        )}
-      </div>
-
-      {hasStats && (
-        <div class="mt-5 pt-4 border-t border-white/10 grid grid-cols-3 gap-4 max-w-xs">
-          {distance && (
-            <div>
-              <div class="font-mono text-base font-medium text-amber leading-none">{distance}</div>
-              <div class="text-[10px] uppercase tracking-wide text-white/50 mt-1">Distance</div>
-            </div>
-          )}
-          {mRecord && (
-            <div>
-              <div class="font-mono text-base font-medium text-amber leading-none">{mRecord.time}</div>
-              <div class="text-[10px] uppercase tracking-wide text-white/50 mt-1">M Record</div>
-            </div>
-          )}
-          {fRecord && (
-            <div>
-              <div class="font-mono text-base font-medium text-amber leading-none">{fRecord.time}</div>
-              <div class="text-[10px] uppercase tracking-wide text-white/50 mt-1">F Record</div>
-            </div>
-          )}
-        </div>
-      )}
-
-    </div>
-  </div>
+  <PageHeader
+    slot="hero"
+    eyebrow={`Road Grand Prix · Race ${raceIndex} of ${totalRaces}`}
+    title={name}
+    subtitleParts={raceMeta}
+  />
 
   <!-- Optional race image -->
   {image && (


### PR DESCRIPTION
## Summary

- Replaces the bespoke dark hero in `src/pages/road-gp/[year]/[raceId].astro` with the shared `PageHeader` component (eyebrow, title, subtitle parts)
- Removes the CTA buttons ("View Results →", "Race details ↗") and the stats section (distance, M/F course records) that previously lived inside the header — course records remain visible in the page body under **The Course**
- `PageHeader` itself is **unchanged**; no new props or slots were added

## Reviewer notes

The only visual difference on the race detail page is the header is now the standard dark header used everywhere else on the site — no action buttons or stat grid above the fold. The course record data is still present on the page in the body card.