### PR TITLE
fix: award category ids and individual-winners history gaps

### DIFF
--- a/src/components/AwardsHistoryIndividuals.astro
+++ b/src/components/AwardsHistoryIndividuals.astro
@@ -5,9 +5,11 @@ import { siteUrl } from '../lib/url';
 interface Props {
   series: string;
   categories: CategoryHistoryData[];
+  linkedYears?: Set<number>;
 }
 
-const { series, categories } = Astro.props;
+const { series, categories, linkedYears = new Set<number>() } = Astro.props;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 // ── Year range & stats ──────────────────────────────────────────────────
 const allRowYears = new Set<number>();
@@ -272,7 +274,6 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                   <div class="font-head text-[10px] font-bold tracking-[0.14em] uppercase text-muted mb-0.5">
                     {sexLabel} · {label}
                   </div>
-                  <h2 class="font-head text-2xl font-black tracking-tight">The podium, year by year</h2>
                 </div>
               </div>
 
@@ -305,12 +306,24 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                         </tr>
                       </thead>
                       <tbody>
-                        {rows.map(row => {
+                        {rows.map(row => row.suspended ? (
+                          <tr class="border-b border-line last:border-0 bg-canvas/60">
+                            <td class="py-2 pl-4 pr-3 font-mono text-sm font-medium border-r border-line whitespace-nowrap align-middle text-muted">
+                              {row.year}
+                            </td>
+                            <td colspan={3} class="py-2 px-3 font-mono text-[11px] text-muted italic tracking-wide text-center">
+                              {row.suspended}
+                            </td>
+                          </tr>
+                        ) : (() => {
                           const hasAny = row.positions[1] || row.positions[2] || row.positions[3];
                           return (
                             <tr class={`border-b border-line last:border-0${!hasAny ? ' opacity-40' : ''}`}>
-                              <td class="py-2 pl-4 pr-3 font-mono text-sm font-medium border-r border-line whitespace-nowrap align-middle text-muted">
-                                {row.year}
+                              <td class="py-2 pl-4 pr-3 font-mono text-sm font-medium border-r border-line whitespace-nowrap align-middle">
+                                {linkedYears.has(row.year)
+                                  ? <a href={`${base}/${series}/${row.year}/`} class="hover:text-amber transition-colors">{row.year}</a>
+                                  : <span class="text-muted">{row.year}</span>
+                                }
                               </td>
                               {([1, 2, 3] as const).map(pos => {
                                 const entry = row.positions[pos];
@@ -344,7 +357,7 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                               })}
                             </tr>
                           );
-                        })}
+                        })())}
                       </tbody>
                     </table>
                   </div>
@@ -456,7 +469,11 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                     return (
                       <div class="bg-surface border border-line rounded-xl overflow-hidden">
                         <div class="flex items-baseline px-3.5 py-2 border-b border-line bg-canvas">
-                          <span class="font-head text-lg font-black tracking-tight">{row.year}</span>
+                          {linkedYears.has(row.year) ? (
+                            <a href={`${base}/${series}/${row.year}/`} class="font-head text-lg font-black tracking-tight hover:text-amber transition-colors">{row.year}</a>
+                          ) : (
+                            <span class="font-head text-lg font-black tracking-tight">{row.year}</span>
+                          )}
                         </div>
                         <div>
                           {([1, 2, 3] as const).map(pos => {

--- a/src/data/2017/fell/awards.json
+++ b/src/data/2017/fell/awards.json
@@ -116,7 +116,7 @@
     },
     {
       "club": "chorley",
-      "id": "v40"
+      "id": "vets"
     },
     {
       "club": "preston",

--- a/src/data/2018/fell/awards.json
+++ b/src/data/2018/fell/awards.json
@@ -1,23 +1,23 @@
 {
   "teamAwards": [
     {
-      "id": "overall",
+      "id": "open",
       "club": "preston"
     },
     {
-      "id": "m40",
+      "id": "vets",
       "club": "preston"
     },
     {
-      "id": "m50",
+      "id": "v50",
       "club": "preston"
     },
     {
-      "id": "m60",
+      "id": "v60",
       "club": "preston"
     },
     {
-      "id": "women",
+      "id": "ladies",
       "club": "red-rose"
     }
   ],

--- a/src/data/2019/fell/awards.json
+++ b/src/data/2019/fell/awards.json
@@ -1,11 +1,11 @@
 {
   "teamAwards": [
     {
-      "id": "overall",
+      "id": "open",
       "club": "preston"
     },
     {
-      "id": "v40",
+      "id": "vets",
       "club": "preston"
     },
     {
@@ -17,7 +17,7 @@
       "club": "preston"
     },
     {
-      "id": "women",
+      "id": "ladies",
       "club": "red-rose"
     }
   ],

--- a/src/data/2023/fell/awards.json
+++ b/src/data/2023/fell/awards.json
@@ -1,29 +1,29 @@
 {
   "teamAwards": [
     {
-      "id": "overall",
+      "id": "open",
       "club": "chorley"
     },
     {
-      "id": "m40",
-      "club": "chorley"
-    },
-    {
-      "id": "m50",
-      "club": "chorley"
-    },
-    {
-      "id": "m60",
+      "id": "ladies",
       "club": "red-rose"
     },
     {
-      "id": "women",
+      "id": "vets",
+      "club": "chorley"
+    },
+    {
+      "id": "v50",
+      "club": "chorley"
+    },
+    {
+      "id": "v60",
       "club": "red-rose"
     }
   ],
   "individualAwards": [
     {
-      "id": "m-sen",
+      "id": "m",
       "awards": [
         {
           "position": 1,
@@ -40,8 +40,7 @@
           "seriesRunnerId": 135
         }
       ],
-      "sex": "M",
-      "ageCategory": "SEN"
+      "sex": "M"
     },
     {
       "id": "m-v40",
@@ -107,7 +106,7 @@
       "ageCategory": "V60"
     },
     {
-      "id": "f-sen",
+      "id": "f",
       "awards": [
         {
           "position": 1,
@@ -124,8 +123,7 @@
           "seriesRunnerId": 116
         }
       ],
-      "sex": "F",
-      "ageCategory": "SEN"
+      "sex": "F"
     },
     {
       "id": "f-v40",

--- a/src/data/2023/road-gp/awards.json
+++ b/src/data/2023/road-gp/awards.json
@@ -1,5 +1,30 @@
 {
-  "teamAwards": [],
+  "teamAwards": [
+    {
+      "id": "open",
+      "club": "blackpool"
+    },
+    {
+      "id": "ladies",
+      "club": "preston"
+    },
+    {
+      "id": "vets",
+      "club": "preston"
+    },
+    {
+      "id": "lady-vets",
+      "club": "blackpool"
+    },
+    {
+      "id": "v50",
+      "club": "preston"
+    },
+    {
+      "id": "v60",
+      "club": "red-rose"
+    }
+  ],
   "individualAwards": [
     {
       "id": "f",

--- a/src/lib/awardsHistory.ts
+++ b/src/lib/awardsHistory.ts
@@ -153,6 +153,11 @@ export function buildTeamHistory(
 
 export function buildIndividualHistoryData(series: Series): CategoryHistoryData[] {
   const allYearlyAwards = getAllAwardsByYear(series);
+  const noteByYear = new Map(
+    getAllSeriesConfigs(series)
+      .filter(({ config }) => !!config.note)
+      .map(({ year, config }) => [year, config.note!])
+  );
   const yearlyResolved = allYearlyAwards.map(yearly => {
     const runnerUrlMap = buildRunnerUrlMap(yearly.year, series);
     return {
@@ -171,5 +176,5 @@ export function buildIndividualHistoryData(series: Series): CategoryHistoryData[
       })),
     };
   });
-  return pivotIndividualAwardsByCategory(yearlyResolved);
+  return pivotIndividualAwardsByCategory(yearlyResolved, noteByYear);
 }

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -425,6 +425,7 @@ export interface CategoryHistoryEntry {
 
 export interface CategoryHistoryRow {
   year: number;
+  suspended?: string;
   positions: {
     1: CategoryHistoryEntry | null;
     2: CategoryHistoryEntry | null;
@@ -481,7 +482,8 @@ export function resolveSeriesAwards(
 }
 
 export function pivotIndividualAwardsByCategory(
-  yearlyData: YearlyResolvedIndividual[]
+  yearlyData: YearlyResolvedIndividual[],
+  noteByYear: Map<number, string> = new Map()
 ): CategoryHistoryData[] {
   const categoryMap = new Map<string, { name: string; sex: 'M' | 'F' | null }>();
   for (const yearly of yearlyData) {
@@ -509,6 +511,20 @@ export function pivotIndividualAwardsByCategory(
           },
         };
       });
+
+    // Fill in years between this category's first and last instance so gaps
+    // (e.g. a year the award wasn't recorded) still render as an empty row.
+    if (rows.length > 0) {
+      const presentYears = new Set(rows.map(r => r.year));
+      const minYear = Math.min(...rows.map(r => r.year));
+      const maxYear = Math.max(...rows.map(r => r.year));
+      for (let year = minYear; year <= maxYear; year++) {
+        if (!presentYears.has(year)) {
+          rows.push({ year, suspended: noteByYear.get(year), positions: { 1: null, 2: null, 3: null } });
+        }
+      }
+    }
+
     return { id, name: meta.name, sex: meta.sex, rows };
   });
 }

--- a/src/pages/[series]/history/[type].astro
+++ b/src/pages/[series]/history/[type].astro
@@ -66,6 +66,6 @@ const historyYearRange = historyMin && historyMax ? `${historyMin}–${historyMa
       linkedYears={new Set(getAvailableYears(series))}
     />
   ) : (
-    <AwardsHistoryIndividuals series={series} categories={categoryData} />
+    <AwardsHistoryIndividuals series={series} categories={categoryData} linkedYears={new Set(getAvailableYears(series))} />
   )}
 </Layout>

--- a/tests/lib/results.test.ts
+++ b/tests/lib/results.test.ts
@@ -240,7 +240,7 @@ describe('pivotIndividualAwardsByCategory', () => {
     expect(result[0].rows[0].positions[3]).toBeNull();
   });
 
-  it('omits years that have no entry for a category', () => {
+  it('fills gap years between a category\'s first and last instance with an empty row', () => {
     const input = [
       {
         year: 2024,
@@ -256,8 +256,29 @@ describe('pivotIndividualAwardsByCategory', () => {
       },
     ];
     const result = pivotIndividualAwardsByCategory(input);
-    expect(result[0].rows).toHaveLength(2);
-    expect(result[0].rows.map(r => r.year)).toEqual([2024, 2022]);
+    expect(result[0].rows).toHaveLength(3);
+    expect(result[0].rows.map(r => r.year).sort()).toEqual([2022, 2023, 2024]);
+    const gapRow = result[0].rows.find(r => r.year === 2023)!;
+    expect(gapRow.positions).toEqual({ 1: null, 2: null, 3: null });
+  });
+
+  it('does not add years outside a category\'s first-to-last range', () => {
+    const input = [
+      {
+        year: 2024,
+        categories: [{ id: 'sen-m', name: 'Senior Men', sex: 'M' as const, awards: [{ position: 1, name: 'A', clubName: 'X' }] }],
+      },
+      {
+        year: 2022,
+        categories: [{ id: 'sen-m', name: 'Senior Men', sex: 'M' as const, awards: [{ position: 1, name: 'B', clubName: 'Y' }] }],
+      },
+      {
+        year: 2020,
+        categories: [], // before the category's range -- should not appear
+      },
+    ];
+    const result = pivotIndividualAwardsByCategory(input);
+    expect(result[0].rows.map(r => r.year).sort()).toEqual([2022, 2023, 2024]);
   });
 
   it('preserves the input year order (caller is responsible for sorting)', () => {


### PR DESCRIPTION
## Summary
- Fixed team/individual award category id mismatches for 2017, 2018, 2019, and 2023 fell (`overall`/`m40`/`m50`/`m60`/`women`/`m-sen`/`f-sen` didn't match `config.json`'s `teamCategories` ids or the "Overall" convention used by other years), which were causing missing cells in both the team-winners and individual-winners history tables.
- Populated 2023 road GP's empty `teamAwards` from the position-1 winner of each category in the completed `team-standings.json`.
- Brought the individual-winners "podium, year by year" table in line with the team-winners table: gap years within a category's active range now render as an empty row instead of being omitted, suspended seasons (e.g. COVID-19) show the same notice, year cells link to the season overview page, and matched the year-link text color/styling.
- Removed the redundant "The podium, year by year" section heading.

## Test plan
- [x] `npm test` passes (518 passed, 174 skipped)
- [x] `npm run build` completes with no errors (1700 pages built)
- [x] Verified in the browser preview: 2023 fell "Overall" now shows the correct winners, COVID-suspended years show the notice, and year links navigate to the correct season page with consistent styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)