### PR TITLE
feat: replace custom history page headers with standard PageHeader

### DIFF
--- a/src/components/AwardsHistoryIndividuals.astro
+++ b/src/components/AwardsHistoryIndividuals.astro
@@ -15,8 +15,6 @@ for (const cat of categories) {
   for (const row of cat.rows) allRowYears.add(row.year);
 }
 const sortedYears = [...allRowYears].sort((a, b) => a - b);
-const minYear = sortedYears[0] ?? 0;
-const maxYear = sortedYears[sortedYears.length - 1] ?? 0;
 
 // ── Category sort order ─────────────────────────────────────────────────
 const CAT_ORDER = [
@@ -133,8 +131,7 @@ const greatsM = buildGreats(mCats);
 const greatsF = buildGreats(fCats);
 
 
-const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const seriesLabel = series === 'road-gp' ? 'Road Grand Prix' : 'Fell Championship';
+
 
 // Medal colours (gold / silver / bronze)
 const MEDAL_BG = ['', 'oklch(82% 0.16 85)', 'oklch(82% 0.01 250)', 'oklch(64% 0.13 50)'];
@@ -147,28 +144,6 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
 
 </style>
 
-<!-- ── Back link + Editorial header ─────────────────────────────────────── -->
-<div class="mb-2">
-  <a href={`${base}/${series}/`} class="inline-flex items-center gap-1 text-sm text-muted hover:text-content transition-colors font-mono mb-5">
-    ← {seriesLabel}
-  </a>
-
-  <div class="border-b border-line pb-6">
-    <div class="font-head text-[10px] font-bold tracking-[0.18em] uppercase text-amber mb-1.5">The Roll of Honour</div>
-    <h1 class="font-head font-black text-[clamp(2.5rem,6vw,5rem)] tracking-tight leading-none">Individual Winners</h1>
-    <div class="font-head font-black text-[clamp(2.5rem,6vw,5rem)] tracking-tight leading-none text-amber">{minYear}–{maxYear}</div>
-  </div>
-</div>
-
-<!-- ── Tab bar ─────────────────────────────────────────────────────────── -->
-<div class="tabs tabs-border mb-6">
-  <a href={`${base}/${series}/history/teams`} class="tab font-head font-bold tracking-[0.06em] uppercase">
-    Team Winners
-  </a>
-  <a href={`${base}/${series}/history/individuals`} class="tab tab-active font-head font-bold tracking-[0.06em] uppercase">
-    Individual Winners
-  </a>
-</div>
 
 {categories.length === 0 ? (
   <p class="text-content/60">No individual awards recorded.</p>
@@ -225,7 +200,7 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
 
     <!-- ── Sex toggle + chips (mobile — full-bleed) ───────────────────── -->
     <div class="sm:hidden -mx-4 mb-2">
-      <div class="flex items-center gap-3 px-4 py-3 bg-surface border-b border-line">
+      <div class="flex items-center justify-center gap-3 px-4 py-3 bg-surface border-b border-line">
         <div class="inline-flex gap-1">
           {hasM && (
             <button

--- a/src/components/AwardsHistoryTeams.astro
+++ b/src/components/AwardsHistoryTeams.astro
@@ -118,46 +118,15 @@ for (const cat of allCategories) {
     .sort((a, b) => b.count - a.count);
 }
 
-// ── Header stats ──────────────────────────────────────────────────────────
-const allYears = dataRows.map(r => r.year);
-const minYear = allYears.length ? Math.min(...allYears) : 0;
-const maxYear = allYears.length ? Math.max(...allYears) : 0;
 const seasonCount = dataRows.length;
 const clubsWon = sortedClubs.length;
-
-
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const seriesLabel = series === 'road-gp' ? 'Road Grand Prix' : 'Fell Championship';
 ---
 
 <style>
   .th-cat-panel.is-hidden { display: none; }
 </style>
 
-<!-- ── Editorial header ─────────────────────────────────────────────────── -->
-<div class="mb-2">
-  <a href={`${base}/${series}/`} class="inline-flex items-center gap-1 text-sm text-muted hover:text-content transition-colors font-mono mb-5">
-    ← {seriesLabel}
-  </a>
-
-  <div class="flex items-end justify-between gap-6 flex-wrap border-b border-line pb-6 mb-0">
-    <div>
-      <div class="font-head text-[10px] font-bold tracking-[0.18em] uppercase text-amber mb-1.5">The Roll of Honour</div>
-      <h1 class="font-head font-black text-[clamp(2.5rem,6vw,5rem)] tracking-tight leading-none">Team Winners</h1>
-      <div class="font-head font-black text-[clamp(2.5rem,6vw,5rem)] tracking-tight leading-none text-amber">{minYear}–{maxYear}</div>
-    </div>
-  </div>
-</div>
-
-<!-- ── Tab bar ───────────────────────────────────────────────────────────── -->
-<div class="tabs tabs-border mb-6">
-  <a href={`${base}/${series}/history/teams`} class="tab tab-active font-head font-bold tracking-[0.06em] uppercase">
-    Team Winners
-  </a>
-  <a href={`${base}/${series}/history/individuals`} class="tab font-head font-bold tracking-[0.06em] uppercase">
-    Individual Winners
-  </a>
-</div>
 
 <!-- ══════════════════════════════════════════════════════════════════════
      MOBILE VIEW — category chip + streak timeline  (hidden md+)

--- a/src/pages/fell/history/[type].astro
+++ b/src/pages/fell/history/[type].astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../../../components/Layout.astro';
+import PageHeader from '../../../components/PageHeader.astro';
 import AwardsHistoryTeams from '../../../components/AwardsHistoryTeams.astro';
 import AwardsHistoryIndividuals from '../../../components/AwardsHistoryIndividuals.astro';
 import { getAllAwardsByYear, getAllSeriesConfigs, pivotIndividualAwardsByCategory, resolveIndividualCategoryName } from '../../../lib/results';
@@ -171,9 +172,35 @@ if (type === 'individuals') {
   });
   categoryData = pivotIndividualAwardsByCategory(yearlyResolved);
 }
+const historyBase = import.meta.env.BASE_URL.replace(/\/$/, '');
+const historySeriesLabel = series === 'road-gp' ? 'Road Grand Prix' : 'Fell Championship';
+const historyYears = type === 'individuals'
+  ? categoryData.flatMap(c => c.rows.map(r => r.year))
+  : fullYearList.map(y => y.year);
+const historyMin = historyYears.length ? Math.min(...historyYears) : 0;
+const historyMax = historyYears.length ? Math.max(...historyYears) : 0;
+const historyYearRange = historyMin && historyMax ? `${historyMin}–${historyMax}` : '';
 ---
 
 <Layout title={pageTitle}>
+  <PageHeader
+    slot="hero"
+    eyebrow="The Roll of Honour"
+    title={type === 'teams' ? 'Team Winners' : 'Individual Winners'}
+    subtitleParts={historyYearRange ? [historySeriesLabel, historyYearRange] : [historySeriesLabel]}
+  >
+    <div class="flex">
+      <a
+        href={`${historyBase}/${series}/history/teams`}
+        class={`flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 -mb-px text-center md:text-left transition-colors ${type === 'teams' ? 'border-amber text-hdr-text' : 'border-transparent text-hdr-muted hover:text-hdr-text'}`}
+      >Team Winners</a>
+      <a
+        href={`${historyBase}/${series}/history/individuals`}
+        class={`flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 -mb-px text-center md:text-left transition-colors ${type === 'individuals' ? 'border-amber text-hdr-text' : 'border-transparent text-hdr-muted hover:text-hdr-text'}`}
+      >Individual Winners</a>
+    </div>
+  </PageHeader>
+
   {type === 'teams' ? (
     <AwardsHistoryTeams
       series={series}

--- a/src/pages/road-gp/history/[type].astro
+++ b/src/pages/road-gp/history/[type].astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../../../components/Layout.astro';
+import PageHeader from '../../../components/PageHeader.astro';
 import AwardsHistoryTeams from '../../../components/AwardsHistoryTeams.astro';
 import AwardsHistoryIndividuals from '../../../components/AwardsHistoryIndividuals.astro';
 import { getAllAwardsByYear, getAllSeriesConfigs, pivotIndividualAwardsByCategory, resolveIndividualCategoryName } from '../../../lib/results';
@@ -182,9 +183,35 @@ if (type === 'individuals') {
   });
   categoryData = pivotIndividualAwardsByCategory(yearlyResolved);
 }
+const historyBase = import.meta.env.BASE_URL.replace(/\/$/, '');
+const historySeriesLabel = series === 'road-gp' ? 'Road Grand Prix' : 'Fell Championship';
+const historyYears = type === 'individuals'
+  ? categoryData.flatMap(c => c.rows.map(r => r.year))
+  : fullYearList.map(y => y.year);
+const historyMin = historyYears.length ? Math.min(...historyYears) : 0;
+const historyMax = historyYears.length ? Math.max(...historyYears) : 0;
+const historyYearRange = historyMin && historyMax ? `${historyMin}–${historyMax}` : '';
 ---
 
 <Layout title={pageTitle}>
+  <PageHeader
+    slot="hero"
+    eyebrow="The Roll of Honour"
+    title={type === 'teams' ? 'Team Winners' : 'Individual Winners'}
+    subtitleParts={historyYearRange ? [historySeriesLabel, historyYearRange] : [historySeriesLabel]}
+  >
+    <div class="flex">
+      <a
+        href={`${historyBase}/${series}/history/teams`}
+        class={`flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 -mb-px text-center md:text-left transition-colors ${type === 'teams' ? 'border-amber text-hdr-text' : 'border-transparent text-hdr-muted hover:text-hdr-text'}`}
+      >Team Winners</a>
+      <a
+        href={`${historyBase}/${series}/history/individuals`}
+        class={`flex-1 md:flex-none font-head text-[13px] font-bold tracking-[0.06em] uppercase py-2.5 md:mr-7 border-b-2 -mb-px text-center md:text-left transition-colors ${type === 'individuals' ? 'border-amber text-hdr-text' : 'border-transparent text-hdr-muted hover:text-hdr-text'}`}
+      >Individual Winners</a>
+    </div>
+  </PageHeader>
+
   {type === 'teams' ? (
     <AwardsHistoryTeams
       series={series}


### PR DESCRIPTION
## Summary

- Removes the bespoke editorial headers and tab bars from `AwardsHistoryIndividuals` and `AwardsHistoryTeams` components
- Adds the standard `PageHeader` component (`slot="hero"`) to both `road-gp` and `fell` history pages, matching the styling of other detail pages (individual standings, team standings, etc.)
- Header shows: "The Roll of Honour" eyebrow, "Team/Individual Winners" title, series name and year range subtitle, and Team/Individual Winners tab strip
- Centres the Men/Women toggle on the mobile chip bar

## Test plan

- [ ] Visit `/road-gp/history/individuals` — verify dark PageHeader with correct title, eyebrow, year range, and active tab
- [ ] Visit `/road-gp/history/teams` — same checks, Team Winners active tab
- [ ] Visit `/fell/history/individuals` and `/fell/history/teams` — same checks with Fell Championship label
- [ ] On mobile (< 640px) verify Men/Women toggle is centred
- [ ] Confirm no double headers appear on any of the four pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)