### PR TITLE
fix: revert 2026 Road GP team category ids to match historical convention

### DIFF
--- a/src/data/2026/road-gp/config.json
+++ b/src/data/2026/road-gp/config.json
@@ -38,21 +38,21 @@
       "eligibility": "Men 40+, Women 35+"
     },
     {
-      "id": "fv40",
+      "id": "lady-vets",
       "name": "Lady Vets",
       "shortName": "LVT",
       "scorerCount": 5,
       "eligibility": "Women 40+"
     },
     {
-      "id": "vet50s",
+      "id": "v50",
       "name": "Vet 50s",
       "shortName": "V50",
       "scorerCount": 4,
       "eligibility": "Men & Women 50+"
     },
     {
-      "id": "vet60s",
+      "id": "v60",
       "name": "Vet 60s",
       "shortName": "V60",
       "scorerCount": 3,

--- a/src/data/2026/road-gp/results/blackpool-teams.json
+++ b/src/data/2026/road-gp/results/blackpool-teams.json
@@ -542,7 +542,7 @@
                                      ]
                        },
                        {
-                           "id":  "fv40",
+                           "id":  "lady-vets",
                            "clubs":  [
                                          {
                                              "position":  1,
@@ -968,7 +968,7 @@
                                      ]
                        },
                        {
-                           "id":  "vet50s",
+                           "id":  "v50",
                            "clubs":  [
                                          {
                                              "position":  1,
@@ -1141,7 +1141,7 @@
                                      ]
                        },
                        {
-                           "id":  "vet60s",
+                           "id":  "v60",
                            "clubs":  [
                                          {
                                              "position":  1,

--- a/src/data/2026/road-gp/results/blackpool.csv
+++ b/src/data/2026/road-gp/results/blackpool.csv
@@ -1,4 +1,4 @@
-position,cat_open,cat_vets,cat_vet50s,cat_vet60s,cat_ladies,cat_fv40,race_number,first_name,last_name,club,age_category,sex,time,series_runner_id
+position,cat_open,cat_vets,cat_v50,cat_v60,cat_ladies,cat_lady-vets,race_number,first_name,last_name,club,age_category,sex,time,series_runner_id
 1,1,,,,,,55,Luke,Minns,blackpool,V35,M,19:35,100
 2,2,,,,,,366,Rob,Danson,preston,V35,M,19:37,101
 3,3,,,,,,19,Jude,Cowan,blackpool,SEN,M,20:32,102

--- a/src/data/2026/road-gp/results/lytham-provisional.csv
+++ b/src/data/2026/road-gp/results/lytham-provisional.csv
@@ -1,4 +1,4 @@
-position,cat_open,cat_vets,cat_vet50s,cat_vet60s,cat_ladies,cat_fv40,race_number,first_name,last_name,club,age_category,sex,time,series_runner_id
+position,cat_open,cat_vets,cat_v50,cat_v60,cat_ladies,cat_lady-vets,race_number,first_name,last_name,club,age_category,sex,time,series_runner_id
 1,1,,,,,,366,Rob,Danson,preston,V35,M,25:07,101
 2,2,,,,,,305,Mike,Toft,lytham,V35,M,25:47,103
 3,3,1,,,,,308,Andrew,Coley-Maud,lytham,V40,M,26:11,511

--- a/src/data/2026/road-gp/results/lytham-teams-provisional.json
+++ b/src/data/2026/road-gp/results/lytham-teams-provisional.json
@@ -543,7 +543,7 @@
                                      ]
                        },
                        {
-                           "id":  "fv40",
+                           "id":  "lady-vets",
                            "clubs":  [
                                          {
                                              "position":  1,
@@ -969,7 +969,7 @@
                                      ]
                        },
                        {
-                           "id":  "vet50s",
+                           "id":  "v50",
                            "clubs":  [
                                          {
                                              "position":  1,
@@ -1142,7 +1142,7 @@
                                      ]
                        },
                        {
-                           "id":  "vet60s",
+                           "id":  "v60",
                            "clubs":  [
                                          {
                                              "position":  1,

--- a/src/data/2026/road-gp/results/preston-teams.json
+++ b/src/data/2026/road-gp/results/preston-teams.json
@@ -919,7 +919,7 @@
                                      ]
                        },
                        {
-                           "id":  "fv40",
+                           "id":  "lady-vets",
                            "clubs":  [
                                          {
                                              "position":  1,
@@ -1135,7 +1135,7 @@
                                      ]
                        },
                        {
-                           "id":  "vet50s",
+                           "id":  "v50",
                            "clubs":  [
                                          {
                                              "position":  1,
@@ -1336,7 +1336,7 @@
                                      ]
                        },
                        {
-                           "id":  "vet60s",
+                           "id":  "v60",
                            "clubs":  [
                                          {
                                              "position":  1,

--- a/src/data/2026/road-gp/results/preston.csv
+++ b/src/data/2026/road-gp/results/preston.csv
@@ -1,4 +1,4 @@
-﻿position,cat_open,cat_ladies,cat_fv40,cat_vet50s,cat_vet60s,cat_vets,race_number,first_name,last_name,club,age_category,sex,time,series_runner_id
+﻿position,cat_open,cat_ladies,cat_lady-vets,cat_v50,cat_v60,cat_vets,race_number,first_name,last_name,club,age_category,sex,time,series_runner_id
 1,1,,,,,,366,Rob,Danson,preston,V35,M,00:21:23,101
 2,2,,,,,,372,Sam,Evans,preston,SEN,M,00:21:43,645
 3,3,,,,,,1022,Max,Swarbrick,wesham,U23,M,00:22:29,104

--- a/src/data/2026/road-gp/results/thornton-teams.json
+++ b/src/data/2026/road-gp/results/thornton-teams.json
@@ -919,7 +919,7 @@
                                      ]
                        },
                        {
-                           "id":  "fv40",
+                           "id":  "lady-vets",
                            "clubs":  [
                                          {
                                              "position":  1,
@@ -1130,7 +1130,7 @@
                                      ]
                        },
                        {
-                           "id":  "vet50s",
+                           "id":  "v50",
                            "clubs":  [
                                          {
                                              "position":  1,
@@ -1331,7 +1331,7 @@
                                      ]
                        },
                        {
-                           "id":  "vet60s",
+                           "id":  "v60",
                            "clubs":  [
                                          {
                                              "position":  1,

--- a/src/data/2026/road-gp/results/thornton.csv
+++ b/src/data/2026/road-gp/results/thornton.csv
@@ -1,4 +1,4 @@
-position,cat_open,cat_ladies,cat_fv40,cat_vet50s,cat_vet60s,cat_vets,race_number,first_name,last_name,club,age_category,sex,time,series_runner_id
+position,cat_open,cat_ladies,cat_lady-vets,cat_v50,cat_v60,cat_vets,race_number,first_name,last_name,club,age_category,sex,time,series_runner_id
 1,1,,,,,,55,Luke,Minns,blackpool,V35,M,00:25:57,100
 2,2,,,,,,1022,Max,Swarbrick,wesham,U23,M,00:26:28,104
 3,3,,,,,,305,Mike,Toft,lytham,V35,M,00:26:37,103

--- a/src/data/2026/road-gp/team-standings.json
+++ b/src/data/2026/road-gp/team-standings.json
@@ -275,7 +275,7 @@
                                      ]
                        },
                        {
-                           "id":  "fv40",
+                           "id":  "lady-vets",
                            "clubs":  [
                                          {
                                              "position":  1,
@@ -364,7 +364,7 @@
                                      ]
                        },
                        {
-                           "id":  "vet50s",
+                           "id":  "v50",
                            "clubs":  [
                                          {
                                              "position":  1,
@@ -453,7 +453,7 @@
                                      ]
                        },
                        {
-                           "id":  "vet60s",
+                           "id":  "v60",
                            "clubs":  [
                                          {
                                              "position":  1,


### PR DESCRIPTION
## Summary
- 2026's Road GP `config.json` had renamed team category ids `lady-vets`→`fv40`, `v50`→`vet50s`, `v60`→`vet60s`, diverging from every other year (2004–2025) and from the Fell series, which still uses `lady-vets`/`v50`/`v60`.
- This divergence is the same class of bug already fixed in `preston.csv`/`thornton.csv` (category id/column mismatches), so it's reverted here to eliminate the ongoing risk.
- Reverts ids in `config.json`, all four 2026 results CSVs (`cat_fv40`→`cat_lady-vets`, `cat_vet50s`→`cat_v50`, `cat_vet60s`→`cat_v60`), all four `*-teams*.json` files, and `team-standings.json`. Display names/shortNames ("Lady Vets", "Vet 50s", "Vet 60s", "V50", "V60") are unchanged — this is purely an id realignment.

## Test plan
- [x] `npm run build` completes successfully (1523 pages built, no errors)
- [x] Verified no remaining references to `fv40`, `vet50s`, or `vet60s` anywhere under `src/data/2026/road-gp/`
- [x] Verified all `-teams*.json` and `team-standings.json` category ids match `config.json` team category ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)