### PR TITLE
feat: series-aware accent colour (amber for Road GP, teal for Fell)

### DIFF
--- a/docs/superpowers/plans/2026-06-04-series-accent-colour.md
+++ b/docs/superpowers/plans/2026-06-04-series-accent-colour.md
@@ -1,0 +1,173 @@
+# Series Accent Colour Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Road GP pages use the existing amber accent; Fell pages automatically switch to teal by overriding `--color-amber` via a `data-series` attribute on `<html>`.
+
+**Architecture:** `Layout.astro` derives the series from the build-time URL and writes `data-series="fell"` or `data-series="road-gp"` onto `<html>`. Two CSS override blocks in `global.css` remap `--color-amber` / `--color-amber-bg` to teal values for fell. Every component that already uses `text-amber`, `bg-amber`, `border-amber`, or `var(--color-amber)` picks up the correct colour automatically — no per-component changes are needed except one hardcoded colour in `PageHeader.astro`.
+
+**Tech Stack:** Astro v6, Tailwind CSS v4 (custom CSS tokens, not DaisyUI themes), TypeScript strict.
+
+---
+
+### Task 1: Fix hardcoded amber in the focus ring and add the fell CSS overrides
+
+**Files:**
+- Modify: `src/styles/global.css:126` (focus shadow)
+- Modify: `src/styles/global.css:195` (append fell overrides after dark-mode block)
+
+- [ ] **Step 1: Fix the hardcoded focus shadow**
+
+In `src/styles/global.css`, replace line 126:
+
+```css
+/* BEFORE (line 122–127) */
+.input:focus,
+.select:focus,
+.textarea:focus {
+  border-color: var(--color-amber);
+  box-shadow: 0 0 0 3px oklch(72% 0.18 60 / 0.15);
+}
+```
+
+```css
+/* AFTER */
+.input:focus,
+.select:focus,
+.textarea:focus {
+  border-color: var(--color-amber);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--color-amber) 20%, transparent);
+}
+```
+
+- [ ] **Step 2: Append the fell accent override block**
+
+At the end of `src/styles/global.css` (after the `html[data-theme="dark"]` block that ends at line 195), add:
+
+```css
+
+/* ── Series accent overrides ── */
+html[data-series="fell"] {
+  --color-amber:    oklch(58% 0.14 195);
+  --color-amber-bg: oklch(96% 0.04 195);
+}
+html[data-series="fell"][data-theme="dark"] {
+  --color-amber:    oklch(70% 0.12 195);
+  --color-amber-bg: oklch(31% 0.05 195);
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/styles/global.css
+git commit -m "style: remap amber token to teal for fell series pages"
+```
+
+---
+
+### Task 2: Detect series in Layout and set data-series on html
+
+**Files:**
+- Modify: `src/components/Layout.astro:10–24`
+
+- [ ] **Step 1: Add series detection in the frontmatter**
+
+In `src/components/Layout.astro`, add after the existing `const base = ...` line (currently line 14):
+
+```astro
+---
+import '../styles/global.css';
+import SearchBox from './SearchBox.astro';
+
+interface Props {
+  title: string;
+  noPad?: boolean;
+}
+
+const { title, noPad = false } = Astro.props;
+const hasHero = Astro.slots.has('hero');
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const currentPath = Astro.url.pathname;
+
+const seriesAccent = currentPath.includes('/fell')
+  ? 'fell'
+  : currentPath.includes('/road-gp')
+  ? 'road-gp'
+  : undefined;
+
+function isActive(path: string): boolean {
+  const fullPath = base + path;
+  return currentPath === fullPath || currentPath.startsWith(fullPath + '/');
+}
+---
+```
+
+- [ ] **Step 2: Write seriesAccent to the html element**
+
+Still in `src/components/Layout.astro`, update the `<html>` opening tag (currently line 24):
+
+```html
+<!-- BEFORE -->
+<html lang="en" data-theme="light">
+
+<!-- AFTER -->
+<html lang="en" data-theme="light" data-series={seriesAccent}>
+```
+
+When `seriesAccent` is `undefined`, Astro omits the attribute entirely — non-series pages get no `data-series`, so they keep the default amber.
+
+- [ ] **Step 3: Verify the build passes**
+
+```bash
+npm run build
+```
+
+Expected: build completes with no TypeScript errors. Check the output HTML for a fell page (e.g. `dist/fell/2026/index.html`) and confirm `data-series="fell"` is present on `<html>`. Check a road page (e.g. `dist/road-gp/2026/index.html`) and confirm `data-series="road-gp"`. Check the home page (`dist/index.html`) and confirm no `data-series` attribute.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Layout.astro
+git commit -m "feat: set data-series on html for series-aware accent colour"
+```
+
+---
+
+### Task 3: Fix hardcoded amber in the Provisional badge
+
+**Files:**
+- Modify: `src/components/PageHeader.astro:41`
+
+The Provisional badge on results/standings page headers uses hardcoded oklch amber values. These won't shift when `--color-amber` is overridden, so a fell page would show an amber Provisional badge even though everything else is teal.
+
+- [ ] **Step 1: Replace hardcoded colours with CSS variables**
+
+In `src/components/PageHeader.astro`, replace line 41:
+
+```html
+<!-- BEFORE -->
+<span class="font-head text-[10px] font-bold tracking-[0.08em] uppercase bg-[oklch(88%_0.12_60)] text-[oklch(35%_0.12_60)] px-2 py-0.5 rounded-full">
+  Provisional
+</span>
+
+<!-- AFTER -->
+<span class="font-head text-[10px] font-bold tracking-[0.08em] uppercase px-2 py-0.5 rounded-full" style="background: var(--color-amber-bg); color: var(--color-amber);">
+  Provisional
+</span>
+```
+
+- [ ] **Step 2: Verify the build passes**
+
+```bash
+npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/PageHeader.astro
+git commit -m "fix: provisional badge uses accent token instead of hardcoded amber"
+```

--- a/docs/superpowers/specs/2026-06-04-series-accent-colour-design.md
+++ b/docs/superpowers/specs/2026-06-04-series-accent-colour-design.md
@@ -1,0 +1,100 @@
+# Series Accent Colour Design
+
+**Date:** 2026-06-04
+**Status:** Approved
+
+## Goal
+
+The site accent colour changes based on the series being viewed:
+- **Road GP** pages (`/road-gp/**`) — amber/orange (existing default)
+- **Fell** pages (`/fell/**`) — teal
+- **Non-series pages** (home, runners, search, contact) — amber/orange (no change)
+
+## Approach
+
+URL-based series detection in `Layout.astro` sets `data-series` on `<html>` at build time. A CSS override block remaps the `--color-amber` token to teal for fell pages. No prop threading required.
+
+## Changes
+
+### `src/components/Layout.astro`
+
+Detect series from `Astro.url.pathname` and write `data-series` on `<html>`:
+
+```astro
+const path = Astro.url.pathname;
+const series = path.includes('/fell') ? 'fell'
+  : path.includes('/road-gp') ? 'road-gp'
+  : undefined;
+```
+
+```html
+<html lang="en" data-theme="light" data-series={series}>
+```
+
+The existing dark-mode JS only touches `data-theme`, so there is no conflict.
+
+### `src/styles/global.css`
+
+Add two override blocks after the existing `html[data-theme="dark"]` block:
+
+```css
+html[data-series="fell"] {
+  --color-amber:    oklch(58% 0.14 195);   /* teal (= --color-teal) */
+  --color-amber-bg: oklch(96% 0.04 195);   /* teal-bg (= --color-teal-bg) */
+}
+html[data-series="fell"][data-theme="dark"] {
+  --color-amber:    oklch(70% 0.12 195);   /* dark teal */
+  --color-amber-bg: oklch(31% 0.05 195);   /* dark teal-bg */
+}
+```
+
+Also fix the hardcoded amber focus shadow on line 126 to use the variable:
+
+```css
+/* before */
+box-shadow: 0 0 0 3px oklch(72% 0.18 60 / 0.15);
+/* after */
+box-shadow: 0 0 0 3px color-mix(in oklch, var(--color-amber) 20%, transparent);
+```
+
+### `src/components/PageHeader.astro`
+
+The Provisional badge uses hardcoded amber `oklch` values. Replace with CSS variable-based colours so it shifts with the series:
+
+```html
+<!-- before -->
+<span class="... bg-[oklch(88%_0.12_60)] text-[oklch(35%_0.12_60)] ...">
+<!-- after -->
+<span class="... bg-[var(--color-amber-bg)] text-[var(--color-amber)] ...">
+```
+
+## Coverage
+
+Because every accent in the UI flows through `var(--color-amber)`, this override automatically shifts:
+
+| Element | Mechanism |
+|---|---|
+| Navbar active tab | `bg-amber` → CSS var |
+| PageHeader eyebrow | `text-amber` → CSS var |
+| PageLabel | `text-amber`, `bg-amber` → CSS var |
+| ChipBar active chips | `bg-amber border-amber` → CSS var |
+| Sex-toggle active buttons | `bg-amber border-amber` → CSS var |
+| `btn-primary` / `btn-active` | `background: var(--color-amber)` |
+| `badge-primary` | `var(--color-amber-bg)` / `var(--color-amber)` |
+| Input / select / textarea focus ring | CSS var (after fix above) |
+| `link-primary` | `var(--color-amber)` |
+| Tab active indicator | `var(--color-amber)` |
+| `SeriesDetailLayout` eyebrow + rule bullets | `text-amber` → CSS var |
+| `hover:border-amber` on archive cards | → CSS var |
+
+## Files Changed
+
+- `src/components/Layout.astro`
+- `src/styles/global.css`
+- `src/components/PageHeader.astro`
+
+## Out of Scope
+
+- Club logo colours (`src/lib/clubColors.ts`) — unrelated
+- Dark-mode toggle behaviour — unchanged
+- Any test changes — no pure functions affected

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -14,6 +14,12 @@ const hasHero = Astro.slots.has('hero');
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const currentPath = Astro.url.pathname;
 
+const seriesAccent = currentPath.includes('/fell')
+  ? 'fell'
+  : currentPath.includes('/road-gp')
+  ? 'road-gp'
+  : undefined;
+
 function isActive(path: string): boolean {
   const fullPath = base + path;
   return currentPath === fullPath || currentPath.startsWith(fullPath + '/');
@@ -21,7 +27,7 @@ function isActive(path: string): boolean {
 ---
 
 <!doctype html>
-<html lang="en" data-theme="light">
+<html lang="en" data-theme="light" data-series={seriesAccent}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -14,9 +14,9 @@ const hasHero = Astro.slots.has('hero');
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const currentPath = Astro.url.pathname;
 
-const seriesAccent = currentPath.includes('/fell')
+const seriesAccent = currentPath.includes('/fell/')
   ? 'fell'
-  : currentPath.includes('/road-gp')
+  : currentPath.includes('/road-gp/')
   ? 'road-gp'
   : undefined;
 

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -38,7 +38,7 @@ const hasTabStrip = Astro.slots.has('default');
         {title}
       </h1>
       {provisional && (
-        <span class="font-head text-[10px] font-bold tracking-[0.08em] uppercase bg-[oklch(88%_0.12_60)] text-[oklch(35%_0.12_60)] px-2 py-0.5 rounded-full">
+        <span class="font-head text-[10px] font-bold tracking-[0.08em] uppercase px-2 py-0.5 rounded-full" style="background: var(--color-amber-bg); color: var(--color-amber);">
           Provisional
         </span>
       )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -123,7 +123,7 @@ body { color: var(--color-content); }
 .select:focus,
 .textarea:focus {
   border-color: var(--color-amber);
-  box-shadow: 0 0 0 3px oklch(72% 0.18 60 / 0.15);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--color-amber) 20%, transparent);
 }
 .input-sm,
 .select-sm { padding: 0.1875rem 0.5rem; font-size: 0.8125rem; }
@@ -192,5 +192,15 @@ html[data-theme="dark"] {
   --color-teal:      oklch(70% 0.12 195);
   --color-teal-bg:   oklch(31% 0.05 195);
   --color-hdr-dark:  oklch(15% 0.014 250);
+}
+
+/* ── Series accent overrides ── */
+html[data-series="fell"] {
+  --color-amber:    oklch(58% 0.14 195);
+  --color-amber-bg: oklch(96% 0.04 195);
+}
+html[data-series="fell"][data-theme="dark"] {
+  --color-amber:    oklch(70% 0.12 195);
+  --color-amber-bg: oklch(31% 0.05 195);
 }
 


### PR DESCRIPTION
## Summary

- Fell pages (`/fell/**`) now use a teal accent; Road GP pages keep the existing amber
- All accent-derived UI elements shift automatically: navbar active tab, page header eyebrows, chip bar, buttons, badges, input focus rings, links, tab indicators, and the Provisional badge
- Non-series pages (home, runners, search, contact) keep amber unchanged

## How it works

`Layout.astro` detects `/fell/` or `/road-gp/` in the build-time URL path and writes `data-series="fell"` or `data-series="road-gp"` onto `<html>`. Two CSS override blocks in `global.css` remap `--color-amber` and `--color-amber-bg` to teal values for `html[data-series="fell"]` (with dark-mode variant). Because every accent in the codebase flows through `var(--color-amber)`, no per-component changes are needed beyond fixing one hardcoded value in `PageHeader.astro`.

## Test Plan

- [ ] Visit a Road GP page (e.g. `/road-gp/`) — accent is orange/amber
- [ ] Visit a Fell page (e.g. `/fell/`) — accent is teal
- [ ] Verify navbar active tab colour matches the series on both
- [ ] Check a results page with active category chips — chips match series colour
- [ ] Check a page with a Provisional badge — badge matches series colour
- [ ] Toggle dark mode on a fell page — teal accent persists in dark mode
- [ ] Visit home page / runner profile — accent stays amber

🤖 Generated with [Claude Code](https://claude.com/claude-code)