### PR TITLE
fix: correct race time display — h:mm:ss format and narrower columns

### DIFF
--- a/src/components/IndividualResultsLayout.astro
+++ b/src/components/IndividualResultsLayout.astro
@@ -337,8 +337,8 @@ const showSexToggle = hasMale && hasFemale;
             <col class="ic-col w-9 sm:hidden" />
             <col class="no-col w-14" />
             <col />
-            <col class="w-12" />
-            <col class="w-24" />
+            <col class="w-10 sm:w-12" />
+            <col class="w-20" />
           </colgroup>
           <thead>
             <tr>

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -13,19 +13,30 @@ export function formatRaceDate(date: string, time?: string): string {
   return time ? `${dateStr} · ${time}` : dateStr;
 }
 
-/** Normalise any stored time to hh:mm:ss (zero-padded). */
+/** Format a stored time as h:mm:ss or m:ss (no leading zeros on the first component). */
 export function formatTime(time: string | null | undefined): string {
   if (!time) return '–';
   const parts = time.trim().split(':');
+  let h = 0, m = 0, s = 0;
   if (parts.length === 2) {
-    const [mm, ss] = parts;
-    return `00:${mm.padStart(2, '0')}:${ss.padStart(2, '0')}`;
+    m = parseInt(parts[0], 10);
+    s = parseInt(parts[1], 10);
+  } else if (parts.length === 3) {
+    h = parseInt(parts[0], 10);
+    m = parseInt(parts[1], 10);
+    s = parseInt(parts[2], 10);
+  } else {
+    return time;
   }
-  if (parts.length === 3) {
-    const [hh, mm, ss] = parts;
-    return `${hh.padStart(2, '0')}:${mm.padStart(2, '0')}:${ss.padStart(2, '0')}`;
+  if (isNaN(h) || isNaN(m) || isNaN(s)) return time;
+  const total = h * 3600 + m * 60 + s;
+  const hh = Math.floor(total / 3600);
+  const mm = Math.floor((total % 3600) / 60);
+  const ss = total % 60;
+  if (hh > 0) {
+    return `${hh}:${mm.toString().padStart(2, '0')}:${ss.toString().padStart(2, '0')}`;
   }
-  return time;
+  return `${mm}:${ss.toString().padStart(2, '0')}`;
 }
 
 export function getSeriesLabel(series: Series): string {

--- a/tests/lib/format.test.ts
+++ b/tests/lib/format.test.ts
@@ -1,5 +1,43 @@
 import { describe, it, expect } from 'vitest';
-import { formatRaceDate, getSeriesLabel, getSeriesLongLabel } from '../../src/lib/format';
+import { formatRaceDate, formatTime, getSeriesLabel, getSeriesLongLabel } from '../../src/lib/format';
+
+describe('formatTime', () => {
+  it('formats a sub-hour mm:ss time', () => {
+    expect(formatTime('25:10')).toBe('25:10');
+  });
+
+  it('formats a single-digit minutes mm:ss time', () => {
+    expect(formatTime('9:30')).toBe('9:30');
+  });
+
+  it('converts mm:ss where minutes >= 60 to h:mm:ss', () => {
+    expect(formatTime('89:40')).toBe('1:29:40');
+  });
+
+  it('formats a stored hh:mm:ss with leading-zero hours to h:mm:ss', () => {
+    expect(formatTime('01:29:40')).toBe('1:29:40');
+  });
+
+  it('formats a stored hh:mm:ss sub-hour to m:ss', () => {
+    expect(formatTime('00:25:10')).toBe('25:10');
+  });
+
+  it('pads minutes and seconds when hours present', () => {
+    expect(formatTime('1:05:03')).toBe('1:05:03');
+  });
+
+  it('returns dash for null', () => {
+    expect(formatTime(null)).toBe('–');
+  });
+
+  it('returns dash for undefined', () => {
+    expect(formatTime(undefined)).toBe('–');
+  });
+
+  it('returns dash for empty string', () => {
+    expect(formatTime('')).toBe('–');
+  });
+});
 
 describe('formatRaceDate', () => {
   it('formats date with time', () => {


### PR DESCRIPTION
## Summary

- **Bug fix:** Times stored as `mm:ss` where minutes ≥ 60 (e.g. `89:40`) were being displayed as `00:89:40`. They now correctly normalise to `1:29:40`.
- **Format change:** All race times now display as `h:mm:ss` (over an hour) or `m:ss` (under an hour) with no leading zero on the first component — e.g. `1:29:40` instead of `01:29:40`, `34:37` instead of `00:34:37`.
- **Column widths:** Time column reduced (`w-24` → `w-20`) to fit the shorter format; category column narrowed on mobile (`w-10 sm:w-12`) to give the runner name more room on xs screens.

## Changes

- `src/lib/format.ts` — rewrote `formatTime` to convert to total seconds then reformat, so mm:ss values with minutes ≥ 60 carry over correctly to hours
- `src/components/IndividualResultsLayout.astro` — updated `<colgroup>` widths for cat and time columns
- `tests/lib/format.test.ts` — added 9 unit tests covering the new behaviour (null/undefined/empty, sub-hour, over-hour, overflow normalisation, zero-padded stored values)

## Test plan

- [ ] `npm test` passes (92 tests)
- [ ] Mearley Clough 2024 results — John Dunn shows `1:29:40` (was `00:89:40`)
- [ ] Sub-hour times show as `m:ss` e.g. `34:37` with no `00:` prefix
- [ ] Mobile (375px) — runner name column has more horizontal space