### PR TITLE
Use compact dd/mm date on mobile schedule table

### DIFF
--- a/src/components/ScheduleTable.astro
+++ b/src/components/ScheduleTable.astro
@@ -10,7 +10,7 @@
 // highlight against the real current date so stale builds stay correct.
 import { hasResults, isResultsProvisional } from '../lib/results';
 import { siteUrl } from '../lib/url';
-import { formatRaceDate } from '../lib/format';
+import { formatRaceDate, formatRaceDateShort } from '../lib/format';
 import type { Race, Series } from '../lib/types';
 
 interface Props {
@@ -68,7 +68,7 @@ const scriptRaceData = showNextRace ? raceStates.map(({ race, past, rowUrl, isEx
     <table class="table table-fixed">
       <colgroup>
         <col class="hidden sm:table-column w-10" />
-        <col class="w-[100px]" />
+        <col class="w-[56px] sm:w-[100px]" />
         <col />
         <col class="w-[90px]" />
       </colgroup>
@@ -88,7 +88,10 @@ const scriptRaceData = showNextRace ? raceStates.map(({ race, past, rowUrl, isEx
           >
             <td class="hidden sm:table-cell py-3 px-3 text-center font-mono text-xs text-muted">{i + 1}</td>
             <td class="py-3 pl-4 sm:pl-3 pr-3 whitespace-nowrap">
-              <div data-date class:list={['font-mono text-[12px]', isNext ? `${accentText} font-semibold` : 'text-muted']}>{formatRaceDate(race.date)}</div>
+              <div data-date class:list={['font-mono text-[12px]', isNext ? `${accentText} font-semibold` : 'text-muted']}>
+                <span class="sm:hidden">{formatRaceDateShort(race.date)}</span>
+                <span class="hidden sm:inline">{formatRaceDate(race.date)}</span>
+              </div>
               {showNextRace && race.time && (
                 <div data-time class:list={['font-mono text-[11px]', isNext ? (series === 'fell' ? 'text-teal/70' : 'text-amber/70') : 'text-muted/70']}>{race.time}</div>
               )}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -13,6 +13,11 @@ export function formatRaceDate(date: string, time?: string): string {
   return time ? `${dateStr} · ${time}` : dateStr;
 }
 
+export function formatRaceDateShort(date: string): string {
+  const [, month, day] = date.split('-').map(Number);
+  return `${String(day).padStart(2, '0')}/${String(month).padStart(2, '0')}`;
+}
+
 /** Format a stored time as h:mm:ss or m:ss (no leading zeros on the first component). */
 export function formatTime(time: string | null | undefined): string {
   if (!time) return '–';


### PR DESCRIPTION
## Summary

- Adds `formatRaceDateShort` to `src/lib/format.ts` — returns a zero-padded `dd/mm` string (e.g. `07/06`)
- `ScheduleTable.astro` now renders the short format on mobile (`< sm`) and the full `"Sat 7 Jun"` format at `sm` and above
- Shrinks the date column from `w-[100px]` to `w-[56px]` on mobile (`sm:w-[100px]` restores it at wider viewports), giving the race name column significantly more horizontal space

## Why

On narrow mobile viewports the full `"Sat 7 Jun"` date string occupied ~100px, leaving little room for the race name. The compact `dd/mm` format and narrower column fix this without any change to the desktop layout.

## Reviewer notes

- The client-side script that updates `[data-date]` styling on `showNextRace` pages only modifies `className`, not text content, so the two inner `<span>` elements are unaffected.
- No unit tests needed — `formatRaceDateShort` is a pure formatting helper; the existing test suite pattern only covers pure functions that are already tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)