### PR TITLE
fix: compact date format and narrower column on xs screens in home race list

### DIFF
--- a/src/components/home/RaceListRow.astro
+++ b/src/components/home/RaceListRow.astro
@@ -6,7 +6,7 @@
  * The client-side script in index.astro targets the data-* attributes to
  * update the Next highlight and badge dynamically — keep those in sync.
  */
-import { formatRaceDate } from '../../lib/format';
+import { formatRaceDate, formatRaceDateShort } from '../../lib/format';
 import type { Race } from '../../lib/types';
 
 interface Props {
@@ -67,9 +67,10 @@ const accentBadge = accent === 'amber' ? 'bg-amber'      : 'bg-teal';
   ]}
 >
   <!-- Date + time column -->
-  <div class="shrink-0 w-[76px]">
+  <div class="shrink-0 w-[44px] sm:w-[76px]">
     <div data-date class:list={['font-mono text-[12px]', isNext ? `${accentText} font-semibold` : 'text-muted']}>
-      {formatRaceDate(race.date)}
+      <span class="sm:hidden">{formatRaceDateShort(race.date)}</span>
+      <span class="hidden sm:inline">{formatRaceDate(race.date)}</span>
     </div>
     {race.time && (
       <div data-time class:list={['font-mono text-[11px]', isNext ? accentTime : 'text-muted/70']}>


### PR DESCRIPTION
## Summary

- On extra-small viewports (< 640px), the home page race list now shows dates as `dd/mm` instead of `Tue 15 Apr`
- The date column is narrowed from 76 px to 44 px at xs, restoring that space to the race name
- At sm+ (≥ 640 px) both revert to the full format and column width, unchanged

## Why

The race name was getting cramped on mobile because the date column was sized for the long format even when the shorter `dd/mm` format was shown. This brings the home page in line with the series detail page (`ScheduleTable.astro`), which already used the same responsive pattern.

## Files changed

- `src/components/home/RaceListRow.astro` — responsive date format + column width