### PR TITLE
feat: runner profile page improvements

### DIFF
--- a/src/lib/runners.ts
+++ b/src/lib/runners.ts
@@ -155,6 +155,14 @@ export function resolveClubName(clubId: string): string {
   return clubId;
 }
 
+function resolveClubVest(clubId: string): string | undefined {
+  for (const clubs of Object.values(allClubFiles)) {
+    const club = clubs.default.find(c => c.id === clubId);
+    if (club?.vest) return club.vest;
+  }
+  return undefined;
+}
+
 function buildClubHistory(entries: Array<{ year: number; club: string }>): RunnerClubHistory[] {
   const clubYears = new Map<string, Set<number>>();
   for (const { year, club } of entries) {
@@ -164,10 +172,10 @@ function buildClubHistory(entries: Array<{ year: number; club: string }>): Runne
   return [...clubYears.entries()]
     .map(([clubId, yearsSet]) => {
       const years = [...yearsSet].sort((a, b) => a - b);
-      return { clubId, clubName: resolveClubName(clubId), yearRanges: formatYearRanges(years), firstYear: years[0] };
+      return { clubId, clubName: resolveClubName(clubId), yearRanges: formatYearRanges(years), vest: resolveClubVest(clubId), firstYear: years[0] };
     })
     .sort((a, b) => a.firstYear - b.firstYear)
-    .map(({ clubId, clubName, yearRanges }) => ({ clubId, clubName, yearRanges }));
+    .map(({ clubId, clubName, yearRanges, vest }) => ({ clubId, clubName, yearRanges, vest }));
 }
 
 function buildAwardSummary(yearBlocks: RunnerYearBlock[]): RunnerAwardSummary {

--- a/src/lib/runners.ts
+++ b/src/lib/runners.ts
@@ -120,18 +120,12 @@ function getRacesForRunner(year: number, series: Series, seriesLocalId: number):
     if (!match) continue;
     const race = raceById[raceId];
     if (!race) continue;
-    const openPositions = raceResults
-      .map(r => r.categoryPositions['open'])
-      .filter((p): p is number => p != null);
-    const totalOpen = openPositions.length > 0 ? Math.max(...openPositions) : null;
     results.push({
       date: race.date,
       raceName: race.name,
       raceId,
       time: match.time,
       hasResults: hasResults(year, series, raceId),
-      position: match.position ?? null,
-      totalOpen,
     });
   }
   return results.sort((a, b) => a.date.localeCompare(b.date));

--- a/src/lib/runners.ts
+++ b/src/lib/runners.ts
@@ -120,12 +120,18 @@ function getRacesForRunner(year: number, series: Series, seriesLocalId: number):
     if (!match) continue;
     const race = raceById[raceId];
     if (!race) continue;
+    const openPositions = raceResults
+      .map(r => r.categoryPositions['open'])
+      .filter((p): p is number => p != null);
+    const totalOpen = openPositions.length > 0 ? Math.max(...openPositions) : null;
     results.push({
       date: race.date,
       raceName: race.name,
       raceId,
       time: match.time,
       hasResults: hasResults(year, series, raceId),
+      position: match.position ?? null,
+      totalOpen,
     });
   }
   return results.sort((a, b) => a.date.localeCompare(b.date));

--- a/src/lib/runners.ts
+++ b/src/lib/runners.ts
@@ -126,6 +126,7 @@ function getRacesForRunner(year: number, series: Series, seriesLocalId: number):
       raceId,
       time: match.time,
       hasResults: hasResults(year, series, raceId),
+      distance: race.distance,
     });
   }
   return results.sort((a, b) => a.date.localeCompare(b.date));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -101,6 +101,7 @@ export interface RunnerClubHistory {
   clubId: string;
   clubName: string;
   yearRanges: string;   // pre-formatted, e.g. "2019–2021, 2025"
+  vest?: string;        // vest filename e.g. "blackpool.png" from clubs.json
 }
 
 export interface RunnerAwardSummaryEntry {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,6 +79,8 @@ export interface RunnerProfileRace {
   raceId: string;
   time: string;
   hasResults: boolean;
+  position: number | null;   // runner's overall finish position
+  totalOpen: number | null;  // total finishers in the open category (null if not available)
 }
 
 export interface RunnerProfileAward {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,8 +79,6 @@ export interface RunnerProfileRace {
   raceId: string;
   time: string;
   hasResults: boolean;
-  position: number | null;   // runner's overall finish position
-  totalOpen: number | null;  // total finishers in the open category (null if not available)
 }
 
 export interface RunnerProfileAward {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,6 +79,7 @@ export interface RunnerProfileRace {
   raceId: string;
   time: string;
   hasResults: boolean;
+  distance?: string;  // e.g. "5.2 miles" from races.json
 }
 
 export interface RunnerProfileAward {

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -161,14 +161,23 @@ function positionLabel(pos: number): string {
         </div>
       </div>
 
-      <!-- Filter bar -->
-      <div class="bg-surface border border-line rounded-xl p-3 mb-6 flex flex-wrap gap-2 items-center">
-        <div class="flex gap-1">
-          <button class="btn btn-sm btn-active" data-series-filter="all">All</button>
-          <button class="btn btn-sm btn-ghost" data-series-filter="road-gp">Road GP</button>
-          <button class="btn btn-sm btn-ghost" data-series-filter="fell">Fell</button>
+      <!-- Filter bar — matches chip-bar / results-page filter style -->
+      <div class="bg-surface lg:bg-transparent border-b border-line lg:border-b-0 -mx-4 lg:mx-0 px-4 lg:px-0 py-3 lg:py-0 mb-6 flex flex-wrap gap-x-3 gap-y-2.5 items-center justify-center">
+        <div class="flex gap-1.5 shrink-0">
+          <button
+            class="font-head text-xs font-bold tracking-[0.06em] uppercase px-3.5 py-[7px] rounded-full border transition-colors bg-amber border-amber text-white"
+            data-series-filter="all"
+          >All</button>
+          <button
+            class="font-head text-xs font-bold tracking-[0.06em] uppercase px-3.5 py-[7px] rounded-full border transition-colors bg-surface border-line text-muted hover:text-content"
+            data-series-filter="road-gp"
+          >Road GP</button>
+          <button
+            class="font-head text-xs font-bold tracking-[0.06em] uppercase px-3.5 py-[7px] rounded-full border transition-colors bg-surface border-line text-muted hover:text-content"
+            data-series-filter="fell"
+          >Fell</button>
         </div>
-        <select id="filter-race" class="select select-sm">
+        <select id="filter-race" class="w-full sm:w-auto sm:min-w-[180px] sm:max-w-xs bg-surface border border-line rounded-lg px-3 py-[7px] font-body text-[13px] text-muted outline-none">
           <option value="">All Races</option>
         </select>
       </div>
@@ -468,10 +477,14 @@ function positionLabel(pos: number): string {
   document.querySelectorAll<HTMLButtonElement>('[data-series-filter]').forEach(btn => {
     btn.addEventListener('click', () => {
       activeSeries = btn.dataset.seriesFilter!;
-      document.querySelectorAll('[data-series-filter]').forEach(b => {
+      document.querySelectorAll<HTMLButtonElement>('[data-series-filter]').forEach(b => {
         const active = b === btn;
-        b.classList.toggle('btn-active', active);
-        b.classList.toggle('btn-ghost', !active);
+        b.classList.toggle('bg-amber',     active);
+        b.classList.toggle('border-amber', active);
+        b.classList.toggle('text-white',   active);
+        b.classList.toggle('bg-surface',   !active);
+        b.classList.toggle('border-line',  !active);
+        b.classList.toggle('text-muted',   !active);
       });
       applyFilters();
       updateRaceDropdown();

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -25,6 +25,10 @@ const categoryLabel = `${runner.sex}${runner.ageCategory}`;
 const hasRoadGpAwards = awardSummary.roadGp.length > 0;
 const hasFellAwards = awardSummary.fell.length > 0;
 
+const totalRoadGp = yearBlocks.reduce((n, b) => n + (b.roadGp?.races.length ?? 0), 0);
+const totalFell   = yearBlocks.reduce((n, b) => n + (b.fell?.races.length ?? 0), 0);
+const totalRaces  = totalRoadGp + totalFell;
+
 function formatDateShort(isoDate: string): string {
   const d = new Date(isoDate);
   return `${d.getUTCDate()}/${d.getUTCMonth() + 1}`;
@@ -77,6 +81,31 @@ function positionLabel(pos: number): string {
               </div>
             </div>
           ))}
+        </div>
+      </div>
+
+      <!-- Race stats -->
+      <div class="bg-surface border border-line rounded-xl p-4">
+        <h2 class="font-head font-bold text-xs uppercase tracking-widest text-muted mb-3">
+          Races
+        </h2>
+        <div class="space-y-1.5">
+          <div class="flex items-center justify-between text-sm">
+            <span class="text-content font-medium">Total</span>
+            <span class="font-mono tabular-nums text-muted">{totalRaces}</span>
+          </div>
+          {totalRoadGp > 0 && (
+            <div class="flex items-center justify-between text-sm">
+              <span class="text-amber font-medium">Road GP</span>
+              <span class="font-mono tabular-nums text-muted">{totalRoadGp}</span>
+            </div>
+          )}
+          {totalFell > 0 && (
+            <div class="flex items-center justify-between text-sm">
+              <span class="text-teal font-medium">Fell</span>
+              <span class="font-mono tabular-nums text-muted">{totalFell}</span>
+            </div>
+          )}
         </div>
       </div>
 
@@ -137,28 +166,58 @@ function positionLabel(pos: number): string {
     <!-- Main content -->
     <div>
 
-      <!-- Competed for (mobile/tablet, < lg) -->
-      <div class="lg:hidden mb-6 bg-surface border border-line rounded-xl p-4">
-        <h2 class="font-head font-bold text-xs uppercase tracking-widest text-muted mb-3">
-          Competed for
-        </h2>
-        <div class="flex flex-col xs:flex-row xs:flex-wrap gap-x-6 gap-y-3">
-          {clubHistory.map(ch => (
-            <div class="flex items-center gap-3 text-sm">
-              {ch.vest && (
-                <img
-                  src={siteUrl(`/images/vests/${ch.vest}`)}
-                  alt=""
-                  class="h-10 w-auto shrink-0 object-contain"
-                />
-              )}
-              <div class="min-w-0">
-                <div class="font-semibold">{ch.clubName}</div>
-                <div class="font-mono text-xs text-muted">{ch.yearRanges}</div>
+      <!-- Competed for + Race stats row (mobile/tablet, < lg) -->
+      <div class="lg:hidden mb-6 flex flex-col xs:flex-row xs:items-stretch gap-4">
+
+        <!-- Competed for -->
+        <div class="bg-surface border border-line rounded-xl p-4 flex-1 min-w-0">
+          <h2 class="font-head font-bold text-xs uppercase tracking-widest text-muted mb-3">
+            Competed for
+          </h2>
+          <div class="flex flex-col xs:flex-row xs:flex-wrap gap-x-6 gap-y-3">
+            {clubHistory.map(ch => (
+              <div class="flex items-center gap-3 text-sm">
+                {ch.vest && (
+                  <img
+                    src={siteUrl(`/images/vests/${ch.vest}`)}
+                    alt=""
+                    class="h-10 w-auto shrink-0 object-contain"
+                  />
+                )}
+                <div class="min-w-0">
+                  <div class="font-semibold">{ch.clubName}</div>
+                  <div class="font-mono text-xs text-muted">{ch.yearRanges}</div>
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
+
+        <!-- Race stats — narrow card at xs+, full-width below xs -->
+        <div class="bg-surface border border-line rounded-xl p-4 xs:w-36 shrink-0">
+          <h2 class="font-head font-bold text-xs uppercase tracking-widest text-muted mb-3">
+            Races
+          </h2>
+          <div class="space-y-1.5">
+            <div class="flex items-center justify-between text-sm">
+              <span class="text-content font-medium">Total</span>
+              <span class="font-mono tabular-nums text-muted">{totalRaces}</span>
+            </div>
+            {totalRoadGp > 0 && (
+              <div class="flex items-center justify-between text-sm">
+                <span class="text-amber font-medium">Road GP</span>
+                <span class="font-mono tabular-nums text-muted">{totalRoadGp}</span>
+              </div>
+            )}
+            {totalFell > 0 && (
+              <div class="flex items-center justify-between text-sm">
+                <span class="text-teal font-medium">Fell</span>
+                <span class="font-mono tabular-nums text-muted">{totalFell}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
       </div>
 
       <!-- Filter bar — matches chip-bar / results-page filter style -->

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -19,10 +19,9 @@ interface Props {
 
 const { runner, clubHistory, awardSummary, yearBlocks } = Astro.props;
 const title = `${runner.firstName} ${runner.lastName}`;
-const sexLabel = runner.sex === 'M' ? 'Men' : 'Women';
 const currentClubName = resolveClubName(runner.club);
+const categoryLabel = `${runner.sex}${runner.ageCategory}`;
 
-const allYears = yearBlocks.map(b => b.year);
 const hasRoadGpAwards = awardSummary.roadGp.length > 0;
 const hasFellAwards = awardSummary.fell.length > 0;
 
@@ -46,9 +45,9 @@ function positionLabel(pos: number): string {
   <!-- ── Dark hero ── -->
   <PageHeader
     slot="hero"
-    eyebrow={currentClubName}
+    eyebrow="Runner"
     title={title}
-    subtitleParts={[sexLabel, runner.ageCategory]}
+    subtitleParts={[currentClubName, categoryLabel]}
   />
 
   <!-- ── Body: sidebar + main ── -->
@@ -169,10 +168,6 @@ function positionLabel(pos: number): string {
           <button class="btn btn-sm btn-ghost" data-series-filter="road-gp">Road GP</button>
           <button class="btn btn-sm btn-ghost" data-series-filter="fell">Fell</button>
         </div>
-        <select id="filter-year" class="select select-sm">
-          <option value="">All Years</option>
-          {allYears.map(y => <option value={String(y)}>{y}</option>)}
-        </select>
         <select id="filter-race" class="select select-sm">
           <option value="">All Races</option>
         </select>
@@ -373,7 +368,6 @@ function positionLabel(pos: number): string {
 </Layout>
 
 <script>
-  const yearSelect = document.getElementById('filter-year') as HTMLSelectElement;
   const raceSelect = document.getElementById('filter-race') as HTMLSelectElement;
   const profileContent = document.getElementById('profile-content') as HTMLElement;
   const raceCompact = document.getElementById('race-compact') as HTMLElement;
@@ -396,13 +390,12 @@ function positionLabel(pos: number): string {
       : `${mm}:${String(ss).padStart(2,'0')}`;
   }
 
-  function buildCompactView(activeRace: string, activeYear: string) {
+  function buildCompactView(activeRace: string) {
     const rows = Array.from(document.querySelectorAll<HTMLElement>('tr[data-race-id]'))
       .filter(row => {
         const seriesDiv = row.closest<HTMLElement>('[data-series]');
         const seriesMatch = activeSeries === 'all' || seriesDiv?.dataset.series === activeSeries;
-        const yearMatch = activeYear === '' || row.dataset.year === activeYear;
-        return row.dataset.raceId === activeRace && seriesMatch && yearMatch;
+        return row.dataset.raceId === activeRace && seriesMatch;
       })
       .sort((a, b) => Number(b.dataset.year) - Number(a.dataset.year));
 
@@ -422,14 +415,13 @@ function positionLabel(pos: number): string {
   }
 
   function applyFilters() {
-    const activeYear = yearSelect.value;
     const activeRace = raceSelect.value;
 
     if (activeRace !== '') {
       // Switch to compact view
       profileContent.classList.add('hidden');
       raceCompact.classList.remove('hidden');
-      buildCompactView(activeRace, activeYear);
+      buildCompactView(activeRace);
       return;
     }
 
@@ -442,30 +434,21 @@ function positionLabel(pos: number): string {
       div.classList.toggle('hidden', activeSeries !== 'all' && div.dataset.series !== activeSeries);
     });
 
-    // Show/hide race rows
-    document.querySelectorAll<HTMLElement>('tr[data-race-id]').forEach(row => {
-      row.classList.remove('hidden');
-    });
-
     // Show/hide year blocks
-    document.querySelectorAll<HTMLElement>('[data-year]').forEach(block => {
-      const yearMatch = activeYear === '' || block.dataset.year === activeYear;
+    document.querySelectorAll<HTMLElement>('div[data-year]').forEach(block => {
       const hasVisibleSeries = block.querySelector('[data-series]:not(.hidden)') !== null;
-      block.classList.toggle('hidden', !yearMatch || !hasVisibleSeries);
+      block.classList.toggle('hidden', !hasVisibleSeries);
     });
   }
 
   function updateRaceDropdown() {
-    const activeYear = yearSelect.value;
     const seen = new Set<string>();
     const options: Array<{ id: string; name: string }> = [];
 
     document.querySelectorAll<HTMLElement>('tr[data-race-id]').forEach(row => {
-      const yearBlock = row.closest<HTMLElement>('[data-year]');
       const seriesDiv = row.closest<HTMLElement>('[data-series]');
-      const yearMatch = activeYear === '' || yearBlock?.dataset.year === activeYear;
       const seriesMatch = activeSeries === 'all' || seriesDiv?.dataset.series === activeSeries;
-      if (yearMatch && seriesMatch) {
+      if (seriesMatch) {
         const id = row.dataset.raceId!;
         if (!seen.has(id)) {
           seen.add(id);
@@ -473,6 +456,8 @@ function positionLabel(pos: number): string {
         }
       }
     });
+
+    options.sort((a, b) => a.name.localeCompare(b.name));
 
     const current = raceSelect.value;
     raceSelect.innerHTML = '<option value="">All Races</option>' +
@@ -493,7 +478,6 @@ function positionLabel(pos: number): string {
     });
   });
 
-  yearSelect.addEventListener('change', () => { applyFilters(); updateRaceDropdown(); });
   raceSelect.addEventListener('change', applyFilters);
 
   // Initialise race dropdown on page load

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -188,30 +188,10 @@ function positionLabel(pos: number): string {
             <div data-year={String(block.year)} class="mb-8">
 
               <!-- Year heading -->
-              <div class="flex items-baseline gap-2 flex-wrap border-b-2 border-content pb-1.5 mb-4">
+              <div class="flex items-baseline gap-2 border-b-2 border-content pb-1.5 mb-4">
                 <span class="font-head font-extrabold text-2xl tracking-tight leading-none">
                   {block.year}
                 </span>
-                {blockAwardsRoad.map(a => (
-                  <span class="inline-flex items-center gap-1 bg-amber text-white font-head font-bold uppercase tracking-wider text-xs px-2.5 py-0.5 rounded-full">
-                    <svg width="10" height="10" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-                      <path d="M3 1.5h6v3a3 3 0 0 1-6 0v-3Z" fill="currentColor"/>
-                      <path d="M4.5 8h3v1h-3z" fill="currentColor"/>
-                      <path d="M3.5 10h5v0.6h-5z" fill="currentColor"/>
-                    </svg>
-                    Road GP · {a.categoryName} · {positionLabel(a.position)}
-                  </span>
-                ))}
-                {blockAwardsFell.map(a => (
-                  <span class="inline-flex items-center gap-1 bg-teal text-white font-head font-bold uppercase tracking-wider text-xs px-2.5 py-0.5 rounded-full">
-                    <svg width="10" height="10" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-                      <path d="M3 1.5h6v3a3 3 0 0 1-6 0v-3Z" fill="currentColor"/>
-                      <path d="M4.5 8h3v1h-3z" fill="currentColor"/>
-                      <path d="M3.5 10h5v0.6h-5z" fill="currentColor"/>
-                    </svg>
-                    Fell · {a.categoryName} · {positionLabel(a.position)}
-                  </span>
-                ))}
                 <span class="flex-1"></span>
                 <span class="font-mono text-xs text-muted">
                   {blockRaces} race{blockRaces !== 1 ? 's' : ''}
@@ -221,11 +201,18 @@ function positionLabel(pos: number): string {
               <!-- Road GP races -->
               {block.roadGp && (
                 <div data-series="road-gp" class="mb-5">
-                  <h3 class="font-head font-bold text-xs uppercase tracking-widest text-amber mb-2">
+                  <h3 class="flex items-center gap-2 flex-wrap font-head font-bold text-xs uppercase tracking-widest text-amber mb-2">
                     Road GP
-                    <span class="font-mono normal-case tracking-normal font-normal text-muted ml-1.5">
-                      {block.roadGp.races.length} race{block.roadGp.races.length !== 1 ? 's' : ''}
-                    </span>
+                    {blockAwardsRoad.map(a => (
+                      <span class="inline-flex items-center gap-1 bg-amber text-white font-bold uppercase tracking-wider text-xs px-2 py-0.5 rounded-full normal-case">
+                        <svg width="9" height="9" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                          <path d="M3 1.5h6v3a3 3 0 0 1-6 0v-3Z" fill="currentColor"/>
+                          <path d="M4.5 8h3v1h-3z" fill="currentColor"/>
+                          <path d="M3.5 10h5v0.6h-5z" fill="currentColor"/>
+                        </svg>
+                        {a.categoryName} · {positionLabel(a.position)}
+                      </span>
+                    ))}
                   </h3>
                   <table class="w-full text-sm border-collapse">
                     <tbody>
@@ -259,11 +246,18 @@ function positionLabel(pos: number): string {
               <!-- Fell races -->
               {block.fell && (
                 <div data-series="fell" class="mb-5">
-                  <h3 class="font-head font-bold text-xs uppercase tracking-widest text-teal mb-2">
+                  <h3 class="flex items-center gap-2 flex-wrap font-head font-bold text-xs uppercase tracking-widest text-teal mb-2">
                     Fell
-                    <span class="font-mono normal-case tracking-normal font-normal text-muted ml-1.5">
-                      {block.fell.races.length} race{block.fell.races.length !== 1 ? 's' : ''}
-                    </span>
+                    {blockAwardsFell.map(a => (
+                      <span class="inline-flex items-center gap-1 bg-teal text-white font-bold uppercase tracking-wider text-xs px-2 py-0.5 rounded-full normal-case">
+                        <svg width="9" height="9" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                          <path d="M3 1.5h6v3a3 3 0 0 1-6 0v-3Z" fill="currentColor"/>
+                          <path d="M4.5 8h3v1h-3z" fill="currentColor"/>
+                          <path d="M3.5 10h5v0.6h-5z" fill="currentColor"/>
+                        </svg>
+                        {a.categoryName} · {positionLabel(a.position)}
+                      </span>
+                    ))}
                   </h3>
                   <table class="w-full text-sm border-collapse">
                     <tbody>

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -51,7 +51,7 @@ function positionLabel(pos: number): string {
   />
 
   <!-- ── Body: sidebar + main ── -->
-  <div class="lg:grid lg:grid-cols-[260px_1fr] lg:gap-7 xl:grid-cols-[280px_1fr]">
+  <div class="lg:grid lg:grid-cols-[220px_1fr] xl:grid-cols-[260px_1fr] lg:gap-8 lg:items-start">
 
     <!-- Sidebar (lg+) -->
     <aside class="hidden lg:block space-y-4">
@@ -218,7 +218,7 @@ function positionLabel(pos: number): string {
                       </span>
                     ))}
                   </h3>
-                  <table class="w-full text-sm border-collapse">
+                  <table class="w-full text-sm border-collapse table-fixed">
                     <tbody>
                       {block.roadGp.races.map(race => (
                         <tr
@@ -227,18 +227,23 @@ function positionLabel(pos: number): string {
                           data-year={String(block.year)}
                           data-time={race.time ?? ''}
                           data-results-url={race.hasResults ? siteUrl(`/road-gp/${block.year}/${race.raceId}/results`) : ''}
+                          data-distance={race.distance ?? ''}
                           class="border-b border-line last:border-b-0"
                         >
-                          <td class="py-2 pr-3 font-mono text-xs text-muted w-10 tabular-nums align-middle">
+                          <td class="py-2 pr-3 font-mono text-xs text-muted w-10 shrink-0 tabular-nums align-middle">
                             {formatDateShort(race.date)}
                           </td>
-                          <td class="py-2 font-medium align-middle">
+                          <td class="py-2 font-medium align-middle truncate">
                             {race.hasResults
                               ? <a href={siteUrl(`/road-gp/${block.year}/${race.raceId}/results`)} class="link link-hover">{race.raceName}</a>
                               : <span class="text-muted">{race.raceName}</span>}
+                            {race.distance && <div class="sm:hidden font-mono text-xs text-muted mt-0.5">{race.distance}</div>}
+                          </td>
+                          <td class="hidden sm:table-cell py-2 px-3 font-mono text-xs text-muted text-left align-middle w-32">
+                            {race.distance ?? ''}
                           </td>
                           <td class:list={[
-                            'py-2 text-right font-mono text-sm tabular-nums align-middle',
+                            'py-2 text-right font-mono text-sm tabular-nums align-middle w-16',
                             !race.time ? 'text-muted' : 'text-content',
                           ]}>
                             {formatTime(race.time)}
@@ -266,7 +271,7 @@ function positionLabel(pos: number): string {
                       </span>
                     ))}
                   </h3>
-                  <table class="w-full text-sm border-collapse">
+                  <table class="w-full text-sm border-collapse table-fixed">
                     <tbody>
                       {block.fell.races.map(race => (
                         <tr
@@ -277,16 +282,19 @@ function positionLabel(pos: number): string {
                           data-results-url={race.hasResults ? siteUrl(`/fell/${block.year}/${race.raceId}/results`) : ''}
                           class="border-b border-line last:border-b-0"
                         >
-                          <td class="py-2 pr-3 font-mono text-xs text-muted w-10 tabular-nums align-middle">
+                          <td class="py-2 pr-3 font-mono text-xs text-muted w-10 shrink-0 tabular-nums align-middle">
                             {formatDateShort(race.date)}
                           </td>
-                          <td class="py-2 font-medium align-middle">
+                          <td class="py-2 font-medium align-middle truncate">
                             {race.hasResults
                               ? <a href={siteUrl(`/fell/${block.year}/${race.raceId}/results`)} class="link link-hover">{race.raceName}</a>
                               : <span class="text-muted">{race.raceName}</span>}
                           </td>
+                          <td class="py-2 px-3 font-mono text-xs text-muted text-left align-middle w-32">
+                            {race.distance ?? ''}
+                          </td>
                           <td class:list={[
-                            'py-2 text-right font-mono text-sm tabular-nums align-middle',
+                            'py-2 text-right font-mono text-sm tabular-nums align-middle w-16',
                             !race.time ? 'text-muted' : 'text-content',
                           ]}>
                             {formatTime(race.time)}
@@ -305,11 +313,12 @@ function positionLabel(pos: number): string {
 
       <!-- Compact race-selected view -->
       <div id="race-compact" class="hidden">
-        <table class="w-full text-sm border-collapse">
+        <table class="w-full text-sm border-collapse table-fixed">
           <thead>
             <tr class="border-b-2 border-content">
               <th class="pb-1.5 text-left font-head font-bold text-xs uppercase tracking-widest text-muted w-16">Year</th>
-              <th class="pb-1.5 text-right font-head font-bold text-xs uppercase tracking-widest text-muted">Time</th>
+              <th class="pb-1.5 px-3 text-left font-head font-bold text-xs uppercase tracking-widest text-muted w-32">Distance</th>
+              <th class="pb-1.5 text-right font-head font-bold text-xs uppercase tracking-widest text-muted w-16">Time</th>
             </tr>
           </thead>
           <tbody id="race-compact-body"></tbody>
@@ -415,9 +424,11 @@ function positionLabel(pos: number): string {
       const yearCell = url
         ? `<a href="${url}" class="link link-hover font-mono tabular-nums">${year}</a>`
         : `<span class="font-mono tabular-nums text-muted">${year}</span>`;
+      const distance = row.dataset.distance ?? '';
       const timeClass = row.dataset.time ? 'text-content' : 'text-muted';
       return `<tr class="border-b border-line last:border-b-0">
         <td class="py-2 pr-3 align-middle">${yearCell}</td>
+        <td class="py-2 px-3 text-left font-mono text-xs text-muted align-middle whitespace-nowrap">${distance}</td>
         <td class="py-2 text-right font-mono tabular-nums align-middle ${timeClass}">${time}</td>
       </tr>`;
     }).join('');

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -3,6 +3,7 @@ import Layout from '../../components/Layout.astro';
 import PageHeader from '../../components/PageHeader.astro';
 import { getRunnerProfileStaticPaths, resolveClubName } from '../../lib/runners';
 import { siteUrl } from '../../lib/url';
+import { formatTime } from '../../lib/format';
 import type { GlobalRunner, RunnerYearBlock, RunnerClubHistory, RunnerAwardSummary } from '../../lib/types';
 
 export async function getStaticPaths() {
@@ -51,21 +52,30 @@ function positionLabel(pos: number): string {
   />
 
   <!-- ── Body: sidebar + main ── -->
-  <div class="md:grid md:grid-cols-[220px_1fr] md:gap-7 lg:grid-cols-[260px_1fr]">
+  <div class="lg:grid lg:grid-cols-[260px_1fr] lg:gap-7 xl:grid-cols-[280px_1fr]">
 
-    <!-- Sidebar -->
-    <aside class="mb-6 md:mb-0 space-y-4">
+    <!-- Sidebar (lg+) -->
+    <aside class="hidden lg:block space-y-4">
 
       <!-- Competed for -->
       <div class="bg-surface border border-line rounded-xl p-4">
         <h2 class="font-head font-bold text-xs uppercase tracking-widest text-muted mb-3">
           Competed for
         </h2>
-        <div class="space-y-2">
+        <div class="space-y-3">
           {clubHistory.map(ch => (
-            <div class="flex justify-between items-baseline gap-3 text-sm">
-              <span class="font-semibold">{ch.clubName}</span>
-              <span class="font-mono text-xs text-muted shrink-0">{ch.yearRanges}</span>
+            <div class="flex items-center gap-3 text-sm">
+              {ch.vest && (
+                <img
+                  src={siteUrl(`/images/vests/${ch.vest}`)}
+                  alt=""
+                  class="h-10 w-auto shrink-0 object-contain"
+                />
+              )}
+              <div class="min-w-0">
+                <div class="font-semibold">{ch.clubName}</div>
+                <div class="font-mono text-xs text-muted">{ch.yearRanges}</div>
+              </div>
             </div>
           ))}
         </div>
@@ -80,7 +90,6 @@ function positionLabel(pos: number): string {
           <div class="space-y-1.5">
             {awardSummary.roadGp.map(a => (
               <div class="flex items-center gap-2 text-sm">
-                <!-- Trophy icon -->
                 <svg width="12" height="12" viewBox="0 0 12 12" fill="none" class="shrink-0 text-amber" aria-hidden="true">
                   <path d="M3 1.5h6v3a3 3 0 0 1-6 0v-3Z" fill="currentColor"/>
                   <path d="M2 2.5H1v1a1.5 1.5 0 0 0 1.5 1.5" stroke="currentColor" stroke-width="0.8"/>
@@ -128,6 +137,30 @@ function positionLabel(pos: number): string {
 
     <!-- Main content -->
     <div>
+
+      <!-- Competed for (mobile/tablet, < lg) -->
+      <div class="lg:hidden mb-6 bg-surface border border-line rounded-xl p-4">
+        <h2 class="font-head font-bold text-xs uppercase tracking-widest text-muted mb-3">
+          Competed for
+        </h2>
+        <div class="flex flex-col xs:flex-row xs:flex-wrap gap-x-6 gap-y-3">
+          {clubHistory.map(ch => (
+            <div class="flex items-center gap-3 text-sm">
+              {ch.vest && (
+                <img
+                  src={siteUrl(`/images/vests/${ch.vest}`)}
+                  alt=""
+                  class="h-10 w-auto shrink-0 object-contain"
+                />
+              )}
+              <div class="min-w-0">
+                <div class="font-semibold">{ch.clubName}</div>
+                <div class="font-mono text-xs text-muted">{ch.yearRanges}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
 
       <!-- Filter bar -->
       <div class="bg-surface border border-line rounded-xl p-3 mb-6 flex flex-wrap gap-2 items-center">
@@ -212,9 +245,9 @@ function positionLabel(pos: number): string {
                           </td>
                           <td class:list={[
                             'py-2 text-right font-mono text-sm tabular-nums align-middle',
-                            !race.time ? 'text-muted' : '',
+                            !race.time ? 'text-muted' : 'text-content',
                           ]}>
-                            {race.time || '–'}
+                            {formatTime(race.time)}
                           </td>
                         </tr>
                       ))}
@@ -250,9 +283,9 @@ function positionLabel(pos: number): string {
                           </td>
                           <td class:list={[
                             'py-2 text-right font-mono text-sm tabular-nums align-middle',
-                            !race.time ? 'text-muted' : '',
+                            !race.time ? 'text-muted' : 'text-content',
                           ]}>
-                            {race.time || '–'}
+                            {formatTime(race.time)}
                           </td>
                         </tr>
                       ))}
@@ -267,6 +300,61 @@ function positionLabel(pos: number): string {
       </div>
 
     </div>
+
+    <!-- Mobile-only award panels (below results) -->
+    {(hasRoadGpAwards || hasFellAwards) && (
+      <div class="lg:hidden mt-6 space-y-4">
+        {hasRoadGpAwards && (
+          <div class="bg-surface border border-line rounded-xl p-4">
+            <h2 class="font-head font-bold text-xs uppercase tracking-widest text-amber mb-3">
+              Road GP Awards
+            </h2>
+            <div class="space-y-1.5">
+              {awardSummary.roadGp.map(a => (
+                <div class="flex items-center gap-2 text-sm">
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" class="shrink-0 text-amber" aria-hidden="true">
+                    <path d="M3 1.5h6v3a3 3 0 0 1-6 0v-3Z" fill="currentColor"/>
+                    <path d="M2 2.5H1v1a1.5 1.5 0 0 0 1.5 1.5" stroke="currentColor" stroke-width="0.8"/>
+                    <path d="M10 2.5h1v1a1.5 1.5 0 0 1-1.5 1.5" stroke="currentColor" stroke-width="0.8"/>
+                    <path d="M4.5 8h3v1h-3z" fill="currentColor"/>
+                    <path d="M3.5 10h5v0.6h-5z" fill="currentColor"/>
+                  </svg>
+                  <span class="font-medium flex-1 text-content">{a.categoryName}</span>
+                  <span class="font-mono text-xs text-muted">
+                    {positionLabel(a.position)}{a.count > 1 ? ` ×${a.count}` : ''}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        {hasFellAwards && (
+          <div class="bg-surface border border-line rounded-xl p-4">
+            <h2 class="font-head font-bold text-xs uppercase tracking-widest text-teal mb-3">
+              Fell Awards
+            </h2>
+            <div class="space-y-1.5">
+              {awardSummary.fell.map(a => (
+                <div class="flex items-center gap-2 text-sm">
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" class="shrink-0 text-teal" aria-hidden="true">
+                    <path d="M3 1.5h6v3a3 3 0 0 1-6 0v-3Z" fill="currentColor"/>
+                    <path d="M2 2.5H1v1a1.5 1.5 0 0 0 1.5 1.5" stroke="currentColor" stroke-width="0.8"/>
+                    <path d="M10 2.5h1v1a1.5 1.5 0 0 1-1.5 1.5" stroke="currentColor" stroke-width="0.8"/>
+                    <path d="M4.5 8h3v1h-3z" fill="currentColor"/>
+                    <path d="M3.5 10h5v0.6h-5z" fill="currentColor"/>
+                  </svg>
+                  <span class="font-medium flex-1 text-content">{a.categoryName}</span>
+                  <span class="font-mono text-xs text-muted">
+                    {positionLabel(a.position)}{a.count > 1 ? ` ×${a.count}` : ''}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    )}
+
   </div>
 
 </Layout>

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -220,6 +220,9 @@ function positionLabel(pos: number): string {
                         <tr
                           data-race-id={race.raceId}
                           data-race-name={race.raceName}
+                          data-year={String(block.year)}
+                          data-time={race.time ?? ''}
+                          data-results-url={race.hasResults ? siteUrl(`/road-gp/${block.year}/${race.raceId}/results`) : ''}
                           class="border-b border-line last:border-b-0"
                         >
                           <td class="py-2 pr-3 font-mono text-xs text-muted w-10 tabular-nums align-middle">
@@ -265,6 +268,9 @@ function positionLabel(pos: number): string {
                         <tr
                           data-race-id={race.raceId}
                           data-race-name={race.raceName}
+                          data-year={String(block.year)}
+                          data-time={race.time ?? ''}
+                          data-results-url={race.hasResults ? siteUrl(`/fell/${block.year}/${race.raceId}/results`) : ''}
                           class="border-b border-line last:border-b-0"
                         >
                           <td class="py-2 pr-3 font-mono text-xs text-muted w-10 tabular-nums align-middle">
@@ -291,6 +297,19 @@ function positionLabel(pos: number): string {
             </div>
           );
         })}
+      </div>
+
+      <!-- Compact race-selected view -->
+      <div id="race-compact" class="hidden">
+        <table class="w-full text-sm border-collapse">
+          <thead>
+            <tr class="border-b-2 border-content">
+              <th class="pb-1.5 text-left font-head font-bold text-xs uppercase tracking-widest text-muted w-16">Year</th>
+              <th class="pb-1.5 text-right font-head font-bold text-xs uppercase tracking-widest text-muted">Time</th>
+            </tr>
+          </thead>
+          <tbody id="race-compact-body"></tbody>
+        </table>
       </div>
 
     </div>
@@ -356,11 +375,67 @@ function positionLabel(pos: number): string {
 <script>
   const yearSelect = document.getElementById('filter-year') as HTMLSelectElement;
   const raceSelect = document.getElementById('filter-race') as HTMLSelectElement;
+  const profileContent = document.getElementById('profile-content') as HTMLElement;
+  const raceCompact = document.getElementById('race-compact') as HTMLElement;
+  const raceCompactBody = document.getElementById('race-compact-body') as HTMLElement;
   let activeSeries = 'all';
+
+  function fmtTime(raw: string): string {
+    if (!raw) return '–';
+    const parts = raw.trim().split(':');
+    let h = 0, m = 0, s = 0;
+    if (parts.length === 2) { m = +parts[0]; s = +parts[1]; }
+    else if (parts.length === 3) { h = +parts[0]; m = +parts[1]; s = +parts[2]; }
+    else return raw;
+    const total = h * 3600 + m * 60 + s;
+    const hh = Math.floor(total / 3600);
+    const mm = Math.floor((total % 3600) / 60);
+    const ss = total % 60;
+    return hh > 0
+      ? `${hh}:${String(mm).padStart(2,'0')}:${String(ss).padStart(2,'0')}`
+      : `${mm}:${String(ss).padStart(2,'0')}`;
+  }
+
+  function buildCompactView(activeRace: string, activeYear: string) {
+    const rows = Array.from(document.querySelectorAll<HTMLElement>('tr[data-race-id]'))
+      .filter(row => {
+        const seriesDiv = row.closest<HTMLElement>('[data-series]');
+        const seriesMatch = activeSeries === 'all' || seriesDiv?.dataset.series === activeSeries;
+        const yearMatch = activeYear === '' || row.dataset.year === activeYear;
+        return row.dataset.raceId === activeRace && seriesMatch && yearMatch;
+      })
+      .sort((a, b) => Number(b.dataset.year) - Number(a.dataset.year));
+
+    raceCompactBody.innerHTML = rows.map(row => {
+      const year = row.dataset.year!;
+      const time = fmtTime(row.dataset.time ?? '');
+      const url = row.dataset.resultsUrl ?? '';
+      const yearCell = url
+        ? `<a href="${url}" class="link link-hover font-mono tabular-nums">${year}</a>`
+        : `<span class="font-mono tabular-nums text-muted">${year}</span>`;
+      const timeClass = row.dataset.time ? 'text-content' : 'text-muted';
+      return `<tr class="border-b border-line last:border-b-0">
+        <td class="py-2 pr-3 align-middle">${yearCell}</td>
+        <td class="py-2 text-right font-mono tabular-nums align-middle ${timeClass}">${time}</td>
+      </tr>`;
+    }).join('');
+  }
 
   function applyFilters() {
     const activeYear = yearSelect.value;
     const activeRace = raceSelect.value;
+
+    if (activeRace !== '') {
+      // Switch to compact view
+      profileContent.classList.add('hidden');
+      raceCompact.classList.remove('hidden');
+      buildCompactView(activeRace, activeYear);
+      return;
+    }
+
+    // Normal year-block view
+    profileContent.classList.remove('hidden');
+    raceCompact.classList.add('hidden');
 
     // Show/hide series sections
     document.querySelectorAll<HTMLElement>('[data-series]').forEach(div => {
@@ -369,16 +444,8 @@ function positionLabel(pos: number): string {
 
     // Show/hide race rows
     document.querySelectorAll<HTMLElement>('tr[data-race-id]').forEach(row => {
-      row.classList.toggle('hidden', activeRace !== '' && row.dataset.raceId !== activeRace);
+      row.classList.remove('hidden');
     });
-
-    // Hide series sections whose race rows are all hidden (only when race filter active)
-    if (activeRace !== '') {
-      document.querySelectorAll<HTMLElement>('[data-series]:not(.hidden)').forEach(div => {
-        const visibleRows = div.querySelectorAll('tr[data-race-id]:not(.hidden)');
-        if (visibleRows.length === 0) div.classList.add('hidden');
-      });
-    }
 
     // Show/hide year blocks
     document.querySelectorAll<HTMLElement>('[data-year]').forEach(block => {
@@ -428,4 +495,7 @@ function positionLabel(pos: number): string {
 
   yearSelect.addEventListener('change', () => { applyFilters(); updateRaceDropdown(); });
   raceSelect.addEventListener('change', applyFilters);
+
+  // Initialise race dropdown on page load
+  updateRaceDropdown();
 </script>

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -220,6 +220,11 @@ function positionLabel(pos: number): string {
                         <tr
                           data-race-id={race.raceId}
                           data-race-name={race.raceName}
+                          data-year={String(block.year)}
+                          data-time={race.time ?? ''}
+                          data-position={race.position != null ? String(race.position) : ''}
+                          data-total={race.totalOpen != null ? String(race.totalOpen) : ''}
+                          data-results-url={race.hasResults ? siteUrl(`/road-gp/${block.year}/${race.raceId}/results`) : ''}
                           class="border-b border-line last:border-b-0"
                         >
                           <td class="py-2 pr-3 font-mono text-xs text-muted w-10 tabular-nums align-middle">
@@ -229,6 +234,11 @@ function positionLabel(pos: number): string {
                             {race.hasResults
                               ? <a href={siteUrl(`/road-gp/${block.year}/${race.raceId}/results`)} class="link link-hover">{race.raceName}</a>
                               : <span class="text-muted">{race.raceName}</span>}
+                          </td>
+                          <td class="py-2 text-right font-mono text-xs text-muted tabular-nums align-middle whitespace-nowrap">
+                            {race.position != null && race.totalOpen != null
+                              ? `${race.position}/${race.totalOpen}`
+                              : race.position != null ? String(race.position) : ''}
                           </td>
                           <td class:list={[
                             'py-2 text-right font-mono text-sm tabular-nums align-middle',
@@ -265,6 +275,11 @@ function positionLabel(pos: number): string {
                         <tr
                           data-race-id={race.raceId}
                           data-race-name={race.raceName}
+                          data-year={String(block.year)}
+                          data-time={race.time ?? ''}
+                          data-position={race.position != null ? String(race.position) : ''}
+                          data-total={race.totalOpen != null ? String(race.totalOpen) : ''}
+                          data-results-url={race.hasResults ? siteUrl(`/fell/${block.year}/${race.raceId}/results`) : ''}
                           class="border-b border-line last:border-b-0"
                         >
                           <td class="py-2 pr-3 font-mono text-xs text-muted w-10 tabular-nums align-middle">
@@ -274,6 +289,11 @@ function positionLabel(pos: number): string {
                             {race.hasResults
                               ? <a href={siteUrl(`/fell/${block.year}/${race.raceId}/results`)} class="link link-hover">{race.raceName}</a>
                               : <span class="text-muted">{race.raceName}</span>}
+                          </td>
+                          <td class="py-2 text-right font-mono text-xs text-muted tabular-nums align-middle whitespace-nowrap">
+                            {race.position != null && race.totalOpen != null
+                              ? `${race.position}/${race.totalOpen}`
+                              : race.position != null ? String(race.position) : ''}
                           </td>
                           <td class:list={[
                             'py-2 text-right font-mono text-sm tabular-nums align-middle',
@@ -291,6 +311,20 @@ function positionLabel(pos: number): string {
             </div>
           );
         })}
+      </div>
+
+      <!-- Compact race-selected view -->
+      <div id="race-compact" class="hidden">
+        <table class="w-full text-sm border-collapse">
+          <thead>
+            <tr class="border-b-2 border-content">
+              <th class="pb-1.5 text-left font-head font-bold text-xs uppercase tracking-widest text-muted w-16">Year</th>
+              <th class="pb-1.5 text-right font-head font-bold text-xs uppercase tracking-widest text-muted pr-4">Pos</th>
+              <th class="pb-1.5 text-right font-head font-bold text-xs uppercase tracking-widest text-muted">Time</th>
+            </tr>
+          </thead>
+          <tbody id="race-compact-body"></tbody>
+        </table>
       </div>
 
     </div>
@@ -356,29 +390,81 @@ function positionLabel(pos: number): string {
 <script>
   const yearSelect = document.getElementById('filter-year') as HTMLSelectElement;
   const raceSelect = document.getElementById('filter-race') as HTMLSelectElement;
+  const profileContent = document.getElementById('profile-content') as HTMLElement;
+  const raceCompact = document.getElementById('race-compact') as HTMLElement;
+  const raceCompactBody = document.getElementById('race-compact-body') as HTMLElement;
   let activeSeries = 'all';
+
+  function formatTime(raw: string): string {
+    if (!raw) return '–';
+    const parts = raw.trim().split(':');
+    let h = 0, m = 0, s = 0;
+    if (parts.length === 2) { m = +parts[0]; s = +parts[1]; }
+    else if (parts.length === 3) { h = +parts[0]; m = +parts[1]; s = +parts[2]; }
+    else return raw;
+    const total = h * 3600 + m * 60 + s;
+    const hh = Math.floor(total / 3600);
+    const mm = Math.floor((total % 3600) / 60);
+    const ss = total % 60;
+    return hh > 0
+      ? `${hh}:${String(mm).padStart(2,'0')}:${String(ss).padStart(2,'0')}`
+      : `${mm}:${String(ss).padStart(2,'0')}`;
+  }
+
+  function buildCompactView(activeRace: string, activeYear: string) {
+    const rows = Array.from(document.querySelectorAll<HTMLElement>('tr[data-race-id]'))
+      .filter(row => {
+        const seriesDiv = row.closest<HTMLElement>('[data-series]');
+        const seriesMatch = activeSeries === 'all' || seriesDiv?.dataset.series === activeSeries;
+        const yearMatch = activeYear === '' || row.dataset.year === activeYear;
+        return row.dataset.raceId === activeRace && seriesMatch && yearMatch;
+      })
+      .sort((a, b) => Number(b.dataset.year) - Number(a.dataset.year));
+
+    raceCompactBody.innerHTML = rows.map(row => {
+      const year = row.dataset.year!;
+      const time = formatTime(row.dataset.time ?? '');
+      const url = row.dataset.resultsUrl ?? '';
+      const pos = row.dataset.position ?? '';
+      const total = row.dataset.total ?? '';
+      const posLabel = pos && total ? `${pos}/${total}` : pos || '–';
+      const yearCell = url
+        ? `<a href="${url}" class="link link-hover font-mono tabular-nums">${year}</a>`
+        : `<span class="font-mono tabular-nums text-muted">${year}</span>`;
+      const timeClass = row.dataset.time ? 'text-content' : 'text-muted';
+      return `<tr class="border-b border-line last:border-b-0">
+        <td class="py-2 pr-3 align-middle">${yearCell}</td>
+        <td class="py-2 pr-4 text-right font-mono text-xs tabular-nums align-middle text-muted">${posLabel}</td>
+        <td class="py-2 text-right font-mono tabular-nums align-middle ${timeClass}">${time}</td>
+      </tr>`;
+    }).join('');
+  }
 
   function applyFilters() {
     const activeYear = yearSelect.value;
     const activeRace = raceSelect.value;
+
+    if (activeRace !== '') {
+      // Switch to compact view
+      profileContent.classList.add('hidden');
+      raceCompact.classList.remove('hidden');
+      buildCompactView(activeRace, activeYear);
+      return;
+    }
+
+    // Normal year-block view
+    profileContent.classList.remove('hidden');
+    raceCompact.classList.add('hidden');
 
     // Show/hide series sections
     document.querySelectorAll<HTMLElement>('[data-series]').forEach(div => {
       div.classList.toggle('hidden', activeSeries !== 'all' && div.dataset.series !== activeSeries);
     });
 
-    // Show/hide race rows
+    // Show/hide race rows (no active race, so all rows visible)
     document.querySelectorAll<HTMLElement>('tr[data-race-id]').forEach(row => {
-      row.classList.toggle('hidden', activeRace !== '' && row.dataset.raceId !== activeRace);
+      row.classList.remove('hidden');
     });
-
-    // Hide series sections whose race rows are all hidden (only when race filter active)
-    if (activeRace !== '') {
-      document.querySelectorAll<HTMLElement>('[data-series]:not(.hidden)').forEach(div => {
-        const visibleRows = div.querySelectorAll('tr[data-race-id]:not(.hidden)');
-        if (visibleRows.length === 0) div.classList.add('hidden');
-      });
-    }
 
     // Show/hide year blocks
     document.querySelectorAll<HTMLElement>('[data-year]').forEach(block => {
@@ -428,4 +514,7 @@ function positionLabel(pos: number): string {
 
   yearSelect.addEventListener('change', () => { applyFilters(); updateRaceDropdown(); });
   raceSelect.addEventListener('change', applyFilters);
+
+  // Initialise race dropdown on page load
+  updateRaceDropdown();
 </script>

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -220,11 +220,6 @@ function positionLabel(pos: number): string {
                         <tr
                           data-race-id={race.raceId}
                           data-race-name={race.raceName}
-                          data-year={String(block.year)}
-                          data-time={race.time ?? ''}
-                          data-position={race.position != null ? String(race.position) : ''}
-                          data-total={race.totalOpen != null ? String(race.totalOpen) : ''}
-                          data-results-url={race.hasResults ? siteUrl(`/road-gp/${block.year}/${race.raceId}/results`) : ''}
                           class="border-b border-line last:border-b-0"
                         >
                           <td class="py-2 pr-3 font-mono text-xs text-muted w-10 tabular-nums align-middle">
@@ -234,11 +229,6 @@ function positionLabel(pos: number): string {
                             {race.hasResults
                               ? <a href={siteUrl(`/road-gp/${block.year}/${race.raceId}/results`)} class="link link-hover">{race.raceName}</a>
                               : <span class="text-muted">{race.raceName}</span>}
-                          </td>
-                          <td class="py-2 text-right font-mono text-xs text-muted tabular-nums align-middle whitespace-nowrap">
-                            {race.position != null && race.totalOpen != null
-                              ? `${race.position}/${race.totalOpen}`
-                              : race.position != null ? String(race.position) : ''}
                           </td>
                           <td class:list={[
                             'py-2 text-right font-mono text-sm tabular-nums align-middle',
@@ -275,11 +265,6 @@ function positionLabel(pos: number): string {
                         <tr
                           data-race-id={race.raceId}
                           data-race-name={race.raceName}
-                          data-year={String(block.year)}
-                          data-time={race.time ?? ''}
-                          data-position={race.position != null ? String(race.position) : ''}
-                          data-total={race.totalOpen != null ? String(race.totalOpen) : ''}
-                          data-results-url={race.hasResults ? siteUrl(`/fell/${block.year}/${race.raceId}/results`) : ''}
                           class="border-b border-line last:border-b-0"
                         >
                           <td class="py-2 pr-3 font-mono text-xs text-muted w-10 tabular-nums align-middle">
@@ -289,11 +274,6 @@ function positionLabel(pos: number): string {
                             {race.hasResults
                               ? <a href={siteUrl(`/fell/${block.year}/${race.raceId}/results`)} class="link link-hover">{race.raceName}</a>
                               : <span class="text-muted">{race.raceName}</span>}
-                          </td>
-                          <td class="py-2 text-right font-mono text-xs text-muted tabular-nums align-middle whitespace-nowrap">
-                            {race.position != null && race.totalOpen != null
-                              ? `${race.position}/${race.totalOpen}`
-                              : race.position != null ? String(race.position) : ''}
                           </td>
                           <td class:list={[
                             'py-2 text-right font-mono text-sm tabular-nums align-middle',
@@ -311,20 +291,6 @@ function positionLabel(pos: number): string {
             </div>
           );
         })}
-      </div>
-
-      <!-- Compact race-selected view -->
-      <div id="race-compact" class="hidden">
-        <table class="w-full text-sm border-collapse">
-          <thead>
-            <tr class="border-b-2 border-content">
-              <th class="pb-1.5 text-left font-head font-bold text-xs uppercase tracking-widest text-muted w-16">Year</th>
-              <th class="pb-1.5 text-right font-head font-bold text-xs uppercase tracking-widest text-muted pr-4">Pos</th>
-              <th class="pb-1.5 text-right font-head font-bold text-xs uppercase tracking-widest text-muted">Time</th>
-            </tr>
-          </thead>
-          <tbody id="race-compact-body"></tbody>
-        </table>
       </div>
 
     </div>
@@ -390,81 +356,29 @@ function positionLabel(pos: number): string {
 <script>
   const yearSelect = document.getElementById('filter-year') as HTMLSelectElement;
   const raceSelect = document.getElementById('filter-race') as HTMLSelectElement;
-  const profileContent = document.getElementById('profile-content') as HTMLElement;
-  const raceCompact = document.getElementById('race-compact') as HTMLElement;
-  const raceCompactBody = document.getElementById('race-compact-body') as HTMLElement;
   let activeSeries = 'all';
-
-  function formatTime(raw: string): string {
-    if (!raw) return '–';
-    const parts = raw.trim().split(':');
-    let h = 0, m = 0, s = 0;
-    if (parts.length === 2) { m = +parts[0]; s = +parts[1]; }
-    else if (parts.length === 3) { h = +parts[0]; m = +parts[1]; s = +parts[2]; }
-    else return raw;
-    const total = h * 3600 + m * 60 + s;
-    const hh = Math.floor(total / 3600);
-    const mm = Math.floor((total % 3600) / 60);
-    const ss = total % 60;
-    return hh > 0
-      ? `${hh}:${String(mm).padStart(2,'0')}:${String(ss).padStart(2,'0')}`
-      : `${mm}:${String(ss).padStart(2,'0')}`;
-  }
-
-  function buildCompactView(activeRace: string, activeYear: string) {
-    const rows = Array.from(document.querySelectorAll<HTMLElement>('tr[data-race-id]'))
-      .filter(row => {
-        const seriesDiv = row.closest<HTMLElement>('[data-series]');
-        const seriesMatch = activeSeries === 'all' || seriesDiv?.dataset.series === activeSeries;
-        const yearMatch = activeYear === '' || row.dataset.year === activeYear;
-        return row.dataset.raceId === activeRace && seriesMatch && yearMatch;
-      })
-      .sort((a, b) => Number(b.dataset.year) - Number(a.dataset.year));
-
-    raceCompactBody.innerHTML = rows.map(row => {
-      const year = row.dataset.year!;
-      const time = formatTime(row.dataset.time ?? '');
-      const url = row.dataset.resultsUrl ?? '';
-      const pos = row.dataset.position ?? '';
-      const total = row.dataset.total ?? '';
-      const posLabel = pos && total ? `${pos}/${total}` : pos || '–';
-      const yearCell = url
-        ? `<a href="${url}" class="link link-hover font-mono tabular-nums">${year}</a>`
-        : `<span class="font-mono tabular-nums text-muted">${year}</span>`;
-      const timeClass = row.dataset.time ? 'text-content' : 'text-muted';
-      return `<tr class="border-b border-line last:border-b-0">
-        <td class="py-2 pr-3 align-middle">${yearCell}</td>
-        <td class="py-2 pr-4 text-right font-mono text-xs tabular-nums align-middle text-muted">${posLabel}</td>
-        <td class="py-2 text-right font-mono tabular-nums align-middle ${timeClass}">${time}</td>
-      </tr>`;
-    }).join('');
-  }
 
   function applyFilters() {
     const activeYear = yearSelect.value;
     const activeRace = raceSelect.value;
-
-    if (activeRace !== '') {
-      // Switch to compact view
-      profileContent.classList.add('hidden');
-      raceCompact.classList.remove('hidden');
-      buildCompactView(activeRace, activeYear);
-      return;
-    }
-
-    // Normal year-block view
-    profileContent.classList.remove('hidden');
-    raceCompact.classList.add('hidden');
 
     // Show/hide series sections
     document.querySelectorAll<HTMLElement>('[data-series]').forEach(div => {
       div.classList.toggle('hidden', activeSeries !== 'all' && div.dataset.series !== activeSeries);
     });
 
-    // Show/hide race rows (no active race, so all rows visible)
+    // Show/hide race rows
     document.querySelectorAll<HTMLElement>('tr[data-race-id]').forEach(row => {
-      row.classList.remove('hidden');
+      row.classList.toggle('hidden', activeRace !== '' && row.dataset.raceId !== activeRace);
     });
+
+    // Hide series sections whose race rows are all hidden (only when race filter active)
+    if (activeRace !== '') {
+      document.querySelectorAll<HTMLElement>('[data-series]:not(.hidden)').forEach(div => {
+        const visibleRows = div.querySelectorAll('tr[data-race-id]:not(.hidden)');
+        if (visibleRows.length === 0) div.classList.add('hidden');
+      });
+    }
 
     // Show/hide year blocks
     document.querySelectorAll<HTMLElement>('[data-year]').forEach(block => {
@@ -514,7 +428,4 @@ function positionLabel(pos: number): string {
 
   yearSelect.addEventListener('change', () => { applyFilters(); updateRaceDropdown(); });
   raceSelect.addEventListener('change', applyFilters);
-
-  // Initialise race dropdown on page load
-  updateRaceDropdown();
 </script>


### PR DESCRIPTION
## Summary

- **Sidebar breakpoint fixed** — sidebar now only appears at `lg` (1024px+), consistent with all other pages in the site
- **Club vest images** — vest image shown next to club name in the "Competed For" panel, resolved from `clubs.json` via a new `resolveClubVest` helper
- **Responsive Competed For layout** — stacked below `xs` (375px), horizontal row from `xs`, sidebar at `lg+`
- **Award panels** — shown in sidebar at `lg+`; moved below results on mobile/tablet (`lg:hidden`)
- **Time formatting** — race times on the runner profile now use `formatTime()` for consistent `h:mm:ss` / `m:ss` display, matching the results pages

## Test plan

- [ ] Check runner profile on mobile (< 375px) — Competed For stacks, awards appear below results
- [ ] Check at 375px+ — Competed For clubs appear in a row (vest left, name/year right)
- [ ] Check at 768px (tablet) — no sidebar, competed-for panel above filter bar
- [ ] Check at 1024px+ (desktop) — sidebar visible with vest images, mobile competed-for panel hidden
- [ ] Verify race times format correctly (sub-hour as `m:ss`, over an hour as `h:mm:ss`)
- [ ] Verify vest images render for runners with known club history

🤖 Generated with [Claude Code](https://claude.com/claude-code)