### PR TITLE
feat: integrate vest images into individual results and standings pages

### DIFF
--- a/src/components/IndividualResultsLayout.astro
+++ b/src/components/IndividualResultsLayout.astro
@@ -373,13 +373,20 @@ const showSexToggle = hasMale && hasFemale;
                   <td class="ic-col sm:hidden py-2.5 px-2 font-mono text-[12px] text-muted align-middle">{openPos}</td>
                   <td class="no-col py-2.5 px-2 font-mono text-[12px] text-muted align-middle">{r.raceNumber ?? '–'}</td>
                   <td class="py-2.5 px-2 align-middle max-w-0 overflow-hidden">
-                    <div class="font-semibold leading-tight truncate">
-                      {url
-                        ? <a href={url} class="link link-hover">{fullName}</a>
-                        : fullName
-                      }
+                    <div class="flex gap-2 min-w-0">
+                      {r.club !== 'Guest' && clubById[r.club]?.vest && (
+                        <img src={siteUrl(`/images/vests/${clubById[r.club].vest}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
+                      )}
+                      <div class="min-w-0">
+                        <div class="font-semibold leading-tight truncate">
+                          {url
+                            ? <a href={url} class="link link-hover">{fullName}</a>
+                            : fullName
+                          }
+                        </div>
+                        <div class="text-xs text-muted mt-0.5 truncate">{clubName}</div>
+                      </div>
                     </div>
-                    <div class="text-xs text-muted mt-0.5 truncate">{clubName}</div>
                   </td>
                   <td class="py-2.5 px-2 font-mono text-[11px] text-muted align-middle">{(r.sex ?? '') + (r.ageCategory ?? '')}</td>
                   <td class="py-2.5 px-2 pr-4 font-mono text-[13px] font-medium text-right tabular-nums align-middle">{formatTime(r.time)}</td>
@@ -437,8 +444,10 @@ const showSexToggle = hasMale && hasFemale;
     seriesRunnerId: number | null;
   };
 
+  const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+
   const allResults: Result[] = JSON.parse(document.getElementById('results-data')!.textContent!);
-  const clubs: Array<{ id: string; name: string; shortName: string }> =
+  const clubs: Array<{ id: string; name: string; shortName: string; vest?: string }> =
     JSON.parse(document.getElementById('clubs-data')!.textContent!);
   const clubById     = Object.fromEntries(clubs.map(c => [c.id, c]));
   const runnerUrlMap: Record<number, string> =
@@ -614,6 +623,8 @@ const showSexToggle = hasMale && hasFemale;
     const url      = r.seriesRunnerId != null ? runnerUrlMap[r.seriesRunnerId] : null;
     const fullName = `${esc(r.firstName ?? '')} ${esc(r.lastName ?? '')}`.trim();
     const clubName = r.club === 'Guest' ? 'Guest' : esc(clubById[r.club]?.name ?? r.club);
+    const vest     = r.club !== 'Guest' ? (clubById[r.club]?.vest ?? null) : null;
+    const vestHtml = vest ? `<img src="${BASE}/images/vests/${esc(vest)}" alt="" class="h-9 w-auto shrink-0 object-contain" />` : '';
     const displayCatId = activeCategoryId ?? 'open';
     const icVal    = r.club === 'Guest' ? '–' : String(r.categoryPositions[displayCatId] ?? '–');
     const nameCell = url ? `<a href="${esc(url)}" class="link link-hover">${fullName}</a>` : fullName;
@@ -630,8 +641,13 @@ const showSexToggle = hasMale && hasFemale;
       <td class="ic-col sm:hidden py-2.5 px-2 font-mono text-[12px] text-muted align-middle">${icVal}</td>
       <td class="no-col py-2.5 px-2 font-mono text-[12px] text-muted align-middle">${r.raceNumber ?? '–'}</td>
       <td class="py-2.5 px-2 align-middle max-w-0 overflow-hidden">
-        <div class="font-semibold leading-tight truncate">${nameCell}</div>
-        <div class="text-xs text-muted mt-0.5 truncate">${clubName}</div>
+        <div class="flex gap-2 min-w-0">
+          ${vestHtml}
+          <div class="min-w-0">
+            <div class="font-semibold leading-tight truncate">${nameCell}</div>
+            <div class="text-xs text-muted mt-0.5 truncate">${clubName}</div>
+          </div>
+        </div>
       </td>
       <td class="py-2.5 px-2 font-mono text-[11px] text-muted align-middle">${cat}</td>
       <td class="py-2.5 px-2 pr-4 font-mono text-[13px] font-medium text-right tabular-nums align-middle">${formatTime(r.time)}</td>

--- a/src/components/IndividualResultsLayout.astro
+++ b/src/components/IndividualResultsLayout.astro
@@ -374,9 +374,7 @@ const showSexToggle = hasMale && hasFemale;
                   <td class="no-col py-2.5 px-2 font-mono text-[12px] text-muted align-middle">{r.raceNumber ?? '–'}</td>
                   <td class="py-2.5 px-2 align-middle max-w-0 overflow-hidden">
                     <div class="flex gap-2 min-w-0">
-                      {r.club !== 'Guest' && clubById[r.club]?.vest && (
-                        <img src={siteUrl(`/images/vests/${clubById[r.club].vest}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
-                      )}
+                      <img src={siteUrl(`/images/vests/${r.club === 'Guest' ? 'unknown-sm.png' : (clubById[r.club]?.vest ?? 'unknown-sm.png')}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
                       <div class="min-w-0">
                         <div class="font-semibold leading-tight truncate">
                           {url
@@ -623,8 +621,8 @@ const showSexToggle = hasMale && hasFemale;
     const url      = r.seriesRunnerId != null ? runnerUrlMap[r.seriesRunnerId] : null;
     const fullName = `${esc(r.firstName ?? '')} ${esc(r.lastName ?? '')}`.trim();
     const clubName = r.club === 'Guest' ? 'Guest' : esc(clubById[r.club]?.name ?? r.club);
-    const vest     = r.club !== 'Guest' ? (clubById[r.club]?.vest ?? null) : null;
-    const vestHtml = vest ? `<img src="${BASE}/images/vests/${esc(vest)}" alt="" class="h-9 w-auto shrink-0 object-contain" />` : '';
+    const vest     = r.club !== 'Guest' ? (clubById[r.club]?.vest ?? 'unknown-sm.png') : 'unknown-sm.png';
+    const vestHtml = `<img src="${BASE}/images/vests/${esc(vest)}" alt="" class="h-9 w-auto shrink-0 object-contain" />`;
     const displayCatId = activeCategoryId ?? 'open';
     const icVal    = r.club === 'Guest' ? '–' : String(r.categoryPositions[displayCatId] ?? '–');
     const nameCell = url ? `<a href="${esc(url)}" class="link link-hover">${fullName}</a>` : fullName;

--- a/src/components/IndividualResultsLayout.astro
+++ b/src/components/IndividualResultsLayout.astro
@@ -374,7 +374,7 @@ const showSexToggle = hasMale && hasFemale;
                   <td class="no-col py-2.5 px-2 font-mono text-[12px] text-muted align-middle">{r.raceNumber ?? '–'}</td>
                   <td class="py-2.5 px-2 align-middle max-w-0 overflow-hidden">
                     <div class="flex gap-2 min-w-0">
-                      <img src={siteUrl(`/images/vests/${r.club === 'Guest' ? 'unknown-sm.png' : (clubById[r.club]?.vest ?? 'unknown-sm.png')}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
+                      <img src={siteUrl(`/images/vests/${(r.club === 'Guest' ? 'unknown.png' : (clubById[r.club]?.vest ?? 'unknown.png')).replace('.png', '-sm.png')}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
                       <div class="min-w-0">
                         <div class="font-semibold leading-tight truncate">
                           {url
@@ -621,8 +621,8 @@ const showSexToggle = hasMale && hasFemale;
     const url      = r.seriesRunnerId != null ? runnerUrlMap[r.seriesRunnerId] : null;
     const fullName = `${esc(r.firstName ?? '')} ${esc(r.lastName ?? '')}`.trim();
     const clubName = r.club === 'Guest' ? 'Guest' : esc(clubById[r.club]?.name ?? r.club);
-    const vest     = r.club !== 'Guest' ? (clubById[r.club]?.vest ?? 'unknown-sm.png') : 'unknown-sm.png';
-    const vestHtml = `<img src="${BASE}/images/vests/${esc(vest)}" alt="" class="h-9 w-auto shrink-0 object-contain" />`;
+    const vestFile = (r.club !== 'Guest' ? (clubById[r.club]?.vest ?? 'unknown.png') : 'unknown.png').replace('.png', '-sm.png');
+    const vestHtml = `<img src="${BASE}/images/vests/${esc(vestFile)}" alt="" class="h-9 w-auto shrink-0 object-contain" />`;
     const displayCatId = activeCategoryId ?? 'open';
     const icVal    = r.club === 'Guest' ? '–' : String(r.categoryPositions[displayCatId] ?? '–');
     const nameCell = url ? `<a href="${esc(url)}" class="link link-hover">${fullName}</a>` : fullName;

--- a/src/components/IndividualStandingsLayout.astro
+++ b/src/components/IndividualStandingsLayout.astro
@@ -334,9 +334,7 @@ const raceColWidth = standings.races.length >= 7 ? '3rem'
                     data-club={runner.club}
                   >
                     <div class="flex gap-2 min-w-0">
-                      {clubById[runner.club]?.vest && (
-                        <img src={siteUrl(`/images/vests/${clubById[runner.club].vest}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
-                      )}
+                      <img src={siteUrl(`/images/vests/${clubById[runner.club]?.vest ?? 'unknown-sm.png'}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
                       <div class="min-w-0">
                         <div class="font-semibold text-[15px] leading-tight truncate">
                           {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]

--- a/src/components/IndividualStandingsLayout.astro
+++ b/src/components/IndividualStandingsLayout.astro
@@ -333,13 +333,18 @@ const raceColWidth = standings.races.length >= 7 ? '3rem'
                     data-name={runner.name}
                     data-club={runner.club}
                   >
-                    <div class="font-semibold text-[15px] leading-tight truncate">
-                      {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]
-                        ? <a href={runnerUrlMap[runner.seriesRunnerId]} class="link link-hover">{runner.name}</a>
-                        : runner.name}
-                    </div>
-                    <div class="text-xs text-muted mt-0.5 truncate">
-                      {clubName}{catLabel && <> · <span class="font-mono">{catLabel}</span></>}
+                    <div class="flex gap-2 min-w-0">
+                      {clubById[runner.club]?.vest && (
+                        <img src={siteUrl(`/images/vests/${clubById[runner.club].vest}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
+                      )}
+                      <div class="min-w-0">
+                        <div class="font-semibold text-[15px] leading-tight truncate">
+                          {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]
+                            ? <a href={runnerUrlMap[runner.seriesRunnerId]} class="link link-hover">{runner.name}</a>
+                            : runner.name}
+                        </div>
+                        <div class="text-xs text-muted mt-0.5 truncate">{clubName}{catLabel && <> · <span class="font-mono">{catLabel}</span></>}</div>
+                      </div>
                     </div>
 
                     <div slot="score" class="text-right shrink-0">
@@ -428,12 +433,19 @@ const raceColWidth = standings.races.length >= 7 ? '3rem'
                             <span class="font-mono text-sm font-medium text-muted tabular-nums">{runner.position}</span>
                           </td>
                           <td class="py-2.5 px-2 align-middle max-w-0 overflow-hidden">
-                            <div class="font-semibold leading-tight truncate">
-                              {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]
-                                ? <a href={runnerUrlMap[runner.seriesRunnerId]} class="link link-hover">{runner.name}</a>
-                                : runner.name}
+                            <div class="flex gap-2 min-w-0">
+                              {clubById[runner.club]?.vest && (
+                                <img src={siteUrl(`/images/vests/${clubById[runner.club].vest}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
+                              )}
+                              <div class="min-w-0">
+                                <div class="font-semibold leading-tight truncate">
+                                  {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]
+                                    ? <a href={runnerUrlMap[runner.seriesRunnerId]} class="link link-hover">{runner.name}</a>
+                                    : runner.name}
+                                </div>
+                                <div class="text-xs text-muted mt-0.5 truncate">{clubName}</div>
+                              </div>
                             </div>
-                            <div class="text-xs text-muted mt-0.5 truncate">{clubName}</div>
                           </td>
                           <td class="py-2.5 px-2 text-content/60 text-xs tabular-nums align-middle">
                             {effectiveSex}{effectiveAge}
@@ -516,12 +528,19 @@ const raceColWidth = standings.races.length >= 7 ? '3rem'
                           <span class="font-mono text-sm font-medium text-muted tabular-nums">{runner.position}</span>
                         </td>
                         <td class="py-2.5 pl-2 pr-4 align-middle max-w-0 overflow-hidden">
-                          <div class="font-semibold leading-tight truncate">
-                            {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]
-                              ? <a href={runnerUrlMap[runner.seriesRunnerId]} class="link link-hover">{runner.name}</a>
-                              : runner.name}
+                          <div class="flex gap-2 min-w-0">
+                            {clubById[runner.club]?.vest && (
+                              <img src={siteUrl(`/images/vests/${clubById[runner.club].vest}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
+                            )}
+                            <div class="min-w-0">
+                              <div class="font-semibold leading-tight truncate">
+                                {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]
+                                  ? <a href={runnerUrlMap[runner.seriesRunnerId]} class="link link-hover">{runner.name}</a>
+                                  : runner.name}
+                              </div>
+                              <div class="text-xs text-muted mt-0.5 truncate">{clubName}</div>
+                            </div>
                           </div>
-                          <div class="text-xs text-muted mt-0.5 truncate">{clubName}</div>
                         </td>
                         <td class="py-2.5 pr-4 text-content/60 text-xs tabular-nums align-middle">
                           {effectiveSex}{effectiveAge}

--- a/src/components/IndividualStandingsLayout.astro
+++ b/src/components/IndividualStandingsLayout.astro
@@ -334,7 +334,7 @@ const raceColWidth = standings.races.length >= 7 ? '3rem'
                     data-club={runner.club}
                   >
                     <div class="flex gap-2 min-w-0">
-                      <img src={siteUrl(`/images/vests/${clubById[runner.club]?.vest ?? 'unknown-sm.png'}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
+                      <img src={siteUrl(`/images/vests/${(clubById[runner.club]?.vest ?? 'unknown.png').replace('.png', '-sm.png')}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
                       <div class="min-w-0">
                         <div class="font-semibold text-[15px] leading-tight truncate">
                           {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]

--- a/src/components/TeamClubCard.astro
+++ b/src/components/TeamClubCard.astro
@@ -8,11 +8,13 @@
 //   desktop — auto-fill scorer grid, slightly larger club name font
 //   mobile  — 2/3-col scorer grid, slightly smaller club name font
 import type { TeamScorer } from '../lib/types';
+import { siteUrl } from '../lib/url';
 
 interface Props {
   detailId: string;
   position: number;
   clubName: string;
+  vest?: string;
   total: number;
   scorers: TeamScorer[];
   /** Scorer count from catConfig; when provided, drives the incomplete-team warning. */
@@ -21,7 +23,7 @@ interface Props {
   variant: 'desktop' | 'mobile';
 }
 
-const { detailId, position, clubName, total, scorers, scorerCount, runnerUrlMap, variant } = Astro.props;
+const { detailId, position, clubName, vest, total, scorers, scorerCount, runnerUrlMap, variant } = Astro.props;
 const isDesktop = variant === 'desktop';
 ---
 
@@ -34,6 +36,9 @@ const isDesktop = variant === 'desktop';
     <span class="font-mono text-sm font-medium text-muted w-6 shrink-0 text-center tabular-nums">
       {position}
     </span>
+    {vest && (
+      <img src={siteUrl(`/images/vests/${vest}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
+    )}
     <div class="flex-1 min-w-0">
       <div class:list={[
         'font-head font-bold tracking-[-0.01em] leading-[1.15] truncate',

--- a/src/components/TeamClubCard.astro
+++ b/src/components/TeamClubCard.astro
@@ -36,7 +36,7 @@ const isDesktop = variant === 'desktop';
     <span class="font-mono text-sm font-medium text-muted w-6 shrink-0 text-center tabular-nums">
       {position}
     </span>
-    <img src={siteUrl(`/images/vests/${vest ?? 'unknown-sm.png'}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
+    <img src={siteUrl(`/images/vests/${(vest ?? 'unknown.png').replace('.png', '-sm.png')}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
     <div class="flex-1 min-w-0">
       <div class:list={[
         'font-head font-bold tracking-[-0.01em] leading-[1.15] truncate',

--- a/src/components/TeamClubCard.astro
+++ b/src/components/TeamClubCard.astro
@@ -36,9 +36,7 @@ const isDesktop = variant === 'desktop';
     <span class="font-mono text-sm font-medium text-muted w-6 shrink-0 text-center tabular-nums">
       {position}
     </span>
-    {vest && (
-      <img src={siteUrl(`/images/vests/${vest}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
-    )}
+    <img src={siteUrl(`/images/vests/${vest ?? 'unknown-sm.png'}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
     <div class="flex-1 min-w-0">
       <div class:list={[
         'font-head font-bold tracking-[-0.01em] leading-[1.15] truncate',

--- a/src/components/TeamResultsLayout.astro
+++ b/src/components/TeamResultsLayout.astro
@@ -128,6 +128,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
                 detailId={`dt-detail-${i}-${clubResult.club}`}
                 position={clubResult.position}
                 clubName={clubById[clubResult.club]?.name ?? clubResult.club}
+                vest={clubById[clubResult.club]?.vest}
                 total={clubResult.total}
                 scorers={clubResult.scorers}
                 scorerCount={catConfig?.scorerCount}
@@ -170,6 +171,7 @@ const categoryById = Object.fromEntries((config.teamCategories ?? []).map(c => [
                 detailId={`mb-detail-${i}-${clubResult.club}`}
                 position={clubResult.position}
                 clubName={clubById[clubResult.club]?.name ?? clubResult.club}
+                vest={clubById[clubResult.club]?.vest}
                 total={clubResult.total}
                 scorers={clubResult.scorers}
                 scorerCount={catConfig?.scorerCount}

--- a/src/components/TeamStandingsLayout.astro
+++ b/src/components/TeamStandingsLayout.astro
@@ -169,7 +169,12 @@ const raceColWidth = races.length >= 7 ? '3rem'
                         {clubResult.position}
                       </td>
                       <td class="py-2.5 px-2 align-middle max-w-0 overflow-hidden">
-                        <div class="font-semibold text-[14px] truncate">{clubName}</div>
+                        <div class="flex items-center gap-2 min-w-0">
+                          {clubById[clubResult.club]?.vest && (
+                            <img src={siteUrl(`/images/vests/${clubById[clubResult.club].vest}`)} alt="" class="h-6 w-auto shrink-0 object-contain" />
+                          )}
+                          <span class="font-semibold text-[14px] truncate">{clubName}</span>
+                        </div>
                       </td>
                       {races.map((race, ri) => {
                         const sIdx = standingsRaceIdx[race.id];
@@ -256,7 +261,12 @@ const raceColWidth = races.length >= 7 ? '3rem'
                           {clubResult.position}
                         </td>
                         <td class="py-3 pl-2 pr-2 align-middle max-w-0 overflow-hidden">
-                          <div class="font-semibold text-[14px] truncate">{clubName}</div>
+                          <div class="flex items-center gap-2 min-w-0">
+                            {clubById[clubResult.club]?.vest && (
+                              <img src={siteUrl(`/images/vests/${clubById[clubResult.club].vest}`)} alt="" class="h-6 w-auto shrink-0 object-contain" />
+                            )}
+                            <span class="font-semibold text-[14px] truncate">{clubName}</span>
+                          </div>
                         </td>
                         {races.map((race, ri) => {
                           const sIdx = standingsRaceIdx[race.id];
@@ -299,7 +309,12 @@ const raceColWidth = races.length >= 7 ? '3rem'
               const detailId = `detail-${i}-${clubResult.club}`;
               return (
                 <MobileAccordionCard detailId={detailId} position={clubResult.position}>
-                  <div class="font-head text-[16px] font-bold tracking-[-0.01em] leading-[1.15] truncate">{clubName}</div>
+                  <div class="flex items-center gap-2 min-w-0">
+                    {clubById[clubResult.club]?.vest && (
+                      <img src={siteUrl(`/images/vests/${clubById[clubResult.club].vest}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
+                    )}
+                    <div class="font-head text-[16px] font-bold tracking-[-0.01em] leading-[1.15] truncate">{clubName}</div>
+                  </div>
 
                   <div slot="score" class="text-right shrink-0 flex flex-col items-end justify-center min-h-10">
                     <div class="font-mono text-[22px] font-medium leading-none tabular-nums">{clubResult.total}</div>

--- a/src/components/TeamStandingsLayout.astro
+++ b/src/components/TeamStandingsLayout.astro
@@ -170,7 +170,7 @@ const raceColWidth = races.length >= 7 ? '3rem'
                       </td>
                       <td class="py-2.5 px-2 align-middle max-w-0 overflow-hidden">
                         <div class="flex items-center gap-2 min-w-0">
-                          <img src={siteUrl(`/images/vests/${clubById[clubResult.club]?.vest ?? 'unknown-sm.png'}`)} alt="" class="h-6 w-auto shrink-0 object-contain" />
+                          <img src={siteUrl(`/images/vests/${(clubById[clubResult.club]?.vest ?? 'unknown.png').replace('.png', '-sm.png')}`)} alt="" class="h-6 w-auto shrink-0 object-contain" />
                           <span class="font-semibold text-[14px] truncate">{clubName}</span>
                         </div>
                       </td>
@@ -308,7 +308,7 @@ const raceColWidth = races.length >= 7 ? '3rem'
               return (
                 <MobileAccordionCard detailId={detailId} position={clubResult.position}>
                   <div class="flex items-center gap-2 min-w-0">
-                    <img src={siteUrl(`/images/vests/${clubById[clubResult.club]?.vest ?? 'unknown-sm.png'}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
+                    <img src={siteUrl(`/images/vests/${(clubById[clubResult.club]?.vest ?? 'unknown.png').replace('.png', '-sm.png')}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
                     <div class="font-head text-[16px] font-bold tracking-[-0.01em] leading-[1.15] truncate">{clubName}</div>
                   </div>
 

--- a/src/components/TeamStandingsLayout.astro
+++ b/src/components/TeamStandingsLayout.astro
@@ -170,9 +170,7 @@ const raceColWidth = races.length >= 7 ? '3rem'
                       </td>
                       <td class="py-2.5 px-2 align-middle max-w-0 overflow-hidden">
                         <div class="flex items-center gap-2 min-w-0">
-                          {clubById[clubResult.club]?.vest && (
-                            <img src={siteUrl(`/images/vests/${clubById[clubResult.club].vest}`)} alt="" class="h-6 w-auto shrink-0 object-contain" />
-                          )}
+                          <img src={siteUrl(`/images/vests/${clubById[clubResult.club]?.vest ?? 'unknown-sm.png'}`)} alt="" class="h-6 w-auto shrink-0 object-contain" />
                           <span class="font-semibold text-[14px] truncate">{clubName}</span>
                         </div>
                       </td>
@@ -310,9 +308,7 @@ const raceColWidth = races.length >= 7 ? '3rem'
               return (
                 <MobileAccordionCard detailId={detailId} position={clubResult.position}>
                   <div class="flex items-center gap-2 min-w-0">
-                    {clubById[clubResult.club]?.vest && (
-                      <img src={siteUrl(`/images/vests/${clubById[clubResult.club].vest}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
-                    )}
+                    <img src={siteUrl(`/images/vests/${clubById[clubResult.club]?.vest ?? 'unknown-sm.png'}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
                     <div class="font-head text-[16px] font-bold tracking-[-0.01em] leading-[1.15] truncate">{clubName}</div>
                   </div>
 

--- a/src/data/1985/clubs.json
+++ b/src/data/1985/clubs.json
@@ -1,18 +1,20 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "springfields",
-    "name": "Springfields AC",
-    "shortName": "SPR"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "springfields",
+        "name":  "Springfields AC",
+        "shortName":  "SPR"
+    }
 ]

--- a/src/data/1985/clubs.json
+++ b/src/data/1985/clubs.json
@@ -3,14 +3,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "springfields",

--- a/src/data/1986/clubs.json
+++ b/src/data/1986/clubs.json
@@ -1,18 +1,20 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "springfields",
-    "name": "Springfields AC",
-    "shortName": "SPR"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "springfields",
+        "name":  "Springfields AC",
+        "shortName":  "SPR"
+    }
 ]

--- a/src/data/1986/clubs.json
+++ b/src/data/1986/clubs.json
@@ -3,14 +3,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "springfields",

--- a/src/data/1987/clubs.json
+++ b/src/data/1987/clubs.json
@@ -1,18 +1,20 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "springfields",
-    "name": "Springfields AC",
-    "shortName": "SPR"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "springfields",
+        "name":  "Springfields AC",
+        "shortName":  "SPR"
+    }
 ]

--- a/src/data/1987/clubs.json
+++ b/src/data/1987/clubs.json
@@ -3,14 +3,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "springfields",

--- a/src/data/1988/clubs.json
+++ b/src/data/1988/clubs.json
@@ -1,24 +1,27 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "springfields",
-    "name": "Springfields AC",
-    "shortName": "SPR"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "springfields",
+        "name":  "Springfields AC",
+        "shortName":  "SPR"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/1988/clubs.json
+++ b/src/data/1988/clubs.json
@@ -3,14 +3,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "springfields",
@@ -22,6 +22,6 @@
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/1989/clubs.json
+++ b/src/data/1989/clubs.json
@@ -1,24 +1,27 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "springfields",
-    "name": "Springfields AC",
-    "shortName": "SPR"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "springfields",
+        "name":  "Springfields AC",
+        "shortName":  "SPR"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/1989/clubs.json
+++ b/src/data/1989/clubs.json
@@ -3,14 +3,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "springfields",
@@ -22,6 +22,6 @@
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/1990/clubs.json
+++ b/src/data/1990/clubs.json
@@ -1,24 +1,27 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "springfields",
-    "name": "Springfields AC",
-    "shortName": "SPR"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "springfields",
+        "name":  "Springfields AC",
+        "shortName":  "SPR"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/1990/clubs.json
+++ b/src/data/1990/clubs.json
@@ -3,14 +3,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "springfields",
@@ -22,6 +22,6 @@
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/1991/clubs.json
+++ b/src/data/1991/clubs.json
@@ -1,24 +1,27 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "springfields",
-    "name": "Springfields AC",
-    "shortName": "SPR"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "springfields",
+        "name":  "Springfields AC",
+        "shortName":  "SPR"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/1991/clubs.json
+++ b/src/data/1991/clubs.json
@@ -3,14 +3,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "springfields",
@@ -22,6 +22,6 @@
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/1992/clubs.json
+++ b/src/data/1992/clubs.json
@@ -1,29 +1,32 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "springfields",
-    "name": "Springfields AC",
-    "shortName": "SPR"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "springfields",
+        "name":  "Springfields AC",
+        "shortName":  "SPR"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/1992/clubs.json
+++ b/src/data/1992/clubs.json
@@ -3,7 +3,7 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "north-fylde",
@@ -15,7 +15,7 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "springfields",
@@ -27,6 +27,6 @@
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/1993/clubs.json
+++ b/src/data/1993/clubs.json
@@ -1,35 +1,39 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "springfields",
-    "name": "Springfields AC",
-    "shortName": "SPR"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "springfields",
+        "name":  "Springfields AC",
+        "shortName":  "SPR"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/1993/clubs.json
+++ b/src/data/1993/clubs.json
@@ -3,7 +3,7 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "north-fylde",
@@ -15,14 +15,14 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "springfields",
@@ -34,6 +34,6 @@
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/1994/clubs.json
+++ b/src/data/1994/clubs.json
@@ -1,35 +1,39 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "springfields",
-    "name": "Springfields AC",
-    "shortName": "SPR"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "springfields",
+        "name":  "Springfields AC",
+        "shortName":  "SPR"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/1994/clubs.json
+++ b/src/data/1994/clubs.json
@@ -3,7 +3,7 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "north-fylde",
@@ -15,14 +15,14 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "springfields",
@@ -34,6 +34,6 @@
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/1995/clubs.json
+++ b/src/data/1995/clubs.json
@@ -1,30 +1,34 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/1995/clubs.json
+++ b/src/data/1995/clubs.json
@@ -3,7 +3,7 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "north-fylde",
@@ -15,20 +15,20 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/1996/clubs.json
+++ b/src/data/1996/clubs.json
@@ -1,30 +1,34 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/1996/clubs.json
+++ b/src/data/1996/clubs.json
@@ -3,7 +3,7 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "north-fylde",
@@ -15,20 +15,20 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/1997/clubs.json
+++ b/src/data/1997/clubs.json
@@ -1,30 +1,34 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/1997/clubs.json
+++ b/src/data/1997/clubs.json
@@ -3,7 +3,7 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "north-fylde",
@@ -15,20 +15,20 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/1998/clubs.json
+++ b/src/data/1998/clubs.json
@@ -1,30 +1,34 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/1998/clubs.json
+++ b/src/data/1998/clubs.json
@@ -3,7 +3,7 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "north-fylde",
@@ -15,20 +15,20 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/1999/clubs.json
+++ b/src/data/1999/clubs.json
@@ -1,30 +1,34 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/1999/clubs.json
+++ b/src/data/1999/clubs.json
@@ -3,7 +3,7 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "north-fylde",
@@ -15,20 +15,20 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2000/clubs.json
+++ b/src/data/2000/clubs.json
@@ -3,14 +3,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "north-fylde",
@@ -22,20 +22,20 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2000/clubs.json
+++ b/src/data/2000/clubs.json
@@ -1,36 +1,41 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2001/clubs.json
+++ b/src/data/2001/clubs.json
@@ -3,14 +3,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "north-fylde",
@@ -22,20 +22,20 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2001/clubs.json
+++ b/src/data/2001/clubs.json
@@ -1,36 +1,41 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2002/clubs.json
+++ b/src/data/2002/clubs.json
@@ -3,14 +3,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "north-fylde",
@@ -22,20 +22,20 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2002/clubs.json
+++ b/src/data/2002/clubs.json
@@ -1,36 +1,41 @@
-[
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2003/clubs.json
+++ b/src/data/2003/clubs.json
@@ -1,41 +1,46 @@
-[
-  {
-    "id": "blackpool-fylde",
-    "name": "Blackpool & Fylde AC",
-    "shortName": "BFA"
-  },
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool-fylde",
+        "name":  "Blackpool \u0026 Fylde AC",
+        "shortName":  "BFA"
+    },
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2003/clubs.json
+++ b/src/data/2003/clubs.json
@@ -8,14 +8,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "north-fylde",
@@ -27,20 +27,20 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2004/clubs.json
+++ b/src/data/2004/clubs.json
@@ -1,41 +1,46 @@
-[
-  {
-    "id": "blackpool-fylde",
-    "name": "Blackpool & Fylde AC",
-    "shortName": "BFA"
-  },
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool-fylde",
+        "name":  "Blackpool \u0026 Fylde AC",
+        "shortName":  "BFA"
+    },
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2004/clubs.json
+++ b/src/data/2004/clubs.json
@@ -8,14 +8,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "north-fylde",
@@ -27,20 +27,20 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2005/clubs.json
+++ b/src/data/2005/clubs.json
@@ -8,14 +8,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "north-fylde",
@@ -27,20 +27,20 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2005/clubs.json
+++ b/src/data/2005/clubs.json
@@ -1,41 +1,46 @@
 ﻿[
-  {
-    "id": "blackpool-fylde",
-    "name": "Blackpool & Fylde AC",
-    "shortName": "BFA"
-  },
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+    {
+        "id":  "blackpool-fylde",
+        "name":  "Blackpool \u0026 Fylde AC",
+        "shortName":  "BFA"
+    },
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2006/clubs.json
+++ b/src/data/2006/clubs.json
@@ -1,41 +1,46 @@
-[
-  {
-    "id": "blackpool-fylde",
-    "name": "Blackpool & Fylde AC",
-    "shortName": "BFA"
-  },
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "north-fylde",
-    "name": "North Fylde AC",
-    "shortName": "NFA"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool-fylde",
+        "name":  "Blackpool \u0026 Fylde AC",
+        "shortName":  "BFA"
+    },
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "north-fylde",
+        "name":  "North Fylde AC",
+        "shortName":  "NFA"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2006/clubs.json
+++ b/src/data/2006/clubs.json
@@ -8,14 +8,14 @@
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "north-fylde",
@@ -27,20 +27,20 @@
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2007/clubs.json
+++ b/src/data/2007/clubs.json
@@ -1,37 +1,43 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool, Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool, Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2007/clubs.json
+++ b/src/data/2007/clubs.json
@@ -4,40 +4,40 @@
         "name":  "Blackpool, Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2008/clubs.json
+++ b/src/data/2008/clubs.json
@@ -1,37 +1,43 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool, Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool, Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2008/clubs.json
+++ b/src/data/2008/clubs.json
@@ -4,40 +4,40 @@
         "name":  "Blackpool, Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2009/clubs.json
+++ b/src/data/2009/clubs.json
@@ -1,37 +1,43 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool, Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool, Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2009/clubs.json
+++ b/src/data/2009/clubs.json
@@ -4,40 +4,40 @@
         "name":  "Blackpool, Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2010/clubs.json
+++ b/src/data/2010/clubs.json
@@ -1,37 +1,43 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool, Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool, Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2010/clubs.json
+++ b/src/data/2010/clubs.json
@@ -4,40 +4,40 @@
         "name":  "Blackpool, Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2011/clubs.json
+++ b/src/data/2011/clubs.json
@@ -1,37 +1,43 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool, Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley-ac",
-    "name": "Chorley AC",
-    "shortName": "CAC"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool, Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley-ac",
+        "name":  "Chorley AC",
+        "shortName":  "CAC",
+        "vest":  "chorley-ac-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2011/clubs.json
+++ b/src/data/2011/clubs.json
@@ -4,40 +4,40 @@
         "name":  "Blackpool, Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley-ac",
         "name":  "Chorley AC",
         "shortName":  "CAC",
-        "vest":  "chorley-ac-sm.png"
+        "vest":  "chorley-ac.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2012/clubs.json
+++ b/src/data/2012/clubs.json
@@ -4,41 +4,41 @@
         "name":  "Blackpool Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley",
         "name":  "Chorley A\u0026TC",
         "shortName":  "CAT",
         "logo":  "chorley.svg",
-        "vest":  "chorley-sm.png"
+        "vest":  "chorley.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2012/clubs.json
+++ b/src/data/2012/clubs.json
@@ -1,38 +1,44 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley",
-    "name": "Chorley A&TC",
-    "shortName": "CAT",
-    "logo": "chorley.svg"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley",
+        "name":  "Chorley A\u0026TC",
+        "shortName":  "CAT",
+        "logo":  "chorley.svg",
+        "vest":  "chorley-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2013/clubs.json
+++ b/src/data/2013/clubs.json
@@ -4,41 +4,41 @@
         "name":  "Blackpool Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley",
         "name":  "Chorley A\u0026TC",
         "shortName":  "CAT",
         "logo":  "chorley.svg",
-        "vest":  "chorley-sm.png"
+        "vest":  "chorley.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2013/clubs.json
+++ b/src/data/2013/clubs.json
@@ -1,38 +1,44 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley",
-    "name": "Chorley A&TC",
-    "shortName": "CAT",
-    "logo": "chorley.svg"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley",
+        "name":  "Chorley A\u0026TC",
+        "shortName":  "CAT",
+        "logo":  "chorley.svg",
+        "vest":  "chorley-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2014/clubs.json
+++ b/src/data/2014/clubs.json
@@ -4,41 +4,41 @@
         "name":  "Blackpool Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley",
         "name":  "Chorley A\u0026TC",
         "shortName":  "CAT",
         "logo":  "chorley.svg",
-        "vest":  "chorley-sm.png"
+        "vest":  "chorley.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2014/clubs.json
+++ b/src/data/2014/clubs.json
@@ -1,38 +1,44 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley",
-    "name": "Chorley A&TC",
-    "shortName": "CAT",
-    "logo": "chorley.svg"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley",
+        "name":  "Chorley A\u0026TC",
+        "shortName":  "CAT",
+        "logo":  "chorley.svg",
+        "vest":  "chorley-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2015/clubs.json
+++ b/src/data/2015/clubs.json
@@ -4,48 +4,48 @@
         "name":  "Blackpool Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley",
         "name":  "Chorley A\u0026TC",
         "shortName":  "CAT",
         "logo":  "chorley.svg",
-        "vest":  "chorley-sm.png"
+        "vest":  "chorley.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "thornton",
         "name":  "Thornton Cleveleys RC",
         "shortName":  "TC",
         "logo":  "thornton.svg",
-        "vest":  "thornton-pre-2022-sm.png"
+        "vest":  "thornton-pre-2022.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2015/clubs.json
+++ b/src/data/2015/clubs.json
@@ -1,44 +1,51 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley",
-    "name": "Chorley A&TC",
-    "shortName": "CAT",
-    "logo": "chorley.svg"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "thornton",
-    "name": "Thornton Cleveleys RC",
-    "shortName": "TC",
-    "logo": "thornton.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley",
+        "name":  "Chorley A\u0026TC",
+        "shortName":  "CAT",
+        "logo":  "chorley.svg",
+        "vest":  "chorley-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "thornton",
+        "name":  "Thornton Cleveleys RC",
+        "shortName":  "TC",
+        "logo":  "thornton.svg",
+        "vest":  "thornton-pre-2022-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2016/clubs.json
+++ b/src/data/2016/clubs.json
@@ -4,48 +4,48 @@
         "name":  "Blackpool Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley",
         "name":  "Chorley A\u0026TC",
         "shortName":  "CAT",
         "logo":  "chorley.svg",
-        "vest":  "chorley-sm.png"
+        "vest":  "chorley.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "thornton",
         "name":  "Thornton Cleveleys RC",
         "shortName":  "TC",
         "logo":  "thornton.svg",
-        "vest":  "thornton-pre-2022-sm.png"
+        "vest":  "thornton-pre-2022.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2016/clubs.json
+++ b/src/data/2016/clubs.json
@@ -1,44 +1,51 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley",
-    "name": "Chorley A&TC",
-    "shortName": "CAT",
-    "logo": "chorley.svg"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "thornton",
-    "name": "Thornton Cleveleys RC",
-    "shortName": "TC",
-    "logo": "thornton.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley",
+        "name":  "Chorley A\u0026TC",
+        "shortName":  "CAT",
+        "logo":  "chorley.svg",
+        "vest":  "chorley-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "thornton",
+        "name":  "Thornton Cleveleys RC",
+        "shortName":  "TC",
+        "logo":  "thornton.svg",
+        "vest":  "thornton-pre-2022-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2017/clubs.json
+++ b/src/data/2017/clubs.json
@@ -4,48 +4,48 @@
         "name":  "Blackpool Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley",
         "name":  "Chorley A\u0026TC",
         "shortName":  "CAT",
         "logo":  "chorley.svg",
-        "vest":  "chorley-sm.png"
+        "vest":  "chorley.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "thornton",
         "name":  "Thornton Cleveleys RC",
         "shortName":  "TC",
         "logo":  "thornton.svg",
-        "vest":  "thornton-pre-2022-sm.png"
+        "vest":  "thornton-pre-2022.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2017/clubs.json
+++ b/src/data/2017/clubs.json
@@ -1,44 +1,51 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley",
-    "name": "Chorley A&TC",
-    "shortName": "CAT",
-    "logo": "chorley.svg"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "thornton",
-    "name": "Thornton Cleveleys RC",
-    "shortName": "TC",
-    "logo": "thornton.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley",
+        "name":  "Chorley A\u0026TC",
+        "shortName":  "CAT",
+        "logo":  "chorley.svg",
+        "vest":  "chorley-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "thornton",
+        "name":  "Thornton Cleveleys RC",
+        "shortName":  "TC",
+        "logo":  "thornton.svg",
+        "vest":  "thornton-pre-2022-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2018/clubs.json
+++ b/src/data/2018/clubs.json
@@ -4,48 +4,48 @@
         "name":  "Blackpool Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley",
         "name":  "Chorley A\u0026TC",
         "shortName":  "CAT",
         "logo":  "chorley.svg",
-        "vest":  "chorley-sm.png"
+        "vest":  "chorley.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "thornton",
         "name":  "Thornton Cleveleys RC",
         "shortName":  "TC",
         "logo":  "thornton.svg",
-        "vest":  "thornton-pre-2022-sm.png"
+        "vest":  "thornton-pre-2022.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2018/clubs.json
+++ b/src/data/2018/clubs.json
@@ -1,44 +1,51 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley",
-    "name": "Chorley A&TC",
-    "shortName": "CAT",
-    "logo": "chorley.svg"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "thornton",
-    "name": "Thornton Cleveleys RC",
-    "shortName": "TC",
-    "logo": "thornton.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley",
+        "name":  "Chorley A\u0026TC",
+        "shortName":  "CAT",
+        "logo":  "chorley.svg",
+        "vest":  "chorley-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "thornton",
+        "name":  "Thornton Cleveleys RC",
+        "shortName":  "TC",
+        "logo":  "thornton.svg",
+        "vest":  "thornton-pre-2022-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2019/clubs.json
+++ b/src/data/2019/clubs.json
@@ -4,48 +4,48 @@
         "name":  "Blackpool Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley",
         "name":  "Chorley A\u0026TC",
         "shortName":  "CAT",
         "logo":  "chorley.svg",
-        "vest":  "chorley-sm.png"
+        "vest":  "chorley.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "thornton",
         "name":  "Thornton Cleveleys RC",
         "shortName":  "TC",
         "logo":  "thornton.svg",
-        "vest":  "thornton-pre-2022-sm.png"
+        "vest":  "thornton-pre-2022.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2019/clubs.json
+++ b/src/data/2019/clubs.json
@@ -1,44 +1,51 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley",
-    "name": "Chorley A&TC",
-    "shortName": "CAT",
-    "logo": "chorley.svg"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "thornton",
-    "name": "Thornton Cleveleys RC",
-    "shortName": "TC",
-    "logo": "thornton.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley",
+        "name":  "Chorley A\u0026TC",
+        "shortName":  "CAT",
+        "logo":  "chorley.svg",
+        "vest":  "chorley-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "thornton",
+        "name":  "Thornton Cleveleys RC",
+        "shortName":  "TC",
+        "logo":  "thornton.svg",
+        "vest":  "thornton-pre-2022-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2022/clubs.json
+++ b/src/data/2022/clubs.json
@@ -1,44 +1,51 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley",
-    "name": "Chorley A&TC",
-    "shortName": "CAT",
-    "logo": "chorley.svg"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "thornton",
-    "name": "Thornton Cleveleys RC",
-    "shortName": "TC",
-    "logo": "thornton.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley",
+        "name":  "Chorley A\u0026TC",
+        "shortName":  "CAT",
+        "logo":  "chorley.svg",
+        "vest":  "chorley-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "thornton",
+        "name":  "Thornton Cleveleys RC",
+        "shortName":  "TC",
+        "logo":  "thornton.svg",
+        "vest":  "thornton-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2022/clubs.json
+++ b/src/data/2022/clubs.json
@@ -4,48 +4,48 @@
         "name":  "Blackpool Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley",
         "name":  "Chorley A\u0026TC",
         "shortName":  "CAT",
         "logo":  "chorley.svg",
-        "vest":  "chorley-sm.png"
+        "vest":  "chorley.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "thornton",
         "name":  "Thornton Cleveleys RC",
         "shortName":  "TC",
         "logo":  "thornton.svg",
-        "vest":  "thornton-sm.png"
+        "vest":  "thornton.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2023/clubs.json
+++ b/src/data/2023/clubs.json
@@ -1,44 +1,51 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley",
-    "name": "Chorley A&TC",
-    "shortName": "CAT",
-    "logo": "chorley.svg"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "thornton",
-    "name": "Thornton Cleveleys RC",
-    "shortName": "TC",
-    "logo": "thornton.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley",
+        "name":  "Chorley A\u0026TC",
+        "shortName":  "CAT",
+        "logo":  "chorley.svg",
+        "vest":  "chorley-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "thornton",
+        "name":  "Thornton Cleveleys RC",
+        "shortName":  "TC",
+        "logo":  "thornton.svg",
+        "vest":  "thornton-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2023/clubs.json
+++ b/src/data/2023/clubs.json
@@ -4,48 +4,48 @@
         "name":  "Blackpool Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley",
         "name":  "Chorley A\u0026TC",
         "shortName":  "CAT",
         "logo":  "chorley.svg",
-        "vest":  "chorley-sm.png"
+        "vest":  "chorley.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "thornton",
         "name":  "Thornton Cleveleys RC",
         "shortName":  "TC",
         "logo":  "thornton.svg",
-        "vest":  "thornton-sm.png"
+        "vest":  "thornton.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2024/clubs.json
+++ b/src/data/2024/clubs.json
@@ -1,44 +1,51 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley",
-    "name": "Chorley A&TC",
-    "shortName": "CAT",
-    "logo": "chorley.svg"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "thornton",
-    "name": "Thornton Cleveleys RC",
-    "shortName": "TC",
-    "logo": "thornton.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley",
+        "name":  "Chorley A\u0026TC",
+        "shortName":  "CAT",
+        "logo":  "chorley.svg",
+        "vest":  "chorley-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "thornton",
+        "name":  "Thornton Cleveleys RC",
+        "shortName":  "TC",
+        "logo":  "thornton.svg",
+        "vest":  "thornton-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2024/clubs.json
+++ b/src/data/2024/clubs.json
@@ -4,48 +4,48 @@
         "name":  "Blackpool Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley",
         "name":  "Chorley A\u0026TC",
         "shortName":  "CAT",
         "logo":  "chorley.svg",
-        "vest":  "chorley-sm.png"
+        "vest":  "chorley.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "thornton",
         "name":  "Thornton Cleveleys RC",
         "shortName":  "TC",
         "logo":  "thornton.svg",
-        "vest":  "thornton-sm.png"
+        "vest":  "thornton.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2025/clubs.json
+++ b/src/data/2025/clubs.json
@@ -1,44 +1,51 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley",
-    "name": "Chorley A&TC",
-    "shortName": "CAT",
-    "logo": "chorley.svg"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "thornton",
-    "name": "Thornton Cleveleys RC",
-    "shortName": "TC",
-    "logo": "thornton.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley",
+        "name":  "Chorley A\u0026TC",
+        "shortName":  "CAT",
+        "logo":  "chorley.svg",
+        "vest":  "chorley-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "thornton",
+        "name":  "Thornton Cleveleys RC",
+        "shortName":  "TC",
+        "logo":  "thornton.svg",
+        "vest":  "thornton-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2025/clubs.json
+++ b/src/data/2025/clubs.json
@@ -4,48 +4,48 @@
         "name":  "Blackpool Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley",
         "name":  "Chorley A\u0026TC",
         "shortName":  "CAT",
         "logo":  "chorley.svg",
-        "vest":  "chorley-sm.png"
+        "vest":  "chorley.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "thornton",
         "name":  "Thornton Cleveleys RC",
         "shortName":  "TC",
         "logo":  "thornton.svg",
-        "vest":  "thornton-sm.png"
+        "vest":  "thornton.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/data/2026/clubs.json
+++ b/src/data/2026/clubs.json
@@ -1,44 +1,51 @@
-[
-  {
-    "id": "blackpool",
-    "name": "Blackpool Wyre & Fylde AC",
-    "shortName": "BWF",
-    "logo": "blackpool.svg"
-  },
-  {
-    "id": "chorley",
-    "name": "Chorley A&TC",
-    "shortName": "CAT",
-    "logo": "chorley.svg"
-  },
-  {
-    "id": "lytham",
-    "name": "Lytham St Annes RR",
-    "shortName": "LSA",
-    "logo": "lytham.svg"
-  },
-  {
-    "id": "preston",
-    "name": "Preston Harriers",
-    "shortName": "PH",
-    "logo": "preston.svg"
-  },
-  {
-    "id": "red-rose",
-    "name": "Red Rose RR",
-    "shortName": "RR",
-    "logo": "red-rose.svg"
-  },
-  {
-    "id": "thornton",
-    "name": "Thornton Cleveleys RC",
-    "shortName": "TC",
-    "logo": "thornton.svg"
-  },
-  {
-    "id": "wesham",
-    "name": "Wesham RR",
-    "shortName": "WRR",
-    "logo": "wesham.svg"
-  }
+﻿[
+    {
+        "id":  "blackpool",
+        "name":  "Blackpool Wyre \u0026 Fylde AC",
+        "shortName":  "BWF",
+        "logo":  "blackpool.svg",
+        "vest":  "blackpool-sm.png"
+    },
+    {
+        "id":  "chorley",
+        "name":  "Chorley A\u0026TC",
+        "shortName":  "CAT",
+        "logo":  "chorley.svg",
+        "vest":  "chorley-sm.png"
+    },
+    {
+        "id":  "lytham",
+        "name":  "Lytham St Annes RR",
+        "shortName":  "LSA",
+        "logo":  "lytham.svg",
+        "vest":  "lytham-sm.png"
+    },
+    {
+        "id":  "preston",
+        "name":  "Preston Harriers",
+        "shortName":  "PH",
+        "logo":  "preston.svg",
+        "vest":  "preston-sm.png"
+    },
+    {
+        "id":  "red-rose",
+        "name":  "Red Rose RR",
+        "shortName":  "RR",
+        "logo":  "red-rose.svg",
+        "vest":  "red-rose-sm.png"
+    },
+    {
+        "id":  "thornton",
+        "name":  "Thornton Cleveleys RC",
+        "shortName":  "TC",
+        "logo":  "thornton.svg",
+        "vest":  "thornton-sm.png"
+    },
+    {
+        "id":  "wesham",
+        "name":  "Wesham RR",
+        "shortName":  "WRR",
+        "logo":  "wesham.svg",
+        "vest":  "wesham-sm.png"
+    }
 ]

--- a/src/data/2026/clubs.json
+++ b/src/data/2026/clubs.json
@@ -4,48 +4,48 @@
         "name":  "Blackpool Wyre \u0026 Fylde AC",
         "shortName":  "BWF",
         "logo":  "blackpool.svg",
-        "vest":  "blackpool-sm.png"
+        "vest":  "blackpool.png"
     },
     {
         "id":  "chorley",
         "name":  "Chorley A\u0026TC",
         "shortName":  "CAT",
         "logo":  "chorley.svg",
-        "vest":  "chorley-sm.png"
+        "vest":  "chorley.png"
     },
     {
         "id":  "lytham",
         "name":  "Lytham St Annes RR",
         "shortName":  "LSA",
         "logo":  "lytham.svg",
-        "vest":  "lytham-sm.png"
+        "vest":  "lytham.png"
     },
     {
         "id":  "preston",
         "name":  "Preston Harriers",
         "shortName":  "PH",
         "logo":  "preston.svg",
-        "vest":  "preston-sm.png"
+        "vest":  "preston.png"
     },
     {
         "id":  "red-rose",
         "name":  "Red Rose RR",
         "shortName":  "RR",
         "logo":  "red-rose.svg",
-        "vest":  "red-rose-sm.png"
+        "vest":  "red-rose.png"
     },
     {
         "id":  "thornton",
         "name":  "Thornton Cleveleys RC",
         "shortName":  "TC",
         "logo":  "thornton.svg",
-        "vest":  "thornton-sm.png"
+        "vest":  "thornton.png"
     },
     {
         "id":  "wesham",
         "name":  "Wesham RR",
         "shortName":  "WRR",
         "logo":  "wesham.svg",
-        "vest":  "wesham-sm.png"
+        "vest":  "wesham.png"
     }
 ]

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,6 +49,7 @@ export interface Club {
   name: string;
   shortName: string;
   logo: string;        // filename in /public/images/clubs/, may not exist yet
+  vest?: string;       // filename in /public/images/vests/, e.g. 'blackpool-sm.png'
 }
 
 export interface GlobalRunner {


### PR DESCRIPTION
## Summary

- Adds club vest images alongside runner names on both the individual results and individual standings pages
- Vest images display as a small icon (matching the height of the two-line name/club text block) in a flex row to the left of the runner name, without increasing row height
- All 40 `clubs.json` files updated with vest filenames; Thornton uses a year-aware mapping (`thornton-pre-2022-sm.png` before 2022, `thornton-sm.png` from 2022 onwards); the old `chorley-ac` club id maps to `chorley-ac-sm.png`

## Changes

- `src/lib/types.ts` — Added optional `vest?: string` field to the `Club` interface (filename in `/public/images/vests/`)
- `src/data/{year}/clubs.json` (all years 1985–2026) — Added `vest` field for each club that has a corresponding image
- `src/components/IndividualResultsLayout.astro` — Runner cell restructured to flex row with vest image spanning both name and club lines; SSR template uses `siteUrl()` for correct base-path; client-side `buildRow` function updated to use `import.meta.env.BASE_URL`
- `src/components/IndividualStandingsLayout.astro` — Same layout applied to all three responsive views (mobile accordion cards, tablet table, desktop table)

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Individual results page shows vest image to the left of each runner's name/club, at the correct height
- [ ] Individual standings page shows vest images in all three breakpoints (mobile accordion, tablet table, desktop table)
- [ ] Guest runners show no vest image
- [ ] Thornton vest differs between pre-2022 and 2022+ years
- [ ] Row height is unchanged by the vest images

🤖 Generated with [Claude Code](https://claude.com/claude-code)