### PR TITLE
feat: uI improvements: schedule table, club turnout component, and archive page polish

### DIFF
--- a/src/components/ClubTurnout.astro
+++ b/src/components/ClubTurnout.astro
@@ -24,7 +24,7 @@ const maxCount = items.reduce((m, i) => Math.max(m, i.count), 1);
 ---
 
 {variant === 'card' ? (
-  <div class="card p-4">
+  <div>
     <div class="flex items-baseline justify-between mb-3">
       <div class="font-head text-[14px] font-bold tracking-[0.04em] uppercase">Club Turnout</div>
       <span class="font-mono text-[11px] text-muted">{total} runners</span>

--- a/src/components/ClubTurnout.astro
+++ b/src/components/ClubTurnout.astro
@@ -24,7 +24,7 @@ const maxCount = items.reduce((m, i) => Math.max(m, i.count), 1);
 ---
 
 {variant === 'card' ? (
-  <div>
+  <div class="card p-4">
     <div class="flex items-baseline justify-between mb-3">
       <div class="font-head text-[14px] font-bold tracking-[0.04em] uppercase">Club Turnout</div>
       <span class="font-mono text-[11px] text-muted">{total} runners</span>

--- a/src/components/ClubTurnout.astro
+++ b/src/components/ClubTurnout.astro
@@ -1,0 +1,72 @@
+---
+// src/components/ClubTurnout.astro
+export interface ClubTurnoutItem {
+  name: string;
+  count: number;
+  /** CSS color for the bar. Defaults to amber. */
+  color?: string;
+  /** Dims bar and text (e.g. guests). */
+  muted?: boolean;
+}
+
+interface Props {
+  items: ClubTurnoutItem[];
+  total: number;
+  /**
+   * 'card'   — standalone card with border/background (archive sidebar, default)
+   * 'inline' — borderless section matching the results page sidebar style
+   */
+  variant?: 'card' | 'inline';
+}
+
+const { items, total, variant = 'card' } = Astro.props;
+const maxCount = items.reduce((m, i) => Math.max(m, i.count), 1);
+---
+
+{variant === 'card' ? (
+  <div class="card p-4">
+    <div class="flex items-baseline justify-between mb-3">
+      <div class="font-head text-[14px] font-bold tracking-[0.04em] uppercase">Club Turnout</div>
+      <span class="font-mono text-[11px] text-muted">{total} runners</span>
+    </div>
+    <div class="flex flex-col gap-2.5">
+      {items.map(item => (
+        <div>
+          <div class="flex items-baseline justify-between mb-[3px]">
+            <span class:list={['font-head text-[11px] font-bold', item.muted ? 'text-muted/50' : 'text-muted']}>{item.name}</span>
+            <span class:list={['font-mono text-[11px]', item.muted ? 'text-muted/50' : 'text-content']}>{item.count}</span>
+          </div>
+          <div class="h-[4px] bg-canvas rounded-full overflow-hidden">
+            <div
+              class="h-full rounded-full"
+              style={`width: ${(item.count / maxCount * 100).toFixed(1)}%; background: ${item.color ?? 'var(--color-amber)'};${item.muted ? ' opacity: 0.4;' : ''}`}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+) : (
+  <div>
+    <div class="flex items-baseline justify-between mb-2.5 px-1">
+      <p class="font-head text-[10px] font-bold tracking-[0.12em] uppercase text-muted">Club Turnout</p>
+      <span class="font-mono text-[10px] text-muted">{total} total</span>
+    </div>
+    <div class="flex flex-col gap-1.5 pl-1">
+      {items.map(item => (
+        <div>
+          <div class="flex items-baseline justify-between text-[11.5px] mb-[3px]">
+            <span class:list={['truncate overflow-hidden max-w-[130px]', item.muted ? 'text-muted' : 'text-content']}>{item.name}</span>
+            <span class:list={['font-mono text-[11px] font-medium', item.muted ? 'text-muted' : 'text-content']}>{item.count}</span>
+          </div>
+          <div class="h-[3px] rounded-[2px] bg-line overflow-hidden">
+            <div
+              class="h-full rounded-[2px]"
+              style={`width: ${(item.count / maxCount * 100).toFixed(1)}%; background: ${item.color ?? 'var(--color-amber)'};${item.muted ? ' opacity: 0.4;' : ''}`}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+)}

--- a/src/components/HistoryRaceList.astro
+++ b/src/components/HistoryRaceList.astro
@@ -118,7 +118,7 @@ const pastYears = availableYears.filter(y => y !== currentYear);
 
     <!-- Schedule -->
     <div class="mb-6">
-      <ScheduleTable series={series} year={year} races={races} note={note} showCard={false} />
+      <ScheduleTable series={series} year={year} races={races} note={note} />
     </div>
 
     <!-- Team Awards — compact list (mobile) / vest gallery (md+) -->
@@ -128,9 +128,9 @@ const pastYears = availableYears.filter(y => y !== currentYear);
         <!-- Mobile: compact list -->
         <div class="md:hidden">
           <h2 class="font-head text-[15px] font-bold tracking-[0.04em] uppercase mb-2">Team Awards</h2>
-          <div>
+          <div class="bg-surface rounded-xl border border-line px-4">
             {awards.teamAwards.map(ta => (
-              <div class="flex items-center gap-3 py-2 border-b border-line last:border-b-0">
+              <div class="flex items-center gap-3 py-2.5 border-b border-line last:border-b-0">
                 <span class="font-head text-[11px] font-bold tracking-[0.06em] uppercase text-muted w-[80px] shrink-0">
                   {ta.categoryName}
                 </span>
@@ -196,7 +196,7 @@ const pastYears = availableYears.filter(y => y !== currentYear);
         {awards!.overallAwards.length > 0 && (
           <div class="flex flex-col gap-2 mb-3">
             {awards!.overallAwards.map(cat => (
-              <div>
+              <div class="rounded-lg border border-line py-2.5 px-3">
                 <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
                   {cat.categoryName}
                 </p>
@@ -233,7 +233,7 @@ const pastYears = availableYears.filter(y => y !== currentYear);
               <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 {/* Male card or empty placeholder */}
                 {male ? (
-                  <div>
+                  <div class="rounded-lg border border-line py-2.5 px-3">
                     <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
                       {male.categoryName}
                     </p>
@@ -264,7 +264,7 @@ const pastYears = availableYears.filter(y => y !== currentYear);
 
                 {/* Female card or empty placeholder */}
                 {female ? (
-                  <div>
+                  <div class="rounded-lg border border-line py-2.5 px-3">
                     <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
                       {female.categoryName}
                     </p>

--- a/src/components/HistoryRaceList.astro
+++ b/src/components/HistoryRaceList.astro
@@ -160,7 +160,7 @@ const pastYears = availableYears.filter(y => y !== currentYear);
         </div>
 
         <!-- Desktop: vest gallery — each category headlined by its winning club's vest -->
-        <div class="hidden md:block">
+        <div class="hidden md:block bg-surface rounded-xl border border-line p-[22px]">
           <h2 class="font-head text-[15px] font-bold tracking-[0.04em] uppercase mb-3">
             Team Awards
           </h2>

--- a/src/components/HistoryRaceList.astro
+++ b/src/components/HistoryRaceList.astro
@@ -53,6 +53,23 @@ const hasIndividualAwards = awards && (
 );
 const hasMF = awards && (awards.maleAwards.length > 0 || awards.femaleAwards.length > 0);
 
+// Pair male and female award categories by ageCategory for aligned row layout.
+const AGE_ORDER: Record<string, number> = {
+  JUN: 1, SEN: 2,
+  V35: 3, V40: 4, V45: 5, V50: 6, V55: 7,
+  V60: 8, V65: 9, V70: 10, V75: 11, V80: 12, V85: 13, V90: 14,
+};
+const pairedAwardRows = hasMF ? (() => {
+  const keys = [...new Set([
+    ...(awards!.maleAwards.map(c => c.ageCategory ?? '')),
+    ...(awards!.femaleAwards.map(c => c.ageCategory ?? '')),
+  ])].sort((a, b) => (AGE_ORDER[a] ?? 0) - (AGE_ORDER[b] ?? 0));
+  return keys.map(key => ({
+    male:   awards!.maleAwards.find(c => (c.ageCategory ?? '') === key),
+    female: awards!.femaleAwards.find(c => (c.ageCategory ?? '') === key),
+  }));
+})() : [];
+
 
 const sidebarRows = clubs
   .map(c => ({ club: c, count: participantCounts[c.id] ?? 0 }))
@@ -101,7 +118,7 @@ const pastYears = availableYears.filter(y => y !== currentYear);
 
     <!-- Schedule -->
     <div class="mb-6">
-      <ScheduleTable series={series} year={year} races={races} note={note} />
+      <ScheduleTable series={series} year={year} races={races} note={note} showCard={false} />
     </div>
 
     <!-- Team Awards — compact list (mobile) / vest gallery (md+) -->
@@ -110,15 +127,10 @@ const pastYears = availableYears.filter(y => y !== currentYear);
 
         <!-- Mobile: compact list -->
         <div class="md:hidden">
-          <div class="flex items-baseline justify-between mb-2">
-            <h2 class="font-head text-[15px] font-bold tracking-[0.04em] uppercase">Team Awards</h2>
-            <span class="font-mono text-[11px] text-muted">
-              {awards.teamAwards.length} {awards.teamAwards.length === 1 ? 'category' : 'categories'}
-            </span>
-          </div>
-          <div class="bg-surface rounded-xl border border-line px-4">
+          <h2 class="font-head text-[15px] font-bold tracking-[0.04em] uppercase mb-2">Team Awards</h2>
+          <div>
             {awards.teamAwards.map(ta => (
-              <div class="flex items-center gap-3 py-2.5 border-b border-line last:border-b-0">
+              <div class="flex items-center gap-3 py-2 border-b border-line last:border-b-0">
                 <span class="font-head text-[11px] font-bold tracking-[0.06em] uppercase text-muted w-[80px] shrink-0">
                   {ta.categoryName}
                 </span>
@@ -184,13 +196,14 @@ const pastYears = availableYears.filter(y => y !== currentYear);
         {awards!.overallAwards.length > 0 && (
           <div class="flex flex-col gap-2 mb-3">
             {awards!.overallAwards.map(cat => (
-              <div class="bg-surface rounded-xl border border-line p-4">
+              <div>
                 <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
                   {cat.categoryName}
                 </p>
                 <div class="flex flex-col gap-2.5">
                   {cat.awards.map(a => (
                     <div class="flex items-center gap-2.5">
+                      <span class="text-[16px] w-6 shrink-0">{positionLabel(a.position)}</span>
                       {a.vest ? (
                         <img src={siteUrl(`/images/vests/${a.vest.replace('.png', '-sm.png')}`)} alt="" class="h-9 w-[26px] object-contain shrink-0" />
                       ) : (
@@ -206,7 +219,6 @@ const pastYears = availableYears.filter(y => y !== currentYear);
                           {a.clubName}{cat.showAgeCategory && a.ageCategory && ` · ${a.ageCategory}`}
                         </div>
                       </div>
-                      <span class="text-[16px] shrink-0">{positionLabel(a.position)}</span>
                     </div>
                   ))}
                 </div>
@@ -216,69 +228,72 @@ const pastYears = availableYears.filter(y => y !== currentYear);
         )}
 
         {hasMF && (
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            <div class="flex flex-col gap-2">
-              {awards!.maleAwards.map(cat => (
-                <div class="bg-surface rounded-xl border border-line p-4">
-                  <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
-                    {cat.categoryName}
-                  </p>
-                  <div class="flex flex-col gap-2.5">
-                    {cat.awards.map(a => (
-                      <div class="flex items-center gap-2.5">
-                        {a.vest ? (
-                          <img src={siteUrl(`/images/vests/${a.vest.replace('.png', '-sm.png')}`)} alt="" class="h-9 w-[26px] object-contain shrink-0" />
-                        ) : (
-                          <div class="w-[26px] h-9 shrink-0" />
-                        )}
-                        <div class="flex-1 min-w-0">
-                          <div class="font-semibold text-[13px] leading-tight truncate">
-                            {a.runnerUrl
-                              ? <a href={a.runnerUrl} class="link link-hover">{a.name}</a>
-                              : a.name}
-                          </div>
-                          <div class="text-[11px] text-muted mt-0.5 truncate">
-                            {a.clubName}{cat.showAgeCategory && a.ageCategory && ` · ${a.ageCategory}`}
-                          </div>
-                        </div>
-                        <span class="text-[16px] shrink-0">{positionLabel(a.position)}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              ))}
-            </div>
-            <div class="flex flex-col gap-2">
-              {awards!.femaleAwards.map(cat => (
-                <div class="bg-surface rounded-xl border border-line p-4">
-                  <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
-                    {cat.categoryName}
-                  </p>
-                  <div class="flex flex-col gap-2.5">
-                    {cat.awards.map(a => (
-                      <div class="flex items-center gap-2.5">
-                        {a.vest ? (
-                          <img src={siteUrl(`/images/vests/${a.vest.replace('.png', '-sm.png')}`)} alt="" class="h-9 w-[26px] object-contain shrink-0" />
-                        ) : (
-                          <div class="w-[26px] h-9 shrink-0" />
-                        )}
-                        <div class="flex-1 min-w-0">
-                          <div class="font-semibold text-[13px] leading-tight truncate">
-                            {a.runnerUrl
-                              ? <a href={a.runnerUrl} class="link link-hover">{a.name}</a>
-                              : a.name}
-                          </div>
-                          <div class="text-[11px] text-muted mt-0.5 truncate">
-                            {a.clubName}{cat.showAgeCategory && a.ageCategory && ` · ${a.ageCategory}`}
+          <div class="flex flex-col gap-2">
+            {pairedAwardRows.map(({ male, female }) => (
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {/* Male card or empty placeholder */}
+                {male ? (
+                  <div>
+                    <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
+                      {male.categoryName}
+                    </p>
+                    <div class="flex flex-col gap-2.5">
+                      {male.awards.map(a => (
+                        <div class="flex items-center gap-2.5">
+                          <span class="text-[16px] w-6 shrink-0">{positionLabel(a.position)}</span>
+                          {a.vest ? (
+                            <img src={siteUrl(`/images/vests/${a.vest.replace('.png', '-sm.png')}`)} alt="" class="h-9 w-[26px] object-contain shrink-0" />
+                          ) : (
+                            <div class="w-[26px] h-9 shrink-0" />
+                          )}
+                          <div class="flex-1 min-w-0">
+                            <div class="font-semibold text-[13px] leading-tight truncate">
+                              {a.runnerUrl
+                                ? <a href={a.runnerUrl} class="link link-hover">{a.name}</a>
+                                : a.name}
+                            </div>
+                            <div class="text-[11px] text-muted mt-0.5 truncate">
+                              {a.clubName}{male.showAgeCategory && a.ageCategory && ` · ${a.ageCategory}`}
+                            </div>
                           </div>
                         </div>
-                        <span class="text-[16px] shrink-0">{positionLabel(a.position)}</span>
-                      </div>
-                    ))}
+                      ))}
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
+                ) : <div class="hidden sm:block" />}
+
+                {/* Female card or empty placeholder */}
+                {female ? (
+                  <div>
+                    <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
+                      {female.categoryName}
+                    </p>
+                    <div class="flex flex-col gap-2.5">
+                      {female.awards.map(a => (
+                        <div class="flex items-center gap-2.5">
+                          <span class="text-[16px] w-6 shrink-0">{positionLabel(a.position)}</span>
+                          {a.vest ? (
+                            <img src={siteUrl(`/images/vests/${a.vest.replace('.png', '-sm.png')}`)} alt="" class="h-9 w-[26px] object-contain shrink-0" />
+                          ) : (
+                            <div class="w-[26px] h-9 shrink-0" />
+                          )}
+                          <div class="flex-1 min-w-0">
+                            <div class="font-semibold text-[13px] leading-tight truncate">
+                              {a.runnerUrl
+                                ? <a href={a.runnerUrl} class="link link-hover">{a.name}</a>
+                                : a.name}
+                            </div>
+                            <div class="text-[11px] text-muted mt-0.5 truncate">
+                              {a.clubName}{female.showAgeCategory && a.ageCategory && ` · ${a.ageCategory}`}
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ) : <div class="hidden sm:block" />}
+              </div>
+            ))}
           </div>
         )}
       </div>

--- a/src/components/HistoryRaceList.astro
+++ b/src/components/HistoryRaceList.astro
@@ -4,6 +4,8 @@ import type { Club, Race, ResolvedSeriesAwards, Series } from '../lib/types';
 import { siteUrl } from '../lib/url';
 import ArchiveYearNav from './ArchiveYearNav.astro';
 import ScheduleTable from './ScheduleTable.astro';
+import ClubTurnout from './ClubTurnout.astro';
+import { CLUB_COLORS } from '../lib/clubColors';
 
 interface Props {
   races: Race[];
@@ -51,24 +53,12 @@ const hasIndividualAwards = awards && (
 );
 const hasMF = awards && (awards.maleAwards.length > 0 || awards.femaleAwards.length > 0);
 
-// Sidebar: "By the Numbers" — runner participation per club
-// Club colours match vest branding. Chorley uses mid-grey (original near-black
-// renders invisible in dark mode). Wesham darkened slightly for bar contrast.
-const CLUB_COLORS: Record<string, string> = {
-  'blackpool': '#e85d2c',
-  'chorley':   '#6b7280',
-  'lytham':    '#3a8a3a',
-  'preston':   '#1d44a8',
-  'red-rose':  '#c0223e',
-  'thornton':  '#2a7aaa',
-  'wesham':    '#4a8ab0',
-};
+
 const sidebarRows = clubs
   .map(c => ({ club: c, count: participantCounts[c.id] ?? 0 }))
   .filter(r => r.count > 0)
   .sort((a, b) => b.count - a.count);
 const totalRunners = sidebarRows.reduce((n, r) => n + r.count, 0);
-const maxCount = sidebarRows[0]?.count ?? 1;
 const showSidebar = sidebarRows.length > 0;
 
 // Past years for the archive year-nav sidebar
@@ -151,18 +141,7 @@ const pastYears = availableYears.filter(y => y !== currentYear);
 
         <!-- Desktop: vest gallery — each category headlined by its winning club's vest -->
         <div class="hidden md:block">
-          <div class="flex items-center justify-between mb-1.5">
-            <div class="flex items-center gap-3">
-              <span class="font-head text-[11px] font-bold tracking-[0.16em] uppercase text-amber">
-                {year} · {seriesShortLabel}
-              </span>
-              <span class="block h-px w-7 bg-line shrink-0"></span>
-            </div>
-            <span class="font-mono text-[12px] text-muted">
-              {awards.teamAwards.length} team title{awards.teamAwards.length !== 1 ? 's' : ''}
-            </span>
-          </div>
-          <h2 class="font-head text-[32px] font-extrabold tracking-tight leading-none mb-[22px]">
+          <h2 class="font-head text-[15px] font-bold tracking-[0.04em] uppercase mb-3">
             Team Awards
           </h2>
           <div
@@ -178,13 +157,13 @@ const pastYears = availableYears.filter(y => y !== currentYear);
                   <img
                     src={siteUrl(`/images/vests/${ta.vest}`)}
                     alt={ta.clubName}
-                    class="w-[84px] h-[100px] object-contain mt-2 mb-2.5"
+                    class="w-[60px] h-[72px] object-contain mt-3 mb-2"
                     style="filter: drop-shadow(0 6px 12px rgba(0,0,0,0.12))"
                   />
                 ) : (
-                  <div class="w-[84px] h-[100px] mt-2 mb-2.5" />
+                  <div class="w-[60px] h-[72px] mt-3 mb-2" />
                 )}
-                <div class="font-head text-[14px] font-bold tracking-tight leading-snug">
+                <div class="font-head text-[13px] font-bold tracking-tight leading-snug">
                   {ta.clubName}
                 </div>
               </div>
@@ -281,34 +260,16 @@ const pastYears = availableYears.filter(y => y !== currentYear);
       <!-- Year navigation (shared component, matches series detail page) -->
       <ArchiveYearNav series={series} years={pastYears} activeYear={year} />
 
-      <!-- By the Numbers — participation counts for the viewed season -->
+      <!-- Club Turnout — participation counts for the viewed season -->
       {showSidebar && (
-        <div class="card p-4">
-          <div class="font-head text-[14px] font-bold tracking-[0.04em] uppercase mb-3">
-            By the Numbers
-          </div>
-          <div class="flex flex-col gap-2.5">
-            {sidebarRows.map(({ club, count }) => (
-              <div class="flex items-center gap-2.5">
-                <span class="font-head text-[12px] font-bold text-muted w-[38px] shrink-0">
-                  {club.shortName}
-                </span>
-                <div class="flex-1 h-[6px] bg-canvas rounded-full overflow-hidden">
-                  <div
-                    class="h-full rounded-full"
-                    style={`width: ${(count / maxCount * 100).toFixed(1)}%; background: ${CLUB_COLORS[club.id] ?? 'var(--color-amber)'}`}
-                  />
-                </div>
-                <span class="font-mono text-[12px] text-content w-[22px] text-right shrink-0">
-                  {count}
-                </span>
-              </div>
-            ))}
-          </div>
-          <div class="mt-3 pt-3 border-t border-line font-mono text-[11px] text-muted">
-            {totalRunners} runners · {sidebarRows.length} club{sidebarRows.length !== 1 ? 's' : ''}
-          </div>
-        </div>
+        <ClubTurnout
+          items={sidebarRows.map(({ club, count }) => ({
+            name: club.name,
+            count,
+            color: CLUB_COLORS[club.id] ?? 'var(--color-amber)',
+          }))}
+          total={totalRunners}
+        />
       )}
 
     </div>

--- a/src/components/HistoryRaceList.astro
+++ b/src/components/HistoryRaceList.astro
@@ -32,7 +32,7 @@ const {
 } = Astro.props;
 
 function positionLabel(pos: number): string {
-  if (pos === 1) return '🥇';
+  if (pos === 1) return '🏆';
   if (pos === 2) return '🥈';
   if (pos === 3) return '🥉';
   const mod10 = pos % 10;
@@ -185,17 +185,28 @@ const pastYears = availableYears.filter(y => y !== currentYear);
           <div class="flex flex-col gap-2 mb-3">
             {awards!.overallAwards.map(cat => (
               <div class="bg-surface rounded-xl border border-line p-4">
-                <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2">
+                <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
                   {cat.categoryName}
                 </p>
-                <div class="flex flex-col gap-1.5">
+                <div class="flex flex-col gap-2.5">
                   {cat.awards.map(a => (
-                    <div class="flex items-baseline gap-2 text-sm">
-                      <span class="w-7 shrink-0 text-[15px]">{positionLabel(a.position)}</span>
-                      {a.runnerUrl
-                        ? <a href={a.runnerUrl} class="font-medium link link-hover flex-1 min-w-0">{a.name}</a>
-                        : <span class="font-medium flex-1 min-w-0">{a.name}</span>}
-                      <span class="text-muted text-xs shrink-0">{a.clubName}</span>
+                    <div class="flex items-center gap-2.5">
+                      {a.vest ? (
+                        <img src={siteUrl(`/images/vests/${a.vest.replace('.png', '-sm.png')}`)} alt="" class="h-9 w-[26px] object-contain shrink-0" />
+                      ) : (
+                        <div class="w-[26px] h-9 shrink-0" />
+                      )}
+                      <div class="flex-1 min-w-0">
+                        <div class="font-semibold text-[13px] leading-tight truncate">
+                          {a.runnerUrl
+                            ? <a href={a.runnerUrl} class="link link-hover">{a.name}</a>
+                            : a.name}
+                        </div>
+                        <div class="text-[11px] text-muted mt-0.5 truncate">
+                          {a.clubName}{cat.showAgeCategory && a.ageCategory && ` · ${a.ageCategory}`}
+                        </div>
+                      </div>
+                      <span class="text-[16px] shrink-0">{positionLabel(a.position)}</span>
                     </div>
                   ))}
                 </div>
@@ -209,17 +220,28 @@ const pastYears = availableYears.filter(y => y !== currentYear);
             <div class="flex flex-col gap-2">
               {awards!.maleAwards.map(cat => (
                 <div class="bg-surface rounded-xl border border-line p-4">
-                  <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2">
+                  <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
                     {cat.categoryName}
                   </p>
-                  <div class="flex flex-col gap-1.5">
+                  <div class="flex flex-col gap-2.5">
                     {cat.awards.map(a => (
-                      <div class="flex items-baseline gap-2 text-sm">
-                        <span class="w-7 shrink-0 text-[15px]">{positionLabel(a.position)}</span>
-                        {a.runnerUrl
-                          ? <a href={a.runnerUrl} class="font-medium link link-hover flex-1 min-w-0">{a.name}</a>
-                          : <span class="font-medium flex-1 min-w-0">{a.name}</span>}
-                        <span class="text-muted text-xs shrink-0">{a.clubName}</span>
+                      <div class="flex items-center gap-2.5">
+                        {a.vest ? (
+                          <img src={siteUrl(`/images/vests/${a.vest.replace('.png', '-sm.png')}`)} alt="" class="h-9 w-[26px] object-contain shrink-0" />
+                        ) : (
+                          <div class="w-[26px] h-9 shrink-0" />
+                        )}
+                        <div class="flex-1 min-w-0">
+                          <div class="font-semibold text-[13px] leading-tight truncate">
+                            {a.runnerUrl
+                              ? <a href={a.runnerUrl} class="link link-hover">{a.name}</a>
+                              : a.name}
+                          </div>
+                          <div class="text-[11px] text-muted mt-0.5 truncate">
+                            {a.clubName}{cat.showAgeCategory && a.ageCategory && ` · ${a.ageCategory}`}
+                          </div>
+                        </div>
+                        <span class="text-[16px] shrink-0">{positionLabel(a.position)}</span>
                       </div>
                     ))}
                   </div>
@@ -229,17 +251,28 @@ const pastYears = availableYears.filter(y => y !== currentYear);
             <div class="flex flex-col gap-2">
               {awards!.femaleAwards.map(cat => (
                 <div class="bg-surface rounded-xl border border-line p-4">
-                  <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2">
+                  <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
                     {cat.categoryName}
                   </p>
-                  <div class="flex flex-col gap-1.5">
+                  <div class="flex flex-col gap-2.5">
                     {cat.awards.map(a => (
-                      <div class="flex items-baseline gap-2 text-sm">
-                        <span class="w-7 shrink-0 text-[15px]">{positionLabel(a.position)}</span>
-                        {a.runnerUrl
-                          ? <a href={a.runnerUrl} class="font-medium link link-hover flex-1 min-w-0">{a.name}</a>
-                          : <span class="font-medium flex-1 min-w-0">{a.name}</span>}
-                        <span class="text-muted text-xs shrink-0">{a.clubName}</span>
+                      <div class="flex items-center gap-2.5">
+                        {a.vest ? (
+                          <img src={siteUrl(`/images/vests/${a.vest.replace('.png', '-sm.png')}`)} alt="" class="h-9 w-[26px] object-contain shrink-0" />
+                        ) : (
+                          <div class="w-[26px] h-9 shrink-0" />
+                        )}
+                        <div class="flex-1 min-w-0">
+                          <div class="font-semibold text-[13px] leading-tight truncate">
+                            {a.runnerUrl
+                              ? <a href={a.runnerUrl} class="link link-hover">{a.name}</a>
+                              : a.name}
+                          </div>
+                          <div class="text-[11px] text-muted mt-0.5 truncate">
+                            {a.clubName}{cat.showAgeCategory && a.ageCategory && ` · ${a.ageCategory}`}
+                          </div>
+                        </div>
+                        <span class="text-[16px] shrink-0">{positionLabel(a.position)}</span>
                       </div>
                     ))}
                   </div>

--- a/src/components/HistoryRaceList.astro
+++ b/src/components/HistoryRaceList.astro
@@ -31,10 +31,14 @@ const {
   availableYears = [], currentYear,
 } = Astro.props;
 
-function positionLabel(pos: number): string {
-  if (pos === 1) return '🏆';
-  if (pos === 2) return '🥈';
-  if (pos === 3) return '🥉';
+function posBadgeClasses(pos: number): string {
+  if (pos === 1) return 'bg-[#f0c040] text-[#5a3a00]';
+  if (pos === 2) return 'bg-[#c8d0d8] text-[#2a3a4a]';
+  if (pos === 3) return 'bg-[#d4884a] text-[#3a1a00]';
+  return 'bg-line text-muted';
+}
+
+function ordinalLabel(pos: number): string {
   const mod10 = pos % 10;
   const mod100 = pos % 100;
   const suffix =
@@ -45,6 +49,7 @@ function positionLabel(pos: number): string {
 }
 
 const seriesShortLabel = series === 'road-gp' ? 'Road GP' : 'Fell';
+const accentText = series === 'fell' ? 'text-teal' : 'text-amber';
 
 const hasIndividualAwards = awards && (
   awards.overallAwards.length > 0 ||
@@ -52,6 +57,9 @@ const hasIndividualAwards = awards && (
   awards.femaleAwards.length > 0
 );
 const hasMF = awards && (awards.maleAwards.length > 0 || awards.femaleAwards.length > 0);
+
+const maleAwardCount   = awards ? awards.maleAwards.reduce((n, c) => n + c.awards.length, 0) : 0;
+const femaleAwardCount = awards ? awards.femaleAwards.reduce((n, c) => n + c.awards.length, 0) : 0;
 
 // Pair male and female award categories by ageCategory for aligned row layout.
 const AGE_ORDER: Record<string, number> = {
@@ -188,22 +196,26 @@ const pastYears = availableYears.filter(y => y !== currentYear);
 
     <!-- Individual Awards -->
     {hasIndividualAwards && (
-      <div class="mb-4">
-        <h2 class="font-head text-[15px] font-bold tracking-[0.04em] uppercase mb-3">
-          Individual Awards
-        </h2>
+      <div class="bg-surface rounded-xl border border-line p-[22px] mb-6">
+        <div class="flex items-baseline justify-between mb-4">
+          <h2 class="font-head text-[15px] font-bold tracking-[0.04em] uppercase">Individual Awards</h2>
+        </div>
 
+        {/* Overall (non-sex) awards */}
         {awards!.overallAwards.length > 0 && (
-          <div class="flex flex-col gap-2 mb-3">
+          <div class="flex flex-col gap-2 mb-5">
             {awards!.overallAwards.map(cat => (
-              <div class="rounded-lg border border-line py-2.5 px-3">
-                <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
-                  {cat.categoryName}
-                </p>
-                <div class="flex flex-col gap-2.5">
+              <div class:list={['rounded-lg border py-2.5 px-3', !cat.ageCategory ? 'bg-canvas border-l-2 border-l-amber border-line' : 'border-line']}>
+                <div class="flex items-baseline justify-between mb-2">
+                  <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase">{cat.categoryName}</p>
+                  <span class="font-mono text-[11px] text-muted shrink-0">{cat.awards.length} award{cat.awards.length !== 1 ? 's' : ''}</span>
+                </div>
+                <div class="flex flex-col gap-2">
                   {cat.awards.map(a => (
-                    <div class="flex items-center gap-2.5">
-                      <span class="text-[16px] w-6 shrink-0">{positionLabel(a.position)}</span>
+                    <div class="flex items-center gap-2">
+                      <span class:list={['inline-flex items-center justify-center w-[22px] h-[22px] rounded-full text-[11px] font-bold font-mono shrink-0', posBadgeClasses(a.position)]}>
+                        {a.position <= 3 ? a.position : ordinalLabel(a.position)}
+                      </span>
                       {a.vest ? (
                         <img src={siteUrl(`/images/vests/${a.vest.replace('.png', '-sm.png')}`)} alt="" class="h-9 w-[26px] object-contain shrink-0" />
                       ) : (
@@ -211,9 +223,7 @@ const pastYears = availableYears.filter(y => y !== currentYear);
                       )}
                       <div class="flex-1 min-w-0">
                         <div class="font-semibold text-[13px] leading-tight truncate">
-                          {a.runnerUrl
-                            ? <a href={a.runnerUrl} class="link link-hover">{a.name}</a>
-                            : a.name}
+                          {a.runnerUrl ? <a href={a.runnerUrl} class="link link-hover">{a.name}</a> : a.name}
                         </div>
                         <div class="text-[11px] text-muted mt-0.5 truncate">
                           {a.clubName}{cat.showAgeCategory && a.ageCategory && ` · ${a.ageCategory}`}
@@ -227,73 +237,94 @@ const pastYears = availableYears.filter(y => y !== currentYear);
           </div>
         )}
 
+        {/* Male / Female two-column layout */}
         {hasMF && (
-          <div class="flex flex-col gap-2">
-            {pairedAwardRows.map(({ male, female }) => (
-              <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                {/* Male card or empty placeholder */}
-                {male ? (
-                  <div class="rounded-lg border border-line py-2.5 px-3">
-                    <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
-                      {male.categoryName}
-                    </p>
-                    <div class="flex flex-col gap-2.5">
-                      {male.awards.map(a => (
-                        <div class="flex items-center gap-2.5">
-                          <span class="text-[16px] w-6 shrink-0">{positionLabel(a.position)}</span>
-                          {a.vest ? (
-                            <img src={siteUrl(`/images/vests/${a.vest.replace('.png', '-sm.png')}`)} alt="" class="h-9 w-[26px] object-contain shrink-0" />
-                          ) : (
-                            <div class="w-[26px] h-9 shrink-0" />
-                          )}
-                          <div class="flex-1 min-w-0">
-                            <div class="font-semibold text-[13px] leading-tight truncate">
-                              {a.runnerUrl
-                                ? <a href={a.runnerUrl} class="link link-hover">{a.name}</a>
-                                : a.name}
-                            </div>
-                            <div class="text-[11px] text-muted mt-0.5 truncate">
-                              {a.clubName}{male.showAgeCategory && a.ageCategory && ` · ${a.ageCategory}`}
-                            </div>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                ) : <div class="hidden sm:block" />}
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
 
-                {/* Female card or empty placeholder */}
-                {female ? (
-                  <div class="rounded-lg border border-line py-2.5 px-3">
-                    <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase text-muted mb-2.5">
-                      {female.categoryName}
-                    </p>
-                    <div class="flex flex-col gap-2.5">
-                      {female.awards.map(a => (
-                        <div class="flex items-center gap-2.5">
-                          <span class="text-[16px] w-6 shrink-0">{positionLabel(a.position)}</span>
-                          {a.vest ? (
-                            <img src={siteUrl(`/images/vests/${a.vest.replace('.png', '-sm.png')}`)} alt="" class="h-9 w-[26px] object-contain shrink-0" />
-                          ) : (
-                            <div class="w-[26px] h-9 shrink-0" />
-                          )}
-                          <div class="flex-1 min-w-0">
-                            <div class="font-semibold text-[13px] leading-tight truncate">
-                              {a.runnerUrl
-                                ? <a href={a.runnerUrl} class="link link-hover">{a.name}</a>
-                                : a.name}
-                            </div>
-                            <div class="text-[11px] text-muted mt-0.5 truncate">
-                              {a.clubName}{female.showAgeCategory && a.ageCategory && ` · ${a.ageCategory}`}
+            {/* Male column */}
+            {awards!.maleAwards.length > 0 && (
+              <div>
+                <div class:list={['flex items-baseline justify-between pb-2 mb-3 border-b-2', accentText === 'text-teal' ? 'border-teal' : 'border-amber']}>
+                  <h3 class="font-head text-[16px] font-extrabold tracking-tight">Male</h3>
+                  <span class="font-mono text-[11px] text-muted">{maleAwardCount} award{maleAwardCount !== 1 ? 's' : ''} · {awards!.maleAwards.length} categories</span>
+                </div>
+                <div class="flex flex-col gap-2">
+                  {awards!.maleAwards.map(cat => (
+                    <div class:list={['rounded-lg border py-2.5 px-3', !cat.ageCategory ? 'bg-canvas border-l-2 border-l-amber border-line' : 'border-line']}>
+                      <div class="flex items-baseline justify-between mb-2">
+                        <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase">{cat.categoryName}</p>
+                        <span class="font-mono text-[11px] text-muted shrink-0">{cat.awards.length} award{cat.awards.length !== 1 ? 's' : ''}</span>
+                      </div>
+                      <div class="flex flex-col gap-2">
+                        {cat.awards.map(a => (
+                          <div class="flex items-center gap-2">
+                            <span class:list={['inline-flex items-center justify-center w-[22px] h-[22px] rounded-full text-[11px] font-bold font-mono shrink-0', posBadgeClasses(a.position)]}>
+                              {a.position <= 3 ? a.position : ordinalLabel(a.position)}
+                            </span>
+                            {a.vest ? (
+                              <img src={siteUrl(`/images/vests/${a.vest.replace('.png', '-sm.png')}`)} alt="" class="h-9 w-[26px] object-contain shrink-0" />
+                            ) : (
+                              <div class="w-[26px] h-9 shrink-0" />
+                            )}
+                            <div class="flex-1 min-w-0">
+                              <div class="font-semibold text-[13px] leading-tight truncate">
+                                {a.runnerUrl ? <a href={a.runnerUrl} class="link link-hover">{a.name}</a> : a.name}
+                              </div>
+                              <div class="text-[11px] text-muted mt-0.5 truncate">
+                                {a.clubName}{cat.showAgeCategory && a.ageCategory && ` · ${a.ageCategory}`}
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      ))}
+                        ))}
+                      </div>
                     </div>
-                  </div>
-                ) : <div class="hidden sm:block" />}
+                  ))}
+                </div>
               </div>
-            ))}
+            )}
+
+            {/* Female column */}
+            {awards!.femaleAwards.length > 0 && (
+              <div>
+                <div class:list={['flex items-baseline justify-between pb-2 mb-3 border-b-2', accentText === 'text-teal' ? 'border-teal' : 'border-amber']}>
+                  <h3 class="font-head text-[16px] font-extrabold tracking-tight">Female</h3>
+                  <span class="font-mono text-[11px] text-muted">{femaleAwardCount} award{femaleAwardCount !== 1 ? 's' : ''} · {awards!.femaleAwards.length} categories</span>
+                </div>
+                <div class="flex flex-col gap-2">
+                  {awards!.femaleAwards.map(cat => (
+                    <div class:list={['rounded-lg border py-2.5 px-3', !cat.ageCategory ? 'bg-canvas border-l-2 border-l-amber border-line' : 'border-line']}>
+                      <div class="flex items-baseline justify-between mb-2">
+                        <p class="font-head text-[11px] font-bold tracking-[0.04em] uppercase">{cat.categoryName}</p>
+                        <span class="font-mono text-[11px] text-muted shrink-0">{cat.awards.length} award{cat.awards.length !== 1 ? 's' : ''}</span>
+                      </div>
+                      <div class="flex flex-col gap-2">
+                        {cat.awards.map(a => (
+                          <div class="flex items-center gap-2">
+                            <span class:list={['inline-flex items-center justify-center w-[22px] h-[22px] rounded-full text-[11px] font-bold font-mono shrink-0', posBadgeClasses(a.position)]}>
+                              {a.position <= 3 ? a.position : ordinalLabel(a.position)}
+                            </span>
+                            {a.vest ? (
+                              <img src={siteUrl(`/images/vests/${a.vest.replace('.png', '-sm.png')}`)} alt="" class="h-9 w-[26px] object-contain shrink-0" />
+                            ) : (
+                              <div class="w-[26px] h-9 shrink-0" />
+                            )}
+                            <div class="flex-1 min-w-0">
+                              <div class="font-semibold text-[13px] leading-tight truncate">
+                                {a.runnerUrl ? <a href={a.runnerUrl} class="link link-hover">{a.name}</a> : a.name}
+                              </div>
+                              <div class="text-[11px] text-muted mt-0.5 truncate">
+                                {a.clubName}{cat.showAgeCategory && a.ageCategory && ` · ${a.ageCategory}`}
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
           </div>
         )}
       </div>

--- a/src/components/IndividualResultsLayout.astro
+++ b/src/components/IndividualResultsLayout.astro
@@ -3,6 +3,8 @@
 import Layout from './Layout.astro';
 import ChipBar from './ChipBar.astro';
 import PageHeader from './PageHeader.astro';
+import ClubTurnout from './ClubTurnout.astro';
+import { CLUB_COLORS } from '../lib/clubColors';
 import { getRace, getRaces } from '../lib/data';
 import { hasTeamResults } from '../lib/results';
 import { siteUrl } from '../lib/url';
@@ -79,7 +81,6 @@ const clubTurnout = [...clubCountMap.entries()]
     isGuest: id === 'Guest',
   }))
   .sort((a, b) => b.count - a.count);
-const maxClubCount = clubTurnout.reduce((m, c) => Math.max(m, c.count), 1);
 
 const raceMeta = [
   race?.date ? formatRaceDate(race.date, race?.time) : null,
@@ -254,26 +255,16 @@ const showSexToggle = hasMale && hasFemale;
 
       {clubTurnout.length > 0 && (
         <div class="mt-6 pt-5 border-t border-line">
-          <div class="flex items-baseline justify-between mb-2.5 px-1">
-            <p class="font-head text-[10px] font-bold tracking-[0.12em] uppercase text-muted">Club Turnout</p>
-            <span class="font-mono text-[10px] text-muted">{finisherCount} total</span>
-          </div>
-          <div class="flex flex-col gap-1.5 pl-1">
-            {clubTurnout.map(({ displayName, count, isGuest }) => (
-              <div>
-                <div class="flex items-baseline justify-between text-[11.5px] mb-[3px]">
-                  <span class:list={['truncate overflow-hidden max-w-[130px]', isGuest ? 'text-muted' : 'text-content']}>{displayName}</span>
-                  <span class:list={['font-mono text-[11px] font-medium', isGuest ? 'text-muted' : 'text-content']}>{count}</span>
-                </div>
-                <div class="h-[3px] rounded-[2px] bg-line overflow-hidden">
-                  <div
-                    class:list={['h-full rounded-[2px]', isGuest ? 'bg-muted opacity-40' : 'bg-amber']}
-                    style={`width:${Math.round((count / maxClubCount) * 100)}%`}
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
+          <ClubTurnout
+            variant="inline"
+            items={clubTurnout.map(({ id, displayName, count, isGuest }) => ({
+              name: displayName,
+              count,
+              color: isGuest ? undefined : CLUB_COLORS[id],
+              muted: isGuest,
+            }))}
+            total={finisherCount}
+          />
         </div>
       )}
 

--- a/src/components/IndividualStandingsLayout.astro
+++ b/src/components/IndividualStandingsLayout.astro
@@ -23,6 +23,8 @@ import { resolveIndividualCategoryName } from '../lib/results';
 import type { Club, IndividualStandings, Series } from '../lib/types';
 import { siteUrl } from '../lib/url';
 import { getSeriesLabel, getSeriesLongLabel } from '../lib/format';
+import ClubTurnout from './ClubTurnout.astro';
+import { CLUB_COLORS } from '../lib/clubColors';
 
 export interface Props {
   series: Series;
@@ -101,6 +103,28 @@ const standingsClubs = standingsClubIds
   .map(id => clubById[id])
   .filter((c): c is (typeof clubById)[string] => c != null)
   .sort((a, b) => a.name.localeCompare(b.name));
+
+// Club Turnout — unique runner count per club across all categories
+const seenRunners = new Set<string>();
+const clubCountMap = new Map<string, number>();
+for (const cat of standings.categories) {
+  for (const runner of cat.runners) {
+    if (runner.club === 'Guest') continue;
+    const key = runner.seriesRunnerId != null ? `id:${runner.seriesRunnerId}` : `name:${runner.name}:${runner.club}`;
+    if (!seenRunners.has(key)) {
+      seenRunners.add(key);
+      clubCountMap.set(runner.club, (clubCountMap.get(runner.club) ?? 0) + 1);
+    }
+  }
+}
+const clubTurnoutItems = [...clubCountMap.entries()]
+  .sort((a, b) => b[1] - a[1])
+  .map(([id, count]) => ({
+    name: clubById[id]?.name ?? id,
+    count,
+    color: CLUB_COLORS[id],
+  }));
+const standingsTotalRunners = seenRunners.size;
 
 // Shared table header classes
 const th  = 'font-head text-[10px] font-bold tracking-[0.1em] uppercase text-muted py-2.5 px-2 bg-surface border-b-2 border-content';
@@ -230,6 +254,17 @@ const raceColWidth = standings.races.length >= 7 ? '3rem'
           })}
         </div>
       </div>
+
+      <!-- Club Turnout -->
+      {clubTurnoutItems.length > 0 && (
+        <div class="mt-5 pt-5 border-t border-line">
+          <ClubTurnout
+            variant="inline"
+            items={clubTurnoutItems}
+            total={standingsTotalRunners}
+          />
+        </div>
+      )}
     </aside>
 
     <!-- ── Main content column ───────────────────────────────────────────────── -->

--- a/src/components/ScheduleTable.astro
+++ b/src/components/ScheduleTable.astro
@@ -19,11 +19,13 @@ interface Props {
   races: Race[];
   /** Highlight the next upcoming race and dim completed ones. Default: false. */
   showNextRace?: boolean;
+  /** Wrap the table in a card with border/background. Default: true. */
+  showCard?: boolean;
   /** Optional note displayed below the card (e.g. suspended-season text). */
   note?: string;
 }
 
-const { series, year, races, showNextRace = false, note } = Astro.props;
+const { series, year, races, showNextRace = false, showCard = true, note } = Astro.props;
 
 const accentBg    = series === 'fell' ? 'bg-teal-bg'  : 'bg-amber-bg';
 const accentText  = series === 'fell' ? 'text-teal'   : 'text-amber';
@@ -47,8 +49,8 @@ const scriptRaceData = showNextRace ? raceStates.map(({ race, past }) => ({
 })) : [];
 ---
 
-<div class="card overflow-hidden">
-  <div class="flex items-baseline justify-between px-4 py-3.5 border-b border-line">
+<div class:list={[showCard && 'card overflow-hidden']}>
+  <div class:list={['flex items-baseline justify-between py-3.5 border-b border-line', showCard ? 'px-4' : 'px-0']}>
     <span class="font-head text-[14px] font-bold tracking-[0.05em] uppercase">Schedule</span>
   </div>
   <table class="table table-fixed">

--- a/src/components/ScheduleTable.astro
+++ b/src/components/ScheduleTable.astro
@@ -5,6 +5,9 @@
 // and HistoryRaceList (archive pages). The only behavioural difference
 // is showNextRace: the current-season page highlights the upcoming race
 // and dims completed ones; the archive page treats all rows equally.
+//
+// When showNextRace is true, a client-side script re-evaluates the "Next"
+// highlight against the real current date so stale builds stay correct.
 import { hasResults, isResultsProvisional } from '../lib/results';
 import { siteUrl } from '../lib/url';
 import { formatRaceDate } from '../lib/format';
@@ -22,6 +25,10 @@ interface Props {
 
 const { series, year, races, showNextRace = false, note } = Astro.props;
 
+const accentBg    = series === 'fell' ? 'bg-teal-bg'  : 'bg-amber-bg';
+const accentText  = series === 'fell' ? 'text-teal'   : 'text-amber';
+const accentBadge = series === 'fell' ? 'bg-teal'     : 'bg-amber';
+
 let nextFound = false;
 const raceStates = races.map(race => {
   const past = hasResults(year, series, race.id);
@@ -31,50 +38,59 @@ const raceStates = races.map(race => {
   return { race, past, provisional, isNext };
 });
 
-const pastCount = raceStates.filter(s => s.past).length;
+// Data passed to the client-side update script (only needed when showNextRace).
+const scriptRaceData = showNextRace ? raceStates.map(({ race, past }) => ({
+  id: race.id,
+  date: race.date,
+  hasResults: past,
+  resultsUrl: siteUrl(`/${series}/${year}/${race.id}/results`),
+})) : [];
 ---
 
 <div class="card overflow-hidden">
   <div class="flex items-baseline justify-between px-4 py-3.5 border-b border-line">
     <span class="font-head text-[14px] font-bold tracking-[0.05em] uppercase">Schedule</span>
-    <span class="font-mono text-[11px] text-muted">{pastCount} of {races.length} run</span>
   </div>
   <table class="table table-fixed">
     <thead>
       <tr>
         <th class="hidden sm:table-cell py-3 px-3 w-10 text-center">#</th>
-        <th class="py-3 pl-4 sm:pl-3 pr-3 w-[76px]">Date</th>
+        <th class="py-3 pl-4 sm:pl-3 pr-3 w-[100px]">Date</th>
         <th class="py-3 px-3">Race</th>
         <th class="py-3 pl-3 pr-4 w-[90px] !text-right">Results</th>
       </tr>
     </thead>
     <tbody>
       {raceStates.map(({ race, past, provisional, isNext }, i) => (
-        <tr class:list={[
-          'border-b border-line last:border-0',
-          isNext && 'bg-amber-bg',
-          past && showNextRace && 'opacity-70',
-        ]}>
+        <tr
+          data-schedule-row
+          data-race-id={race.id}
+          class:list={[
+            'border-b border-line last:border-0',
+            isNext && accentBg,
+            past && showNextRace && 'opacity-70',
+          ]}
+        >
           <td class="hidden sm:table-cell py-3 px-3 text-center font-mono text-xs text-muted">{i + 1}</td>
           <td class="py-3 pl-4 sm:pl-3 pr-3 whitespace-nowrap">
-            <div class="font-mono text-[12px]">{formatRaceDate(race.date)}</div>
+            <div data-date class:list={['font-mono text-[12px]', isNext ? `${accentText} font-semibold` : 'text-muted']}>{formatRaceDate(race.date)}</div>
             {showNextRace && race.time && (
-              <div class="font-mono text-[11px] text-muted">{race.time}</div>
+              <div data-time class:list={['font-mono text-[11px]', isNext ? (series === 'fell' ? 'text-teal/70' : 'text-amber/70') : 'text-muted/70']}>{race.time}</div>
             )}
           </td>
           <td class="py-3 px-3 min-w-0">
-            <div class:list={['text-[14px]', isNext ? 'font-semibold' : 'font-medium']}>{race.name}</div>
+            <div data-name class:list={['text-[14px]', isNext ? 'font-semibold' : 'font-medium']}>{race.name}</div>
             {race.location && (
               <div class="text-[11px] text-muted mt-0.5 truncate">{race.location}</div>
             )}
           </td>
           <td class="py-3 pl-3 pr-4 !text-right whitespace-nowrap">
             {isNext ? (
-              <span class="font-head text-[10px] font-bold tracking-[0.08em] uppercase text-white bg-amber px-2 py-0.5 rounded">Next</span>
+              <span data-badge class:list={['font-head text-[10px] font-bold tracking-[0.08em] uppercase text-white px-2 py-0.5 rounded', accentBadge]}>Next</span>
             ) : past ? (
-              <a href={siteUrl(`/${series}/${year}/${race.id}/results`)} class="font-head text-[10px] font-bold tracking-[0.08em] uppercase text-amber no-underline hover:underline whitespace-nowrap">Results →</a>
+              <a data-badge href={siteUrl(`/${series}/${year}/${race.id}/results`)} class:list={['font-head text-[10px] font-bold tracking-[0.08em] uppercase no-underline hover:underline whitespace-nowrap', accentText]}>Results →</a>
             ) : (
-              <span class="text-[13px] text-muted/50">→</span>
+              <span data-badge class="text-[13px] text-muted/50">→</span>
             )}
           </td>
         </tr>
@@ -84,3 +100,80 @@ const pastCount = raceStates.filter(s => s.past).length;
 </div>
 
 {note && <p class="text-muted text-sm italic mt-2">{note}</p>}
+
+{showNextRace && (
+  <script define:vars={{ scriptRaceData, series }} is:inline>
+  (function () {
+    var RESULTS_WINDOW_DAYS = 5;
+
+    function toDate(s) {
+      var p = s.split('-').map(Number);
+      return new Date(p[0], p[1] - 1, p[2]);
+    }
+
+    function todayMidnight() {
+      var t = new Date();
+      t.setHours(0, 0, 0, 0);
+      return t;
+    }
+
+    function daysAfterRace(dateStr) {
+      return Math.round((todayMidnight() - toDate(dateStr)) / 86400000);
+    }
+
+    function showInNextSlot(race) {
+      return daysAfterRace(race.date) <= RESULTS_WINDOW_DAYS;
+    }
+
+    var nextRace = scriptRaceData.find(function (r) { return showInNextSlot(r); }) || null;
+
+    var accentBg    = series === 'fell' ? 'bg-teal-bg'   : 'bg-amber-bg';
+    var accentText  = series === 'fell' ? 'text-teal'    : 'text-amber';
+    var accentTime  = series === 'fell' ? 'text-teal/70' : 'text-amber/70';
+    var accentBadge = series === 'fell' ? 'bg-teal'      : 'bg-amber';
+
+    var rows = document.querySelectorAll('[data-schedule-row]');
+    rows.forEach(function (row) {
+      var raceId = row.dataset.raceId;
+      var race   = scriptRaceData.find(function (r) { return r.id === raceId; });
+      if (!race) return;
+
+      var isNext    = !!(nextRace && raceId === nextRace.id);
+      var trulyPast = !showInNextSlot(race);
+
+      row.classList.toggle(accentBg, isNext);
+      row.classList.toggle('opacity-70', trulyPast);
+
+      var dateEl = row.querySelector('[data-date]');
+      if (dateEl) {
+        dateEl.className = 'font-mono text-[12px] ' + (isNext ? accentText + ' font-semibold' : 'text-muted');
+      }
+
+      var timeEl = row.querySelector('[data-time]');
+      if (timeEl) {
+        timeEl.className = 'font-mono text-[11px] ' + (isNext ? accentTime : 'text-muted/70');
+      }
+
+      var nameEl = row.querySelector('[data-name]');
+      if (nameEl) {
+        nameEl.className = 'text-[14px] ' + (isNext ? 'font-semibold' : 'font-medium');
+      }
+
+      var badgeEl = row.querySelector('[data-badge]');
+      if (badgeEl) {
+        var newBadge;
+        if (isNext) {
+          newBadge = '<span data-badge class="font-head text-[10px] font-bold tracking-[0.08em] uppercase text-white px-2 py-0.5 rounded ' + accentBadge + '">Next</span>';
+        } else if (trulyPast && race.hasResults) {
+          newBadge = '<a data-badge href="' + race.resultsUrl + '" class="font-head text-[10px] font-bold tracking-[0.08em] uppercase no-underline hover:underline whitespace-nowrap ' + accentText + '">Results →</a>';
+        } else if (!trulyPast) {
+          newBadge = '<span data-badge class="text-[13px] text-muted/50">→</span>';
+        } else {
+          newBadge = '<span data-badge></span>';
+        }
+        badgeEl.outerHTML = newBadge;
+      }
+    });
+  })();
+  </script>
+)}

--- a/src/lib/clubColors.ts
+++ b/src/lib/clubColors.ts
@@ -1,0 +1,9 @@
+export const CLUB_COLORS: Record<string, string> = {
+  'blackpool': '#e85d2c',
+  'chorley':   '#6b7280',
+  'lytham':    '#3a8a3a',
+  'preston':   '#1d44a8',
+  'red-rose':  '#c0223e',
+  'thornton':  '#cc1122',
+  'wesham':    '#4a8ab0',
+};

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -43,7 +43,7 @@ export function resolveIndividualCategoryName(
 ): string {
   if (name) return name;
   if (!sex) return id;
-  const sexLabel = sex === 'M' ? 'Men' : 'Women';
+  const sexLabel = sex === 'M' ? 'Male' : 'Female';
   if (!ageCategory) return sexLabel;
   const ageLabel =
     ageCategory === 'SEN' ? 'Senior' :

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -240,11 +240,15 @@ export interface ResolvedIndividualAwardEntry {
   position: number;
   name: string;
   clubName: string;
+  vest?: string;        // club vest filename e.g. "blackpool.png"
+  ageCategory?: string; // runner's age category (e.g. "V40"); set when relevant to display
   runnerUrl?: string;   // resolved profile URL when seriesRunnerId is present
 }
 
 export interface ResolvedIndividualAward {
   categoryName: string;
+  /** True when the category itself has no age filter — show each runner's age category. */
+  showAgeCategory: boolean;
   awards: ResolvedIndividualAwardEntry[];
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -247,6 +247,8 @@ export interface ResolvedIndividualAwardEntry {
 
 export interface ResolvedIndividualAward {
   categoryName: string;
+  /** Age category key used for pairing male/female rows (e.g. "SEN", "V40"). Absent for overall/no-age categories. */
+  ageCategory?: string;
   /** True when the category itself has no age filter — show each runner's age category. */
   showAgeCategory: boolean;
   awards: ResolvedIndividualAwardEntry[];

--- a/src/pages/fell/[year]/index.astro
+++ b/src/pages/fell/[year]/index.astro
@@ -47,6 +47,7 @@ if (hasAwards(year, 'fell')) {
     sex: ia.sex,
     resolved: {
       categoryName: resolveIndividualCategoryName(ia.id, ia.sex, ia.ageCategory, ia.name),
+      ageCategory: ia.ageCategory,
       showAgeCategory: !ia.ageCategory,
       awards: ia.awards.map(a => ({
         position: a.position,

--- a/src/pages/fell/[year]/index.astro
+++ b/src/pages/fell/[year]/index.astro
@@ -47,10 +47,13 @@ if (hasAwards(year, 'fell')) {
     sex: ia.sex,
     resolved: {
       categoryName: resolveIndividualCategoryName(ia.id, ia.sex, ia.ageCategory, ia.name),
+      showAgeCategory: !ia.ageCategory,
       awards: ia.awards.map(a => ({
         position: a.position,
         name: a.name,
         clubName: resolveClub(a.club),
+        vest: resolveVest(a.club),
+        ageCategory: a.ageCategory,
         runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
       })),
     },

--- a/src/pages/road-gp/[year]/index.astro
+++ b/src/pages/road-gp/[year]/index.astro
@@ -47,6 +47,7 @@ if (hasAwards(year, 'road-gp')) {
     sex: ia.sex,
     resolved: {
       categoryName: resolveIndividualCategoryName(ia.id, ia.sex, ia.ageCategory, ia.name),
+      ageCategory: ia.ageCategory,
       showAgeCategory: !ia.ageCategory,
       awards: ia.awards.map(a => ({
         position: a.position,

--- a/src/pages/road-gp/[year]/index.astro
+++ b/src/pages/road-gp/[year]/index.astro
@@ -47,10 +47,13 @@ if (hasAwards(year, 'road-gp')) {
     sex: ia.sex,
     resolved: {
       categoryName: resolveIndividualCategoryName(ia.id, ia.sex, ia.ageCategory, ia.name),
+      showAgeCategory: !ia.ageCategory,
       awards: ia.awards.map(a => ({
         position: a.position,
         name: a.name,
         clubName: resolveClub(a.club),
+        vest: resolveVest(a.club),
+        ageCategory: a.ageCategory,
         runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
       })),
     },


### PR DESCRIPTION
## Summary

- **ScheduleTable**: Widened date column to prevent text overflow; removed stale run count from header; fixed `Next` race highlight to use correct series accent colour (amber for Road GP, teal for Fell); added a client-side script so the `Next` badge re-evaluates against the real current date on stale/uncrebuilt deploys
- **ClubTurnout component**: Extracted a shared `ClubTurnout.astro` component with `card` and `inline` variants; moved club colour definitions to a shared `src/lib/clubColors.ts`; replaced inline implementations in `HistoryRaceList` and `IndividualResultsLayout`, and added to the `IndividualStandingsLayout` sidebar
- **Archive sidebar**: Renamed "By the Numbers" → "Club Turnout"; moved total runner count to the header; switched from abbreviations to full club names above bars; corrected Thornton Cleveleys colour to red
- **Team Awards (archive desktop)**: Removed decorative eyebrow/year header; reduced vest image size to better match the Individual Awards section; aligned heading style

## Test plan

- [ ] Visit `/road-gp/` and `/fell/` — confirm `Next` badge highlights the correct upcoming race and uses the right accent colour
- [ ] Wait or mock a date change — confirm `Next` updates client-side without a rebuild
- [ ] Visit a past-year archive page (e.g. `/road-gp/2024/`) — confirm Club Turnout sidebar shows full names, coloured bars, runner count in header
- [ ] Visit a race results page — confirm Club Turnout inline section retains original compact styling with coloured bars
- [ ] Visit an individual standings page — confirm Club Turnout appears below the Race Key in the sidebar
- [ ] Check Team Awards section on archive page — smaller vests, no eyebrow header

🤖 Generated with [Claude Code](https://claude.com/claude-code)