### PR TITLE
data: link 2023 road GP individual standings to series runner ids

### DIFF
--- a/src/data/2023/road-gp/individual-standings.json
+++ b/src/data/2023/road-gp/individual-standings.json
@@ -42,7 +42,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  108
                                            },
                                            {
                                                "position":  2,
@@ -78,7 +79,8 @@
                                                                                 "points":  5,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  116
                                            },
                                            {
                                                "position":  3,
@@ -102,7 +104,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  599
                                            },
                                            {
                                                "position":  4,
@@ -130,7 +133,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  180
                                            },
                                            {
                                                "position":  5,
@@ -158,7 +162,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  550
                                            },
                                            {
                                                "position":  6,
@@ -174,7 +179,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  654
                                            },
                                            {
                                                "position":  7,
@@ -190,7 +196,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  567
                                            },
                                            {
                                                "position":  8,
@@ -206,7 +213,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  223
                                            },
                                            {
                                                "position":  9,
@@ -218,7 +226,8 @@
                                                                                "points":  4,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  580
                                            },
                                            {
                                                "position":  10,
@@ -230,7 +239,8 @@
                                                                                "points":  5,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  588
                                            },
                                            {
                                                "position":  11,
@@ -242,7 +252,8 @@
                                                                                  "points":  5,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  259
                                            }
                                        ]
                        },
@@ -277,7 +288,8 @@
                                                                                "points":  2,
                                                                                "counting":  false
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  196
                                            },
                                            {
                                                "position":  2,
@@ -305,7 +317,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  499
                                            },
                                            {
                                                "position":  3,
@@ -325,7 +338,8 @@
                                                                               "points":  3,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  288
                                            },
                                            {
                                                "position":  4,
@@ -337,7 +351,8 @@
                                                                                "points":  1,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  656
                                            },
                                            {
                                                "position":  5,
@@ -349,7 +364,8 @@
                                                                                  "points":  2,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  210
                                            }
                                        ]
                        },
@@ -384,7 +400,8 @@
                                                                                "points":  1,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  101
                                            },
                                            {
                                                "position":  2,
@@ -413,7 +430,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  105
                                            },
                                            {
                                                "position":  3,
@@ -446,7 +464,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  470
                                            },
                                            {
                                                "position":  4,
@@ -479,7 +498,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  107
                                            },
                                            {
                                                "position":  5,
@@ -512,7 +532,8 @@
                                                                                "points":  4,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  106
                                            },
                                            {
                                                "position":  6,
@@ -541,7 +562,8 @@
                                                                                 "points":  5,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  108
                                            },
                                            {
                                                "position":  7,
@@ -566,7 +588,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  111
                                            },
                                            {
                                                "position":  8,
@@ -599,7 +622,8 @@
                                                                                "points":  5,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  122
                                            },
                                            {
                                                "position":  9,
@@ -628,7 +652,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  118
                                            },
                                            {
                                                "position":  10,
@@ -661,7 +686,8 @@
                                                                                 "points":  12,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  113
                                            },
                                            {
                                                "position":  11,
@@ -698,7 +724,8 @@
                                                                                 "points":  60,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  116
                                            },
                                            {
                                                "position":  12,
@@ -735,7 +762,8 @@
                                                                                 "points":  13,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  119
                                            },
                                            {
                                                "position":  13,
@@ -768,7 +796,8 @@
                                                                                 "points":  9,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  112
                                            },
                                            {
                                                "position":  14,
@@ -805,7 +834,8 @@
                                                                                 "points":  14,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  115
                                            },
                                            {
                                                "position":  15,
@@ -830,7 +860,8 @@
                                                                               "points":  4,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  121
                                            },
                                            {
                                                "position":  16,
@@ -863,7 +894,8 @@
                                                                                "points":  16,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  110
                                            },
                                            {
                                                "position":  17,
@@ -892,7 +924,8 @@
                                                                                 "points":  10,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  478
                                            },
                                            {
                                                "position":  18,
@@ -921,7 +954,8 @@
                                                                                 "points":  15,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  473
                                            },
                                            {
                                                "position":  19,
@@ -950,7 +984,8 @@
                                                                                 "points":  30,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  117
                                            },
                                            {
                                                "position":  20,
@@ -987,7 +1022,8 @@
                                                                                 "points":  31,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  135
                                            },
                                            {
                                                "position":  21,
@@ -1020,7 +1056,8 @@
                                                                                 "points":  19,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  130
                                            },
                                            {
                                                "position":  22,
@@ -1053,7 +1090,8 @@
                                                                                 "points":  23,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  136
                                            },
                                            {
                                                "position":  23,
@@ -1090,7 +1128,8 @@
                                                                                 "points":  26,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  124
                                            },
                                            {
                                                "position":  24,
@@ -1119,7 +1158,8 @@
                                                                                 "points":  17,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  128
                                            },
                                            {
                                                "position":  25,
@@ -1148,7 +1188,8 @@
                                                                                "points":  19,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  132
                                            },
                                            {
                                                "position":  26,
@@ -1173,7 +1214,8 @@
                                                                               "points":  29,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  127
                                            },
                                            {
                                                "position":  27,
@@ -1210,7 +1252,8 @@
                                                                                 "points":  29,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  138
                                            },
                                            {
                                                "position":  28,
@@ -1239,7 +1282,8 @@
                                                                                 "points":  18,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  570
                                            },
                                            {
                                                "position":  29,
@@ -1272,7 +1316,8 @@
                                                                                 "points":  20,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  477
                                            },
                                            {
                                                "position":  30,
@@ -1309,7 +1354,8 @@
                                                                                 "points":  21,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  150
                                            },
                                            {
                                                "position":  31,
@@ -1338,7 +1384,8 @@
                                                                               "points":  32,
                                                                               "counting":  false
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  131
                                            },
                                            {
                                                "position":  32,
@@ -1371,7 +1418,8 @@
                                                                                 "points":  28,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  129
                                            },
                                            {
                                                "position":  33,
@@ -1396,7 +1444,8 @@
                                                                                "points":  21,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  140
                                            },
                                            {
                                                "position":  34,
@@ -1425,7 +1474,8 @@
                                                                                 "points":  16,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  123
                                            },
                                            {
                                                "position":  35,
@@ -1454,7 +1504,8 @@
                                                                                 "points":  24,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  160
                                            },
                                            {
                                                "position":  36,
@@ -1491,7 +1542,8 @@
                                                                                 "points":  36,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  120
                                            },
                                            {
                                                "position":  37,
@@ -1528,7 +1580,8 @@
                                                                                 "points":  33,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  134
                                            },
                                            {
                                                "position":  38,
@@ -1557,7 +1610,8 @@
                                                                                 "points":  39,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  133
                                            },
                                            {
                                                "position":  39,
@@ -1590,7 +1644,8 @@
                                                                                 "points":  27,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  139
                                            },
                                            {
                                                "position":  40,
@@ -1619,7 +1674,8 @@
                                                                                 "points":  37,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  161
                                            },
                                            {
                                                "position":  41,
@@ -1648,7 +1704,8 @@
                                                                                "points":  30,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  152
                                            },
                                            {
                                                "position":  42,
@@ -1681,7 +1738,8 @@
                                                                                 "points":  53,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  144
                                            },
                                            {
                                                "position":  43,
@@ -1710,7 +1768,8 @@
                                                                                "points":  42,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  147
                                            },
                                            {
                                                "position":  44,
@@ -1743,7 +1802,8 @@
                                                                                 "points":  35,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  158
                                            },
                                            {
                                                "position":  45,
@@ -1780,7 +1840,8 @@
                                                                                 "points":  34,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  176
                                            },
                                            {
                                                "position":  46,
@@ -1809,7 +1870,8 @@
                                                                               "points":  53,
                                                                               "counting":  false
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  146
                                            },
                                            {
                                                "position":  47,
@@ -1838,7 +1900,8 @@
                                                                               "points":  45,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  157
                                            },
                                            {
                                                "position":  48,
@@ -1875,7 +1938,8 @@
                                                                                 "points":  62,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  154
                                            },
                                            {
                                                "position":  49,
@@ -1908,7 +1972,8 @@
                                                                                "points":  45,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  155
                                            },
                                            {
                                                "position":  50,
@@ -1937,7 +2002,8 @@
                                                                                "points":  38,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  156
                                            },
                                            {
                                                "position":  51,
@@ -1966,7 +2032,8 @@
                                                                                "points":  44,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  151
                                            },
                                            {
                                                "position":  52,
@@ -2003,7 +2070,8 @@
                                                                                 "points":  45,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  166
                                            },
                                            {
                                                "position":  53,
@@ -2028,7 +2096,8 @@
                                                                                 "points":  32,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  599
                                            },
                                            {
                                                "position":  54,
@@ -2057,7 +2126,8 @@
                                                                                 "points":  40,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  211
                                            },
                                            {
                                                "position":  55,
@@ -2086,7 +2156,8 @@
                                                                                "points":  53,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  182
                                            },
                                            {
                                                "position":  56,
@@ -2123,7 +2194,8 @@
                                                                                 "points":  43,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  189
                                            },
                                            {
                                                "position":  57,
@@ -2148,7 +2220,8 @@
                                                                               "points":  56,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  485
                                            },
                                            {
                                                "position":  58,
@@ -2181,7 +2254,8 @@
                                                                                 "points":  58,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  168
                                            },
                                            {
                                                "position":  59,
@@ -2210,7 +2284,8 @@
                                                                                 "points":  48,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  180
                                            },
                                            {
                                                "position":  60,
@@ -2247,7 +2322,8 @@
                                                                                 "points":  59,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  205
                                            },
                                            {
                                                "position":  61,
@@ -2284,7 +2360,8 @@
                                                                                 "points":  61,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  171
                                            },
                                            {
                                                "position":  62,
@@ -2313,7 +2390,8 @@
                                                                               "points":  67,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  177
                                            },
                                            {
                                                "position":  63,
@@ -2342,7 +2420,8 @@
                                                                                 "points":  46,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  488
                                            },
                                            {
                                                "position":  64,
@@ -2367,7 +2446,8 @@
                                                                                 "points":  44,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  173
                                            },
                                            {
                                                "position":  65,
@@ -2400,7 +2480,8 @@
                                                                                 "points":  65,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  162
                                            },
                                            {
                                                "position":  66,
@@ -2429,7 +2510,8 @@
                                                                                 "points":  50,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  174
                                            },
                                            {
                                                "position":  67,
@@ -2458,7 +2540,8 @@
                                                                                 "points":  51,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  486
                                            },
                                            {
                                                "position":  68,
@@ -2483,7 +2566,8 @@
                                                                               "points":  111,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  142
                                            },
                                            {
                                                "position":  69,
@@ -2516,7 +2600,8 @@
                                                                                 "points":  73,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  191
                                            },
                                            {
                                                "position":  70,
@@ -2553,7 +2638,8 @@
                                                                                 "points":  68,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  184
                                            },
                                            {
                                                "position":  71,
@@ -2590,7 +2676,8 @@
                                                                                 "points":  64,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  175
                                            },
                                            {
                                                "position":  72,
@@ -2619,7 +2706,8 @@
                                                                               "points":  58,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  181
                                            },
                                            {
                                                "position":  73,
@@ -2648,7 +2736,8 @@
                                                                                 "points":  67,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  190
                                            },
                                            {
                                                "position":  74,
@@ -2673,7 +2762,8 @@
                                                                                "points":  66,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  489
                                            },
                                            {
                                                "position":  75,
@@ -2710,7 +2800,8 @@
                                                                                 "points":  82,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  225
                                            },
                                            {
                                                "position":  76,
@@ -2743,7 +2834,8 @@
                                                                                 "points":  71,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  209
                                            },
                                            {
                                                "position":  77,
@@ -2768,7 +2860,8 @@
                                                                                "points":  76,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  579
                                            },
                                            {
                                                "position":  78,
@@ -2801,7 +2894,8 @@
                                                                                "points":  65,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  208
                                            },
                                            {
                                                "position":  79,
@@ -2834,7 +2928,8 @@
                                                                                 "points":  93,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  194
                                            },
                                            {
                                                "position":  80,
@@ -2859,7 +2954,8 @@
                                                                                 "points":  66,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  497
                                            },
                                            {
                                                "position":  81,
@@ -2888,7 +2984,8 @@
                                                                                 "points":  85,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  490
                                            },
                                            {
                                                "position":  82,
@@ -2913,7 +3010,8 @@
                                                                                "points":  83,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  178
                                            },
                                            {
                                                "position":  83,
@@ -2938,7 +3036,8 @@
                                                                                 "points":  69,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  492
                                            },
                                            {
                                                "position":  84,
@@ -2971,7 +3070,8 @@
                                                                                 "points":  79,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  201
                                            },
                                            {
                                                "position":  85,
@@ -3000,7 +3100,8 @@
                                                                                 "points":  70,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  249
                                            },
                                            {
                                                "position":  86,
@@ -3025,7 +3126,8 @@
                                                                               "points":  112,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  188
                                            },
                                            {
                                                "position":  87,
@@ -3054,7 +3156,8 @@
                                                                                 "points":  74,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  219
                                            },
                                            {
                                                "position":  88,
@@ -3079,7 +3182,8 @@
                                                                                "points":  61,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  213
                                            },
                                            {
                                                "position":  89,
@@ -3116,7 +3220,8 @@
                                                                                 "points":  81,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  234
                                            },
                                            {
                                                "position":  90,
@@ -3153,7 +3258,8 @@
                                                                                 "points":  91,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  250
                                            },
                                            {
                                                "position":  91,
@@ -3178,7 +3284,8 @@
                                                                                 "points":  76,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  203
                                            },
                                            {
                                                "position":  92,
@@ -3207,7 +3314,8 @@
                                                                                 "points":  54,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  257
                                            },
                                            {
                                                "position":  93,
@@ -3240,7 +3348,8 @@
                                                                                 "points":  88,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  197
                                            },
                                            {
                                                "position":  94,
@@ -3265,7 +3374,8 @@
                                                                               "points":  98,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  498
                                            },
                                            {
                                                "position":  95,
@@ -3298,7 +3408,8 @@
                                                                                 "points":  77,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  256
                                            },
                                            {
                                                "position":  96,
@@ -3335,7 +3446,8 @@
                                                                                 "points":  101,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  252
                                            },
                                            {
                                                "position":  97,
@@ -3360,7 +3472,8 @@
                                                                                 "points":  83,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  606
                                            },
                                            {
                                                "position":  98,
@@ -3389,7 +3502,8 @@
                                                                                 "points":  72,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  238
                                            },
                                            {
                                                "position":  99,
@@ -3422,7 +3536,8 @@
                                                                                 "points":  96,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  512
                                            },
                                            {
                                                "position":  100,
@@ -3447,7 +3562,8 @@
                                                                                 "points":  75,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  607
                                            },
                                            {
                                                "position":  101,
@@ -3484,7 +3600,8 @@
                                                                                 "points":  99,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  306
                                            },
                                            {
                                                "position":  102,
@@ -3513,7 +3630,8 @@
                                                                                 "points":  97,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  226
                                            },
                                            {
                                                "position":  103,
@@ -3546,7 +3664,8 @@
                                                                                "points":  93,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  251
                                            },
                                            {
                                                "position":  104,
@@ -3571,7 +3690,8 @@
                                                                               "points":  107,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  503
                                            },
                                            {
                                                "position":  105,
@@ -3600,7 +3720,8 @@
                                                                                "points":  95,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  224
                                            },
                                            {
                                                "position":  106,
@@ -3633,7 +3754,8 @@
                                                                                 "points":  107,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  255
                                            },
                                            {
                                                "position":  107,
@@ -3662,7 +3784,8 @@
                                                                               "points":  104,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  283
                                            },
                                            {
                                                "position":  108,
@@ -3699,7 +3822,8 @@
                                                                                 "points":  110,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  272
                                            },
                                            {
                                                "position":  109,
@@ -3724,7 +3848,8 @@
                                                                               "points":  108,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  233
                                            },
                                            {
                                                "position":  110,
@@ -3753,7 +3878,8 @@
                                                                                "points":  101,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  215
                                            },
                                            {
                                                "position":  111,
@@ -3790,7 +3916,8 @@
                                                                                 "points":  103,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  298
                                            },
                                            {
                                                "position":  112,
@@ -3823,7 +3950,8 @@
                                                                                 "points":  113,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  264
                                            },
                                            {
                                                "position":  113,
@@ -3856,7 +3984,8 @@
                                                                                 "points":  94,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  247
                                            },
                                            {
                                                "position":  114,
@@ -3881,7 +4010,8 @@
                                                                                 "points":  95,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  523
                                            },
                                            {
                                                "position":  115,
@@ -3906,7 +4036,8 @@
                                                                                "points":  99,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  521
                                            },
                                            {
                                                "position":  116,
@@ -3935,7 +4066,8 @@
                                                                                "points":  128,
                                                                                "counting":  false
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  245
                                            },
                                            {
                                                "position":  117,
@@ -3964,7 +4096,8 @@
                                                                                 "points":  106,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  303
                                            },
                                            {
                                                "position":  118,
@@ -3997,7 +4130,8 @@
                                                                                "points":  147,
                                                                                "counting":  false
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  269
                                            },
                                            {
                                                "position":  119,
@@ -4030,7 +4164,8 @@
                                                                                 "points":  120,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  318
                                            },
                                            {
                                                "position":  120,
@@ -4059,7 +4194,8 @@
                                                                                 "points":  104,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  312
                                            },
                                            {
                                                "position":  121,
@@ -4092,7 +4228,8 @@
                                                                                "points":  105,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  345
                                            },
                                            {
                                                "position":  122,
@@ -4125,7 +4262,8 @@
                                                                                 "points":  116,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  528
                                            },
                                            {
                                                "position":  123,
@@ -4158,7 +4296,8 @@
                                                                                 "points":  115,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  310
                                            },
                                            {
                                                "position":  124,
@@ -4183,7 +4322,8 @@
                                                                                 "points":  71,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  393
                                            },
                                            {
                                                "position":  125,
@@ -4212,7 +4352,8 @@
                                                                                 "points":  114,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  538
                                            },
                                            {
                                                "position":  126,
@@ -4237,7 +4378,8 @@
                                                                               "points":  128,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  518
                                            },
                                            {
                                                "position":  127,
@@ -4270,7 +4412,8 @@
                                                                                "points":  102,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  279
                                            },
                                            {
                                                "position":  128,
@@ -4295,7 +4438,8 @@
                                                                               "points":  132,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  237
                                            },
                                            {
                                                "position":  129,
@@ -4324,7 +4468,8 @@
                                                                                 "points":  119,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  321
                                            },
                                            {
                                                "position":  130,
@@ -4353,7 +4498,8 @@
                                                                                "points":  111,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  287
                                            },
                                            {
                                                "position":  131,
@@ -4386,7 +4532,8 @@
                                                                                "points":  113,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  320
                                            },
                                            {
                                                "position":  132,
@@ -4423,7 +4570,8 @@
                                                                                 "points":  133,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  355
                                            },
                                            {
                                                "position":  133,
@@ -4452,7 +4600,8 @@
                                                                                 "points":  102,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  289
                                            },
                                            {
                                                "position":  134,
@@ -4489,7 +4638,8 @@
                                                                                 "points":  121,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  325
                                            },
                                            {
                                                "position":  135,
@@ -4526,7 +4676,8 @@
                                                                                 "points":  128,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  383
                                            },
                                            {
                                                "position":  136,
@@ -4555,7 +4706,8 @@
                                                                                 "points":  124,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  529
                                            },
                                            {
                                                "position":  137,
@@ -4584,7 +4736,8 @@
                                                                                 "points":  112,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  301
                                            },
                                            {
                                                "position":  138,
@@ -4613,7 +4766,8 @@
                                                                                 "points":  127,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  534
                                            },
                                            {
                                                "position":  139,
@@ -4642,7 +4796,8 @@
                                                                               "points":  147,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  282
                                            },
                                            {
                                                "position":  140,
@@ -4675,7 +4830,8 @@
                                                                                 "points":  129,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  293
                                            },
                                            {
                                                "position":  141,
@@ -4700,7 +4856,8 @@
                                                                                "points":  126,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  527
                                            },
                                            {
                                                "position":  142,
@@ -4725,7 +4882,8 @@
                                                                                 "points":  117,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  307
                                            },
                                            {
                                                "position":  143,
@@ -4754,7 +4912,8 @@
                                                                               "points":  152,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  329
                                            },
                                            {
                                                "position":  144,
@@ -4779,7 +4938,8 @@
                                                                               "points":  141,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  284
                                            },
                                            {
                                                "position":  145,
@@ -4816,7 +4976,8 @@
                                                                                 "points":  136,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  368
                                            },
                                            {
                                                "position":  146,
@@ -4841,7 +5002,8 @@
                                                                                 "points":  118,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  350
                                            },
                                            {
                                                "position":  147,
@@ -4878,7 +5040,8 @@
                                                                                 "points":  138,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  373
                                            },
                                            {
                                                "position":  148,
@@ -4915,7 +5078,8 @@
                                                                                 "points":  135,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  398
                                            },
                                            {
                                                "position":  149,
@@ -4944,7 +5108,8 @@
                                                                                 "points":  126,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  324
                                            },
                                            {
                                                "position":  150,
@@ -4981,7 +5146,8 @@
                                                                                 "points":  145,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  372
                                            },
                                            {
                                                "position":  151,
@@ -5010,7 +5176,8 @@
                                                                                 "points":  141,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  309
                                            },
                                            {
                                                "position":  152,
@@ -5043,7 +5210,8 @@
                                                                                 "points":  143,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  548
                                            },
                                            {
                                                "position":  153,
@@ -5076,7 +5244,8 @@
                                                                                 "points":  146,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  364
                                            },
                                            {
                                                "position":  154,
@@ -5109,7 +5278,8 @@
                                                                                "points":  123,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  378
                                            },
                                            {
                                                "position":  155,
@@ -5138,7 +5308,8 @@
                                                                                 "points":  137,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  356
                                            },
                                            {
                                                "position":  156,
@@ -5171,7 +5342,8 @@
                                                                                 "points":  150,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  380
                                            },
                                            {
                                                "position":  157,
@@ -5200,7 +5372,8 @@
                                                                                 "points":  142,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  344
                                            },
                                            {
                                                "position":  158,
@@ -5225,7 +5398,8 @@
                                                                                "points":  119,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  323
                                            },
                                            {
                                                "position":  159,
@@ -5254,7 +5428,8 @@
                                                                                 "points":  130,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  550
                                            },
                                            {
                                                "position":  160,
@@ -5279,7 +5454,8 @@
                                                                                "points":  106,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  337
                                            },
                                            {
                                                "position":  161,
@@ -5312,7 +5488,8 @@
                                                                                 "points":  139,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  361
                                            },
                                            {
                                                "position":  162,
@@ -5337,7 +5514,8 @@
                                                                               "points":  164,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  331
                                            },
                                            {
                                                "position":  163,
@@ -5362,7 +5540,8 @@
                                                                                 "points":  131,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  335
                                            },
                                            {
                                                "position":  164,
@@ -5399,7 +5578,8 @@
                                                                                 "points":  153,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  421
                                            },
                                            {
                                                "position":  165,
@@ -5436,7 +5616,8 @@
                                                                                 "points":  154,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  465
                                            },
                                            {
                                                "position":  166,
@@ -5461,7 +5642,8 @@
                                                                               "points":  171,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  341
                                            },
                                            {
                                                "position":  167,
@@ -5486,7 +5668,8 @@
                                                                                 "points":  148,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  392
                                            },
                                            {
                                                "position":  168,
@@ -5515,7 +5698,8 @@
                                                                                "points":  145,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  553
                                            },
                                            {
                                                "position":  169,
@@ -5540,7 +5724,8 @@
                                                                                 "points":  144,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  346
                                            },
                                            {
                                                "position":  170,
@@ -5565,7 +5750,8 @@
                                                                                 "points":  147,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  544
                                            },
                                            {
                                                "position":  171,
@@ -5598,7 +5784,8 @@
                                                                                "points":  150,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  449
                                            },
                                            {
                                                "position":  172,
@@ -5627,7 +5814,8 @@
                                                                                "points":  142,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  363
                                            },
                                            {
                                                "position":  173,
@@ -5652,7 +5840,8 @@
                                                                                 "points":  152,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  410
                                            },
                                            {
                                                "position":  174,
@@ -5677,7 +5866,8 @@
                                                                               "points":  187,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  552
                                            },
                                            {
                                                "position":  175,
@@ -5702,7 +5892,8 @@
                                                                               "points":  189,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  370
                                            },
                                            {
                                                "position":  176,
@@ -5727,7 +5918,8 @@
                                                                               "points":  182,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  386
                                            },
                                            {
                                                "position":  177,
@@ -5752,7 +5944,8 @@
                                                                                "points":  149,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  432
                                            },
                                            {
                                                "position":  178,
@@ -5777,7 +5970,8 @@
                                                                               "points":  204,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  442
                                            },
                                            {
                                                "position":  179,
@@ -5798,7 +5992,8 @@
                                                                                 "points":  11,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  104
                                            },
                                            {
                                                "position":  180,
@@ -5819,7 +6014,8 @@
                                                                                 "points":  8,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  621
                                            },
                                            {
                                                "position":  181,
@@ -5840,7 +6036,8 @@
                                                                                "points":  8,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  114
                                            },
                                            {
                                                "position":  182,
@@ -5861,7 +6058,8 @@
                                                                                "points":  11,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  472
                                            },
                                            {
                                                "position":  183,
@@ -5882,7 +6080,8 @@
                                                                                 "points":  25,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  622
                                            },
                                            {
                                                "position":  184,
@@ -5903,7 +6102,8 @@
                                                                               "points":  34,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  126
                                            },
                                            {
                                                "position":  185,
@@ -5924,7 +6124,8 @@
                                                                               "points":  43,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  148
                                            },
                                            {
                                                "position":  186,
@@ -5945,7 +6146,8 @@
                                                                                 "points":  42,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  482
                                            },
                                            {
                                                "position":  187,
@@ -5966,7 +6168,8 @@
                                                                                 "points":  47,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  578
                                            },
                                            {
                                                "position":  188,
@@ -5987,7 +6190,8 @@
                                                                               "points":  59,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  487
                                            },
                                            {
                                                "position":  189,
@@ -6008,7 +6212,8 @@
                                                                                 "points":  49,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  179
                                            },
                                            {
                                                "position":  190,
@@ -6029,7 +6234,8 @@
                                                                                 "points":  55,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  602
                                            },
                                            {
                                                "position":  191,
@@ -6050,7 +6256,8 @@
                                                                                "points":  67,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  577
                                            },
                                            {
                                                "position":  192,
@@ -6071,7 +6278,8 @@
                                                                               "points":  79,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  192
                                            },
                                            {
                                                "position":  193,
@@ -6092,7 +6300,8 @@
                                                                                 "points":  63,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  212
                                            },
                                            {
                                                "position":  194,
@@ -6113,7 +6322,8 @@
                                                                                 "points":  61,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  493
                                            },
                                            {
                                                "position":  195,
@@ -6134,7 +6344,8 @@
                                                                                 "points":  56,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  636
                                            },
                                            {
                                                "position":  196,
@@ -6155,7 +6366,8 @@
                                                                                 "points":  84,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  582
                                            },
                                            {
                                                "position":  197,
@@ -6176,7 +6388,8 @@
                                                                                "points":  81,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  603
                                            },
                                            {
                                                "position":  198,
@@ -6197,7 +6410,8 @@
                                                                                "points":  90,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  605
                                            },
                                            {
                                                "position":  199,
@@ -6218,7 +6432,8 @@
                                                                                "points":  101,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  198
                                            },
                                            {
                                                "position":  200,
@@ -6239,7 +6454,8 @@
                                                                                 "points":  89,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  206
                                            },
                                            {
                                                "position":  201,
@@ -6260,7 +6476,8 @@
                                                                               "points":  97,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  508
                                            },
                                            {
                                                "position":  202,
@@ -6281,7 +6498,8 @@
                                                                                 "points":  86,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  240
                                            },
                                            {
                                                "position":  203,
@@ -6302,7 +6520,8 @@
                                                                               "points":  106,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  266
                                            },
                                            {
                                                "position":  204,
@@ -6323,7 +6542,8 @@
                                                                                 "points":  94,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  258
                                            },
                                            {
                                                "position":  205,
@@ -6344,7 +6564,8 @@
                                                                                 "points":  104,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  522
                                            },
                                            {
                                                "position":  206,
@@ -6365,7 +6586,8 @@
                                                                                 "points":  91,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  276
                                            },
                                            {
                                                "position":  207,
@@ -6386,7 +6608,8 @@
                                                                                "points":  114,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  608
                                            },
                                            {
                                                "position":  208,
@@ -6407,7 +6630,8 @@
                                                                               "points":  129,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  253
                                            },
                                            {
                                                "position":  209,
@@ -6428,7 +6652,8 @@
                                                                               "points":  134,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  517
                                            },
                                            {
                                                "position":  210,
@@ -6449,7 +6674,8 @@
                                                                               "points":  153,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  244
                                            },
                                            {
                                                "position":  211,
@@ -6470,7 +6696,8 @@
                                                                                 "points":  125,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  313
                                            },
                                            {
                                                "position":  212,
@@ -6491,7 +6718,8 @@
                                                                                "points":  135,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  296
                                            },
                                            {
                                                "position":  213,
@@ -6512,7 +6740,8 @@
                                                                                 "points":  132,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  592
                                            },
                                            {
                                                "position":  214,
@@ -6533,7 +6762,8 @@
                                                                                 "points":  137,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  537
                                            },
                                            {
                                                "position":  215,
@@ -6554,7 +6784,8 @@
                                                                                 "points":  130,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  305
                                            },
                                            {
                                                "position":  216,
@@ -6575,7 +6806,8 @@
                                                                                 "points":  134,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  394
                                            },
                                            {
                                                "position":  217,
@@ -6596,7 +6828,8 @@
                                                                                "points":  140,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  615
                                            },
                                            {
                                                "position":  218,
@@ -6617,7 +6850,8 @@
                                                                                 "points":  151,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  388
                                            },
                                            {
                                                "position":  219,
@@ -6638,7 +6872,8 @@
                                                                                "points":  134,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  360
                                            },
                                            {
                                                "position":  220,
@@ -6659,7 +6894,8 @@
                                                                                 "points":  144,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  369
                                            },
                                            {
                                                "position":  221,
@@ -6680,7 +6916,8 @@
                                                                                "points":  127,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  357
                                            },
                                            {
                                                "position":  222,
@@ -6701,7 +6938,8 @@
                                                                               "points":  207,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  598
                                            },
                                            {
                                                "position":  223,
@@ -6722,7 +6960,8 @@
                                                                                "points":  146,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  430
                                            },
                                            {
                                                "position":  224,
@@ -6743,7 +6982,8 @@
                                                                               "points":  193,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  417
                                            },
                                            {
                                                "position":  225,
@@ -6764,7 +7004,8 @@
                                                                               "points":  186,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  389
                                            },
                                            {
                                                "position":  226,
@@ -6785,7 +7026,8 @@
                                                                               "points":  203,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  559
                                            },
                                            {
                                                "position":  227,
@@ -6806,7 +7048,8 @@
                                                                               "points":  202,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  427
                                            },
                                            {
                                                "position":  228,
@@ -6827,7 +7070,8 @@
                                                                               "points":  205,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  434
                                            },
                                            {
                                                "position":  229,
@@ -6844,7 +7088,8 @@
                                                                               "points":  2,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  100
                                            },
                                            {
                                                "position":  230,
@@ -6861,7 +7106,8 @@
                                                                                "points":  2,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  620
                                            },
                                            {
                                                "position":  231,
@@ -6878,7 +7124,8 @@
                                                                               "points":  3,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  102
                                            },
                                            {
                                                "position":  232,
@@ -6895,7 +7142,8 @@
                                                                               "points":  6,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  567
                                            },
                                            {
                                                "position":  233,
@@ -6912,7 +7160,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  654
                                            },
                                            {
                                                "position":  234,
@@ -6929,7 +7178,8 @@
                                                                               "points":  13,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  109
                                            },
                                            {
                                                "position":  235,
@@ -6946,7 +7196,8 @@
                                                                                "points":  18,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  474
                                            },
                                            {
                                                "position":  236,
@@ -6963,7 +7214,8 @@
                                                                                 "points":  22,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  655
                                            },
                                            {
                                                "position":  237,
@@ -6980,7 +7232,8 @@
                                                                                "points":  34,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  141
                                            },
                                            {
                                                "position":  238,
@@ -6997,7 +7250,8 @@
                                                                                "points":  39,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  571
                                            },
                                            {
                                                "position":  239,
@@ -7014,7 +7268,8 @@
                                                                                "points":  34,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  572
                                            },
                                            {
                                                "position":  240,
@@ -7031,7 +7286,8 @@
                                                                               "points":  38,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  143
                                            },
                                            {
                                                "position":  241,
@@ -7048,7 +7304,8 @@
                                                                                 "points":  26,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  576
                                            },
                                            {
                                                "position":  242,
@@ -7065,7 +7322,8 @@
                                                                                 "points":  41,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  658
                                            },
                                            {
                                                "position":  243,
@@ -7082,7 +7340,8 @@
                                                                               "points":  41,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  159
                                            },
                                            {
                                                "position":  244,
@@ -7099,7 +7358,8 @@
                                                                               "points":  51,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  573
                                            },
                                            {
                                                "position":  245,
@@ -7116,7 +7376,8 @@
                                                                                "points":  52,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  483
                                            },
                                            {
                                                "position":  246,
@@ -7133,7 +7394,8 @@
                                                                                "points":  58,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  149
                                            },
                                            {
                                                "position":  247,
@@ -7150,7 +7412,8 @@
                                                                                "points":  46,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  484
                                            },
                                            {
                                                "position":  248,
@@ -7167,7 +7430,8 @@
                                                                               "points":  47,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  169
                                            },
                                            {
                                                "position":  249,
@@ -7184,7 +7448,8 @@
                                                                                 "points":  52,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  627
                                            },
                                            {
                                                "position":  250,
@@ -7201,7 +7466,8 @@
                                                                                 "points":  53,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  186
                                            },
                                            {
                                                "position":  251,
@@ -7218,7 +7484,8 @@
                                                                                 "points":  57,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  185
                                            },
                                            {
                                                "position":  252,
@@ -7235,7 +7502,8 @@
                                                                                "points":  55,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  629
                                            },
                                            {
                                                "position":  253,
@@ -7252,7 +7520,8 @@
                                                                                "points":  78,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  604
                                            },
                                            {
                                                "position":  254,
@@ -7269,7 +7538,8 @@
                                                                               "points":  79,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  187
                                            },
                                            {
                                                "position":  255,
@@ -7286,7 +7556,8 @@
                                                                               "points":  85,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  195
                                            },
                                            {
                                                "position":  256,
@@ -7303,7 +7574,8 @@
                                                                               "points":  89,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  193
                                            },
                                            {
                                                "position":  257,
@@ -7320,7 +7592,8 @@
                                                                               "points":  86,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  200
                                            },
                                            {
                                                "position":  258,
@@ -7337,7 +7610,8 @@
                                                                                "points":  76,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  214
                                            },
                                            {
                                                "position":  259,
@@ -7354,7 +7628,8 @@
                                                                                 "points":  90,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  660
                                            },
                                            {
                                                "position":  260,
@@ -7371,7 +7646,8 @@
                                                                                 "points":  83,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  583
                                            },
                                            {
                                                "position":  261,
@@ -7388,7 +7664,8 @@
                                                                                 "points":  92,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  631
                                            },
                                            {
                                                "position":  262,
@@ -7405,7 +7682,8 @@
                                                                                 "points":  88,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  216
                                            },
                                            {
                                                "position":  263,
@@ -7422,7 +7700,8 @@
                                                                                 "points":  105,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  661
                                            },
                                            {
                                                "position":  264,
@@ -7439,7 +7718,8 @@
                                                                                 "points":  98,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  223
                                            },
                                            {
                                                "position":  265,
@@ -7456,7 +7736,8 @@
                                                                               "points":  122,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  227
                                            },
                                            {
                                                "position":  266,
@@ -7473,7 +7754,8 @@
                                                                               "points":  112,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  246
                                            },
                                            {
                                                "position":  267,
@@ -7490,7 +7772,8 @@
                                                                               "points":  120,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  242
                                            },
                                            {
                                                "position":  268,
@@ -7507,7 +7790,8 @@
                                                                                 "points":  100,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  637
                                            },
                                            {
                                                "position":  269,
@@ -7524,7 +7808,8 @@
                                                                               "points":  105,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  263
                                            },
                                            {
                                                "position":  270,
@@ -7541,7 +7826,8 @@
                                                                                "points":  108,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  519
                                            },
                                            {
                                                "position":  271,
@@ -7558,7 +7844,8 @@
                                                                                 "points":  108,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  260
                                            },
                                            {
                                                "position":  272,
@@ -7575,7 +7862,8 @@
                                                                                 "points":  87,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  641
                                            },
                                            {
                                                "position":  273,
@@ -7592,7 +7880,8 @@
                                                                                 "points":  123,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  589
                                            },
                                            {
                                                "position":  274,
@@ -7609,7 +7898,8 @@
                                                                                 "points":  122,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  281
                                            },
                                            {
                                                "position":  275,
@@ -7626,7 +7916,8 @@
                                                                               "points":  165,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  516
                                            },
                                            {
                                                "position":  276,
@@ -7643,7 +7934,8 @@
                                                                                 "points":  149,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  640
                                            },
                                            {
                                                "position":  277,
@@ -7660,7 +7952,8 @@
                                                                               "points":  185,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  609
                                            },
                                            {
                                                "position":  278,
@@ -7677,7 +7970,8 @@
                                                                               "points":  175,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  614
                                            },
                                            {
                                                "position":  279,
@@ -7694,7 +7988,8 @@
                                                                               "points":  183,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  273
                                            },
                                            {
                                                "position":  280,
@@ -7711,7 +8006,8 @@
                                                                               "points":  152,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  342
                                            },
                                            {
                                                "position":  281,
@@ -7728,7 +8024,8 @@
                                                                                "points":  141,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  645
                                            },
                                            {
                                                "position":  282,
@@ -7745,7 +8042,8 @@
                                                                               "points":  118,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  420
                                            },
                                            {
                                                "position":  283,
@@ -7762,7 +8060,8 @@
                                                                               "points":  178,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  315
                                            },
                                            {
                                                "position":  284,
@@ -7779,7 +8078,8 @@
                                                                               "points":  165,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  351
                                            },
                                            {
                                                "position":  285,
@@ -7796,7 +8096,8 @@
                                                                                 "points":  154,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  555
                                            },
                                            {
                                                "position":  286,
@@ -7813,7 +8114,8 @@
                                                                                 "points":  164,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  565
                                            },
                                            {
                                                "position":  287,
@@ -7830,7 +8132,8 @@
                                                                               "points":  199,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  554
                                            },
                                            {
                                                "position":  288,
@@ -7847,7 +8150,8 @@
                                                                                "points":  178,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  447
                                            },
                                            {
                                                "position":  289,
@@ -7864,7 +8168,8 @@
                                                                               "points":  196,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  409
                                            },
                                            {
                                                "position":  290,
@@ -7881,7 +8186,8 @@
                                                                               "points":  205,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  445
                                            },
                                            {
                                                "position":  291,
@@ -7898,7 +8204,8 @@
                                                                               "points":  207,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  450
                                            },
                                            {
                                                "position":  292,
@@ -7915,7 +8222,8 @@
                                                                               "points":  209,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  448
                                            },
                                            {
                                                "position":  293,
@@ -7928,7 +8236,8 @@
                                                                                  "points":  4,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  103
                                            },
                                            {
                                                "position":  294,
@@ -7941,7 +8250,8 @@
                                                                               "points":  6,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  103
                                            },
                                            {
                                                "position":  295,
@@ -7954,7 +8264,8 @@
                                                                                "points":  8,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  653
                                            },
                                            {
                                                "position":  296,
@@ -7967,7 +8278,8 @@
                                                                               "points":  9,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  471
                                            },
                                            {
                                                "position":  297,
@@ -7980,7 +8292,8 @@
                                                                                "points":  12,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  568
                                            },
                                            {
                                                "position":  298,
@@ -7993,7 +8306,8 @@
                                                                               "points":  20,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  623
                                            },
                                            {
                                                "position":  299,
@@ -8006,7 +8320,8 @@
                                                                               "points":  27,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  475
                                            },
                                            {
                                                "position":  300,
@@ -8019,7 +8334,8 @@
                                                                               "points":  28,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  476
                                            },
                                            {
                                                "position":  301,
@@ -8032,7 +8348,8 @@
                                                                               "points":  31,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  624
                                            },
                                            {
                                                "position":  302,
@@ -8045,7 +8362,8 @@
                                                                                "points":  35,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  657
                                            },
                                            {
                                                "position":  303,
@@ -8058,7 +8376,8 @@
                                                                                  "points":  37,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  137
                                            },
                                            {
                                                "position":  304,
@@ -8071,7 +8390,8 @@
                                                                               "points":  37,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  479
                                            },
                                            {
                                                "position":  305,
@@ -8084,7 +8404,8 @@
                                                                                 "points":  38,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  669
                                            },
                                            {
                                                "position":  306,
@@ -8097,7 +8418,8 @@
                                                                               "points":  45,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  480
                                            },
                                            {
                                                "position":  307,
@@ -8110,7 +8432,8 @@
                                                                               "points":  57,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  625
                                            },
                                            {
                                                "position":  308,
@@ -8123,7 +8446,8 @@
                                                                                "points":  58,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  575
                                            },
                                            {
                                                "position":  309,
@@ -8136,7 +8460,8 @@
                                                                               "points":  61,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  626
                                            },
                                            {
                                                "position":  310,
@@ -8149,7 +8474,8 @@
                                                                                  "points":  61,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  164
                                            },
                                            {
                                                "position":  311,
@@ -8162,7 +8488,8 @@
                                                                                  "points":  62,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  165
                                            },
                                            {
                                                "position":  312,
@@ -8175,7 +8502,8 @@
                                                                                 "points":  62,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  601
                                            },
                                            {
                                                "position":  313,
@@ -8188,7 +8516,8 @@
                                                                                  "points":  67,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  172
                                            },
                                            {
                                                "position":  314,
@@ -8201,7 +8530,8 @@
                                                                               "points":  77,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  628
                                            },
                                            {
                                                "position":  315,
@@ -8214,7 +8544,8 @@
                                                                                 "points":  78,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  670
                                            },
                                            {
                                                "position":  316,
@@ -8227,7 +8558,8 @@
                                                                                 "points":  80,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  671
                                            },
                                            {
                                                "position":  317,
@@ -8253,7 +8585,8 @@
                                                                                "points":  88,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  580
                                            },
                                            {
                                                "position":  319,
@@ -8266,7 +8599,8 @@
                                                                               "points":  89,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  494
                                            },
                                            {
                                                "position":  320,
@@ -8279,7 +8613,8 @@
                                                                               "points":  90,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  495
                                            },
                                            {
                                                "position":  321,
@@ -8292,7 +8627,8 @@
                                                                               "points":  93,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  630
                                            },
                                            {
                                                "position":  322,
@@ -8305,7 +8641,8 @@
                                                                               "points":  97,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  496
                                            },
                                            {
                                                "position":  323,
@@ -8318,7 +8655,8 @@
                                                                                  "points":  105,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  219
                                            },
                                            {
                                                "position":  324,
@@ -8331,7 +8669,8 @@
                                                                               "points":  106,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  501
                                            },
                                            {
                                                "position":  325,
@@ -8344,7 +8683,8 @@
                                                                                  "points":  106,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  221
                                            },
                                            {
                                                "position":  326,
@@ -8357,7 +8697,8 @@
                                                                                 "points":  109,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  672
                                            },
                                            {
                                                "position":  327,
@@ -8370,7 +8711,8 @@
                                                                                 "points":  111,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  673
                                            },
                                            {
                                                "position":  328,
@@ -8383,7 +8725,8 @@
                                                                                  "points":  112,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  230
                                            },
                                            {
                                                "position":  329,
@@ -8396,7 +8739,8 @@
                                                                                  "points":  113,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  232
                                            },
                                            {
                                                "position":  330,
@@ -8409,7 +8753,8 @@
                                                                                  "points":  116,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  235
                                            },
                                            {
                                                "position":  331,
@@ -8422,7 +8767,8 @@
                                                                                  "points":  121,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  243
                                            },
                                            {
                                                "position":  332,
@@ -8435,7 +8781,8 @@
                                                                               "points":  123,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  509
                                            },
                                            {
                                                "position":  333,
@@ -8448,7 +8795,8 @@
                                                                               "points":  123,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  633
                                            },
                                            {
                                                "position":  334,
@@ -8461,7 +8809,8 @@
                                                                                 "points":  131,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  676
                                            },
                                            {
                                                "position":  335,
@@ -8474,7 +8823,8 @@
                                                                                  "points":  135,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  259
                                            },
                                            {
                                                "position":  336,
@@ -8500,7 +8850,8 @@
                                                                                "points":  136,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  588
                                            },
                                            {
                                                "position":  338,
@@ -8513,7 +8864,8 @@
                                                                                "points":  138,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  666
                                            },
                                            {
                                                "position":  339,
@@ -8526,7 +8878,8 @@
                                                                               "points":  139,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  635
                                            },
                                            {
                                                "position":  340,
@@ -8539,7 +8892,8 @@
                                                                                 "points":  140,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  677
                                            },
                                            {
                                                "position":  341,
@@ -8552,7 +8906,8 @@
                                                                                  "points":  140,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  267
                                            },
                                            {
                                                "position":  342,
@@ -8565,7 +8920,8 @@
                                                                                  "points":  142,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  270
                                            },
                                            {
                                                "position":  343,
@@ -8578,7 +8934,8 @@
                                                                               "points":  143,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  638
                                            },
                                            {
                                                "position":  344,
@@ -8591,7 +8948,8 @@
                                                                                  "points":  145,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  274
                                            },
                                            {
                                                "position":  345,
@@ -8604,7 +8962,8 @@
                                                                                 "points":  149,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  613
                                            },
                                            {
                                                "position":  346,
@@ -8617,7 +8976,8 @@
                                                                                  "points":  154,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  291
                                            },
                                            {
                                                "position":  347,
@@ -8630,7 +8990,8 @@
                                                                                  "points":  158,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  299
                                            },
                                            {
                                                "position":  348,
@@ -8643,7 +9004,8 @@
                                                                                  "points":  164,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  308
                                            },
                                            {
                                                "position":  349,
@@ -8656,7 +9018,8 @@
                                                                                  "points":  167,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  311
                                            },
                                            {
                                                "position":  350,
@@ -8669,7 +9032,8 @@
                                                                               "points":  167,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  535
                                            },
                                            {
                                                "position":  351,
@@ -8682,7 +9046,8 @@
                                                                                "points":  172,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  596
                                            },
                                            {
                                                "position":  352,
@@ -8695,7 +9060,8 @@
                                                                               "points":  173,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  642
                                            },
                                            {
                                                "position":  353,
@@ -8708,7 +9074,8 @@
                                                                                  "points":  177,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  327
                                            },
                                            {
                                                "position":  354,
@@ -8721,7 +9088,8 @@
                                                                               "points":  180,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  541
                                            },
                                            {
                                                "position":  355,
@@ -8734,7 +9102,8 @@
                                                                                  "points":  187,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  349
                                            },
                                            {
                                                "position":  356,
@@ -8747,7 +9116,8 @@
                                                                               "points":  191,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  545
                                            },
                                            {
                                                "position":  357,
@@ -8760,7 +9130,8 @@
                                                                               "points":  201,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  647
                                            },
                                            {
                                                "position":  358,
@@ -8773,7 +9144,8 @@
                                                                                  "points":  202,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  375
                                            },
                                            {
                                                "position":  359,
@@ -8786,7 +9158,8 @@
                                                                               "points":  202,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  556
                                            },
                                            {
                                                "position":  360,
@@ -8799,7 +9172,8 @@
                                                                                  "points":  204,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  379
                                            },
                                            {
                                                "position":  361,
@@ -8812,7 +9186,8 @@
                                                                               "points":  208,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  652
                                            },
                                            {
                                                "position":  362,
@@ -8825,7 +9200,8 @@
                                                                                  "points":  214,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  406
                                            },
                                            {
                                                "position":  363,
@@ -8838,7 +9214,8 @@
                                                                                  "points":  217,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  413
                                            },
                                            {
                                                "position":  364,
@@ -8851,7 +9228,8 @@
                                                                                  "points":  218,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  415
                                            },
                                            {
                                                "position":  365,
@@ -8864,7 +9242,8 @@
                                                                                  "points":  220,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  418
                                            },
                                            {
                                                "position":  366,
@@ -8877,7 +9256,8 @@
                                                                                  "points":  224,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  428
                                            },
                                            {
                                                "position":  367,
@@ -8890,7 +9270,8 @@
                                                                                  "points":  227,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  433
                                            },
                                            {
                                                "position":  368,
@@ -8903,7 +9284,8 @@
                                                                                  "points":  229,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  437
                                            },
                                            {
                                                "position":  369,
@@ -8916,7 +9298,8 @@
                                                                                  "points":  236,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  452
                                            },
                                            {
                                                "position":  370,
@@ -8929,7 +9312,8 @@
                                                                                  "points":  238,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  468
                                            },
                                            {
                                                "position":  371,
@@ -8942,7 +9326,8 @@
                                                                                  "points":  239,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  469
                                            }
                                        ]
                        },
@@ -8985,7 +9370,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  153
                                            },
                                            {
                                                "position":  2,
@@ -9018,7 +9404,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  199
                                            },
                                            {
                                                "position":  3,
@@ -9047,7 +9434,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  183
                                            },
                                            {
                                                "position":  4,
@@ -9076,7 +9464,8 @@
                                                                                 "points":  5,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  163
                                            },
                                            {
                                                "position":  5,
@@ -9105,7 +9494,8 @@
                                                                                "points":  6,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  222
                                            },
                                            {
                                                "position":  6,
@@ -9138,7 +9528,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  204
                                            },
                                            {
                                                "position":  7,
@@ -9167,7 +9558,8 @@
                                                                                "points":  7,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  196
                                            },
                                            {
                                                "position":  8,
@@ -9192,7 +9584,8 @@
                                                                                "points":  12,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  491
                                            },
                                            {
                                                "position":  9,
@@ -9217,7 +9610,8 @@
                                                                                 "points":  8,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  504
                                            },
                                            {
                                                "position":  10,
@@ -9246,7 +9640,8 @@
                                                                                 "points":  15,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  499
                                            },
                                            {
                                                "position":  11,
@@ -9275,7 +9670,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  220
                                            },
                                            {
                                                "position":  12,
@@ -9312,7 +9708,8 @@
                                                                                 "points":  12,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  254
                                            },
                                            {
                                                "position":  13,
@@ -9341,7 +9738,8 @@
                                                                                 "points":  9,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  217
                                            },
                                            {
                                                "position":  14,
@@ -9366,7 +9764,8 @@
                                                                                 "points":  14,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  507
                                            },
                                            {
                                                "position":  15,
@@ -9391,7 +9790,8 @@
                                                                               "points":  16,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  502
                                            },
                                            {
                                                "position":  16,
@@ -9424,7 +9824,8 @@
                                                                                "points":  13,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  236
                                            },
                                            {
                                                "position":  17,
@@ -9453,7 +9854,8 @@
                                                                                 "points":  13,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  506
                                            },
                                            {
                                                "position":  18,
@@ -9486,7 +9888,8 @@
                                                                                 "points":  16,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  514
                                            },
                                            {
                                                "position":  19,
@@ -9515,7 +9918,8 @@
                                                                                 "points":  20,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  524
                                            },
                                            {
                                                "position":  20,
@@ -9544,7 +9948,8 @@
                                                                               "points":  18,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  241
                                            },
                                            {
                                                "position":  21,
@@ -9577,7 +9982,8 @@
                                                                                 "points":  25,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  262
                                            },
                                            {
                                                "position":  22,
@@ -9602,7 +10008,8 @@
                                                                                 "points":  19,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  586
                                            },
                                            {
                                                "position":  23,
@@ -9627,7 +10034,8 @@
                                                                                 "points":  17,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  239
                                            },
                                            {
                                                "position":  24,
@@ -9656,7 +10064,8 @@
                                                                                 "points":  32,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  231
                                            },
                                            {
                                                "position":  25,
@@ -9685,7 +10094,8 @@
                                                                                 "points":  22,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  520
                                            },
                                            {
                                                "position":  26,
@@ -9710,7 +10120,8 @@
                                                                                 "points":  18,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  513
                                            },
                                            {
                                                "position":  27,
@@ -9743,7 +10154,8 @@
                                                                                 "points":  24,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  347
                                            },
                                            {
                                                "position":  28,
@@ -9768,7 +10180,8 @@
                                                                                "points":  22,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  278
                                            },
                                            {
                                                "position":  29,
@@ -9797,7 +10210,8 @@
                                                                                "points":  25,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  295
                                            },
                                            {
                                                "position":  30,
@@ -9822,7 +10236,8 @@
                                                                                "points":  27,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  587
                                            },
                                            {
                                                "position":  31,
@@ -9851,7 +10266,8 @@
                                                                                 "points":  28,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  286
                                            },
                                            {
                                                "position":  32,
@@ -9888,7 +10304,8 @@
                                                                                 "points":  30,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  292
                                            },
                                            {
                                                "position":  33,
@@ -9921,7 +10338,8 @@
                                                                                 "points":  40,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  328
                                            },
                                            {
                                                "position":  34,
@@ -9950,7 +10368,8 @@
                                                                                 "points":  34,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  531
                                            },
                                            {
                                                "position":  35,
@@ -9983,7 +10402,8 @@
                                                                                 "points":  29,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  290
                                            },
                                            {
                                                "position":  36,
@@ -10008,7 +10428,8 @@
                                                                                 "points":  36,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  610
                                            },
                                            {
                                                "position":  37,
@@ -10037,7 +10458,8 @@
                                                                                "points":  29,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  302
                                            },
                                            {
                                                "position":  38,
@@ -10070,7 +10492,8 @@
                                                                                "points":  47,
                                                                                "counting":  false
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  340
                                            },
                                            {
                                                "position":  39,
@@ -10095,7 +10518,8 @@
                                                                                 "points":  23,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  319
                                            },
                                            {
                                                "position":  40,
@@ -10124,7 +10548,8 @@
                                                                                 "points":  38,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  304
                                            },
                                            {
                                                "position":  41,
@@ -10153,7 +10578,8 @@
                                                                               "points":  43,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  326
                                            },
                                            {
                                                "position":  42,
@@ -10186,7 +10612,8 @@
                                                                                 "points":  37,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  551
                                            },
                                            {
                                                "position":  43,
@@ -10215,7 +10642,8 @@
                                                                                 "points":  35,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  332
                                            },
                                            {
                                                "position":  44,
@@ -10244,7 +10672,8 @@
                                                                                "points":  32,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  358
                                            },
                                            {
                                                "position":  45,
@@ -10281,7 +10710,8 @@
                                                                                 "points":  43,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  336
                                            },
                                            {
                                                "position":  46,
@@ -10310,7 +10740,8 @@
                                                                                 "points":  44,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  353
                                            },
                                            {
                                                "position":  47,
@@ -10335,7 +10766,8 @@
                                                                                "points":  50,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  339
                                            },
                                            {
                                                "position":  48,
@@ -10372,7 +10804,8 @@
                                                                                 "points":  48,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  384
                                            },
                                            {
                                                "position":  49,
@@ -10397,7 +10830,8 @@
                                                                                 "points":  27,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  540
                                            },
                                            {
                                                "position":  50,
@@ -10430,7 +10864,8 @@
                                                                                 "points":  50,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  407
                                            },
                                            {
                                                "position":  51,
@@ -10459,7 +10894,8 @@
                                                                                 "points":  52,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  362
                                            },
                                            {
                                                "position":  52,
@@ -10488,7 +10924,8 @@
                                                                               "points":  54,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  366
                                            },
                                            {
                                                "position":  53,
@@ -10521,7 +10958,8 @@
                                                                                 "points":  54,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  399
                                            },
                                            {
                                                "position":  54,
@@ -10550,7 +10988,8 @@
                                                                                "points":  37,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  401
                                            },
                                            {
                                                "position":  55,
@@ -10583,7 +11022,8 @@
                                                                                 "points":  46,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  334
                                            },
                                            {
                                                "position":  56,
@@ -10620,7 +11060,8 @@
                                                                                 "points":  51,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  382
                                            },
                                            {
                                                "position":  57,
@@ -10649,7 +11090,8 @@
                                                                               "points":  58,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  374
                                            },
                                            {
                                                "position":  58,
@@ -10678,7 +11120,8 @@
                                                                                "points":  45,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  422
                                            },
                                            {
                                                "position":  59,
@@ -10703,7 +11146,8 @@
                                                                                "points":  46,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  532
                                            },
                                            {
                                                "position":  60,
@@ -10728,7 +11172,8 @@
                                                                               "points":  74,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  333
                                            },
                                            {
                                                "position":  61,
@@ -10753,7 +11198,8 @@
                                                                                 "points":  56,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  348
                                            },
                                            {
                                                "position":  62,
@@ -10778,7 +11224,8 @@
                                                                                 "points":  48,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  359
                                            },
                                            {
                                                "position":  63,
@@ -10807,7 +11254,8 @@
                                                                               "points":  62,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  367
                                            },
                                            {
                                                "position":  64,
@@ -10836,7 +11284,8 @@
                                                                               "points":  72,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  387
                                            },
                                            {
                                                "position":  65,
@@ -10869,7 +11318,8 @@
                                                                                "points":  59,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  403
                                            },
                                            {
                                                "position":  66,
@@ -10894,7 +11344,8 @@
                                                                                 "points":  47,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  617
                                            },
                                            {
                                                "position":  67,
@@ -10923,7 +11374,8 @@
                                                                                "points":  58,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  408
                                            },
                                            {
                                                "position":  68,
@@ -10956,7 +11408,8 @@
                                                                                 "points":  59,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  457
                                            },
                                            {
                                                "position":  69,
@@ -10985,7 +11438,8 @@
                                                                                "points":  64,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  416
                                            },
                                            {
                                                "position":  70,
@@ -11014,7 +11468,8 @@
                                                                                 "points":  61,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  561
                                            },
                                            {
                                                "position":  71,
@@ -11047,7 +11502,8 @@
                                                                                 "points":  56,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  443
                                            },
                                            {
                                                "position":  72,
@@ -11072,7 +11528,8 @@
                                                                                 "points":  63,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  385
                                            },
                                            {
                                                "position":  73,
@@ -11097,7 +11554,8 @@
                                                                                 "points":  58,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  451
                                            },
                                            {
                                                "position":  74,
@@ -11126,7 +11584,8 @@
                                                                                "points":  66,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  446
                                            },
                                            {
                                                "position":  75,
@@ -11151,7 +11610,8 @@
                                                                                 "points":  64,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  396
                                            },
                                            {
                                                "position":  76,
@@ -11180,7 +11640,8 @@
                                                                                "points":  75,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  439
                                            },
                                            {
                                                "position":  77,
@@ -11205,7 +11666,8 @@
                                                                                 "points":  55,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  425
                                            },
                                            {
                                                "position":  78,
@@ -11230,7 +11692,8 @@
                                                                                "points":  61,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  463
                                            },
                                            {
                                                "position":  79,
@@ -11255,7 +11718,8 @@
                                                                                "points":  68,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  557
                                            },
                                            {
                                                "position":  80,
@@ -11280,7 +11744,8 @@
                                                                                 "points":  63,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  436
                                            },
                                            {
                                                "position":  81,
@@ -11305,7 +11770,8 @@
                                                                               "points":  92,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  423
                                            },
                                            {
                                                "position":  82,
@@ -11330,7 +11796,8 @@
                                                                               "points":  93,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  455
                                            },
                                            {
                                                "position":  83,
@@ -11355,7 +11822,8 @@
                                                                                 "points":  73,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  440
                                            },
                                            {
                                                "position":  84,
@@ -11380,7 +11848,8 @@
                                                                               "points":  87,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  453
                                            },
                                            {
                                                "position":  85,
@@ -11405,7 +11874,8 @@
                                                                                "points":  81,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  466
                                            },
                                            {
                                                "position":  86,
@@ -11426,7 +11896,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  170
                                            },
                                            {
                                                "position":  87,
@@ -11447,7 +11918,8 @@
                                                                               "points":  4,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  500
                                            },
                                            {
                                                "position":  88,
@@ -11468,7 +11940,8 @@
                                                                                 "points":  10,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  632
                                            },
                                            {
                                                "position":  89,
@@ -11489,7 +11962,8 @@
                                                                               "points":  10,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  248
                                            },
                                            {
                                                "position":  90,
@@ -11510,7 +11984,8 @@
                                                                               "points":  13,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  280
                                            },
                                            {
                                                "position":  91,
@@ -11531,7 +12006,8 @@
                                                                                 "points":  31,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  639
                                            },
                                            {
                                                "position":  92,
@@ -11552,7 +12028,8 @@
                                                                               "points":  39,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  288
                                            },
                                            {
                                                "position":  93,
@@ -11573,7 +12050,8 @@
                                                                                 "points":  41,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  590
                                            },
                                            {
                                                "position":  94,
@@ -11594,7 +12072,8 @@
                                                                                "points":  43,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  322
                                            },
                                            {
                                                "position":  95,
@@ -11615,7 +12094,8 @@
                                                                               "points":  44,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  536
                                            },
                                            {
                                                "position":  96,
@@ -11636,7 +12116,8 @@
                                                                                 "points":  53,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  644
                                            },
                                            {
                                                "position":  97,
@@ -11657,7 +12138,8 @@
                                                                               "points":  50,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  354
                                            },
                                            {
                                                "position":  98,
@@ -11699,7 +12181,8 @@
                                                                                 "points":  49,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  543
                                            },
                                            {
                                                "position":  100,
@@ -11720,7 +12203,8 @@
                                                                               "points":  63,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  376
                                            },
                                            {
                                                "position":  101,
@@ -11741,7 +12225,8 @@
                                                                                 "points":  57,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  459
                                            },
                                            {
                                                "position":  102,
@@ -11762,7 +12247,8 @@
                                                                                "points":  67,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  431
                                            },
                                            {
                                                "position":  103,
@@ -11783,7 +12269,8 @@
                                                                               "points":  90,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  562
                                            },
                                            {
                                                "position":  104,
@@ -11804,7 +12291,8 @@
                                                                                "points":  82,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  564
                                            },
                                            {
                                                "position":  105,
@@ -11825,7 +12313,8 @@
                                                                               "points":  84,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  438
                                            },
                                            {
                                                "position":  106,
@@ -11846,7 +12335,8 @@
                                                                                "points":  79,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  454
                                            },
                                            {
                                                "position":  107,
@@ -11863,7 +12353,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  569
                                            },
                                            {
                                                "position":  108,
@@ -11880,7 +12371,8 @@
                                                                                 "points":  11,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  659
                                            },
                                            {
                                                "position":  109,
@@ -11897,7 +12389,8 @@
                                                                                "points":  9,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  581
                                            },
                                            {
                                                "position":  110,
@@ -11914,7 +12407,8 @@
                                                                               "points":  15,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  228
                                            },
                                            {
                                                "position":  111,
@@ -11931,7 +12425,8 @@
                                                                                 "points":  12,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  510
                                            },
                                            {
                                                "position":  112,
@@ -11948,7 +12443,8 @@
                                                                               "points":  17,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  585
                                            },
                                            {
                                                "position":  113,
@@ -11965,7 +12461,8 @@
                                                                                "points":  21,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  511
                                            },
                                            {
                                                "position":  114,
@@ -11982,7 +12479,8 @@
                                                                               "points":  20,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  261
                                            },
                                            {
                                                "position":  115,
@@ -11999,7 +12497,8 @@
                                                                               "points":  19,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  265
                                            },
                                            {
                                                "position":  116,
@@ -12016,7 +12515,8 @@
                                                                               "points":  26,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  271
                                            },
                                            {
                                                "position":  117,
@@ -12033,7 +12533,8 @@
                                                                               "points":  28,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  515
                                            },
                                            {
                                                "position":  118,
@@ -12050,7 +12551,8 @@
                                                                               "points":  31,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  268
                                            },
                                            {
                                                "position":  119,
@@ -12067,7 +12569,8 @@
                                                                                 "points":  21,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  294
                                            },
                                            {
                                                "position":  120,
@@ -12084,7 +12587,8 @@
                                                                                "points":  28,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  285
                                            },
                                            {
                                                "position":  121,
@@ -12101,7 +12605,8 @@
                                                                               "points":  34,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  275
                                            },
                                            {
                                                "position":  122,
@@ -12118,7 +12623,8 @@
                                                                               "points":  36,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  277
                                            },
                                            {
                                                "position":  123,
@@ -12135,7 +12641,8 @@
                                                                                 "points":  26,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  533
                                            },
                                            {
                                                "position":  124,
@@ -12152,7 +12659,8 @@
                                                                               "points":  46,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  611
                                            },
                                            {
                                                "position":  125,
@@ -12169,7 +12677,8 @@
                                                                                "points":  44,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  591
                                            },
                                            {
                                                "position":  126,
@@ -12186,7 +12695,8 @@
                                                                                "points":  36,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  317
                                            },
                                            {
                                                "position":  127,
@@ -12203,7 +12713,8 @@
                                                                                 "points":  42,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  643
                                            },
                                            {
                                                "position":  128,
@@ -12220,7 +12731,8 @@
                                                                                "points":  49,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  612
                                            },
                                            {
                                                "position":  129,
@@ -12237,7 +12749,8 @@
                                                                                 "points":  42,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  593
                                            },
                                            {
                                                "position":  130,
@@ -12254,7 +12767,8 @@
                                                                               "points":  47,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  338
                                            },
                                            {
                                                "position":  131,
@@ -12271,7 +12785,8 @@
                                                                                "points":  54,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  539
                                            },
                                            {
                                                "position":  132,
@@ -12288,7 +12803,8 @@
                                                                               "points":  53,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  343
                                            },
                                            {
                                                "position":  133,
@@ -12305,7 +12821,8 @@
                                                                               "points":  65,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  352
                                            },
                                            {
                                                "position":  134,
@@ -12322,7 +12839,8 @@
                                                                                 "points":  60,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  423
                                            },
                                            {
                                                "position":  135,
@@ -12339,7 +12857,8 @@
                                                                               "points":  79,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  616
                                            },
                                            {
                                                "position":  136,
@@ -12356,7 +12875,8 @@
                                                                                 "points":  52,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  397
                                            },
                                            {
                                                "position":  137,
@@ -12373,7 +12893,8 @@
                                                                                "points":  62,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  646
                                            },
                                            {
                                                "position":  138,
@@ -12390,7 +12911,8 @@
                                                                                 "points":  62,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  668
                                            },
                                            {
                                                "position":  139,
@@ -12407,7 +12929,8 @@
                                                                               "points":  70,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  595
                                            },
                                            {
                                                "position":  140,
@@ -12424,7 +12947,8 @@
                                                                                 "points":  57,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  549
                                            },
                                            {
                                                "position":  141,
@@ -12441,7 +12965,8 @@
                                                                               "points":  63,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  391
                                            },
                                            {
                                                "position":  142,
@@ -12458,7 +12983,8 @@
                                                                               "points":  72,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  377
                                            },
                                            {
                                                "position":  143,
@@ -12475,7 +13001,8 @@
                                                                               "points":  78,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  597
                                            },
                                            {
                                                "position":  144,
@@ -12492,7 +13019,8 @@
                                                                               "points":  71,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  395
                                            },
                                            {
                                                "position":  145,
@@ -12509,7 +13037,8 @@
                                                                                "points":  69,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  651
                                            },
                                            {
                                                "position":  146,
@@ -12526,7 +13055,8 @@
                                                                               "points":  74,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  404
                                            },
                                            {
                                                "position":  147,
@@ -12543,7 +13073,8 @@
                                                                               "points":  81,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  411
                                            },
                                            {
                                                "position":  148,
@@ -12560,7 +13091,8 @@
                                                                               "points":  84,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  412
                                            },
                                            {
                                                "position":  149,
@@ -12577,7 +13109,8 @@
                                                                               "points":  87,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  435
                                            },
                                            {
                                                "position":  150,
@@ -12594,7 +13127,8 @@
                                                                                 "points":  72,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  461
                                            },
                                            {
                                                "position":  151,
@@ -12611,7 +13145,8 @@
                                                                                "points":  80,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  464
                                            },
                                            {
                                                "position":  152,
@@ -12628,7 +13163,8 @@
                                                                               "points":  100,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  458
                                            },
                                            {
                                                "position":  153,
@@ -12645,7 +13181,8 @@
                                                                               "points":  102,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  467
                                            },
                                            {
                                                "position":  154,
@@ -12658,7 +13195,8 @@
                                                                                  "points":  1,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  125
                                            },
                                            {
                                                "position":  155,
@@ -12671,7 +13209,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  600
                                            },
                                            {
                                                "position":  156,
@@ -12684,7 +13223,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  481
                                            },
                                            {
                                                "position":  157,
@@ -12697,7 +13237,8 @@
                                                                                "points":  1,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  656
                                            },
                                            {
                                                "position":  158,
@@ -12710,7 +13251,8 @@
                                                                                "points":  2,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  574
                                            },
                                            {
                                                "position":  159,
@@ -12723,7 +13265,8 @@
                                                                                  "points":  2,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  145
                                            },
                                            {
                                                "position":  160,
@@ -12736,7 +13279,8 @@
                                                                                  "points":  5,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  167
                                            },
                                            {
                                                "position":  161,
@@ -12749,7 +13293,8 @@
                                                                                  "points":  10,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  202
                                            },
                                            {
                                                "position":  162,
@@ -12762,7 +13307,8 @@
                                                                                  "points":  12,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  207
                                            },
                                            {
                                                "position":  163,
@@ -12775,7 +13321,8 @@
                                                                                  "points":  13,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  210
                                            },
                                            {
                                                "position":  164,
@@ -12788,7 +13335,8 @@
                                                                                  "points":  15,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  218
                                            },
                                            {
                                                "position":  165,
@@ -12801,7 +13349,8 @@
                                                                               "points":  16,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  505
                                            },
                                            {
                                                "position":  166,
@@ -12814,7 +13363,8 @@
                                                                                "points":  18,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  584
                                            },
                                            {
                                                "position":  167,
@@ -12827,7 +13377,8 @@
                                                                                  "points":  19,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  229
                                            },
                                            {
                                                "position":  168,
@@ -12840,7 +13391,8 @@
                                                                               "points":  27,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  634
                                            },
                                            {
                                                "position":  169,
@@ -12853,7 +13405,8 @@
                                                                                "points":  31,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  662
                                            },
                                            {
                                                "position":  170,
@@ -12866,7 +13419,8 @@
                                                                                 "points":  33,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  674
                                            },
                                            {
                                                "position":  171,
@@ -12879,7 +13433,8 @@
                                                                                 "points":  39,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  675
                                            },
                                            {
                                                "position":  172,
@@ -12892,7 +13447,8 @@
                                                                               "points":  42,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  525
                                            },
                                            {
                                                "position":  173,
@@ -12905,7 +13461,8 @@
                                                                                  "points":  42,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  297
                                            },
                                            {
                                                "position":  174,
@@ -12918,7 +13475,8 @@
                                                                                  "points":  43,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  300
                                            },
                                            {
                                                "position":  175,
@@ -12931,7 +13489,8 @@
                                                                               "points":  43,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  526
                                            },
                                            {
                                                "position":  176,
@@ -12944,7 +13503,8 @@
                                                                               "points":  44,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  530
                                            },
                                            {
                                                "position":  177,
@@ -12957,7 +13517,8 @@
                                                                                 "points":  45,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  678
                                            },
                                            {
                                                "position":  178,
@@ -12970,7 +13531,8 @@
                                                                                  "points":  46,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  314
                                            },
                                            {
                                                "position":  179,
@@ -12983,7 +13545,8 @@
                                                                                  "points":  47,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  316
                                            },
                                            {
                                                "position":  180,
@@ -12996,7 +13559,8 @@
                                                                                "points":  48,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  663
                                            },
                                            {
                                                "position":  181,
@@ -13009,7 +13573,8 @@
                                                                                "points":  51,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  664
                                            },
                                            {
                                                "position":  182,
@@ -13022,7 +13587,8 @@
                                                                                "points":  53,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  665
                                            },
                                            {
                                                "position":  183,
@@ -13035,7 +13601,8 @@
                                                                                  "points":  53,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  330
                                            },
                                            {
                                                "position":  184,
@@ -13048,7 +13615,8 @@
                                                                                "points":  63,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  594
                                            },
                                            {
                                                "position":  185,
@@ -13061,7 +13629,8 @@
                                                                                "points":  63,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  667
                                            },
                                            {
                                                "position":  186,
@@ -13074,7 +13643,8 @@
                                                                               "points":  65,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  542
                                            },
                                            {
                                                "position":  187,
@@ -13087,7 +13657,8 @@
                                                                                 "points":  67,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  618
                                            },
                                            {
                                                "position":  188,
@@ -13100,7 +13671,8 @@
                                                                                 "points":  68,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  619
                                            },
                                            {
                                                "position":  189,
@@ -13113,7 +13685,8 @@
                                                                                  "points":  70,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  365
                                            },
                                            {
                                                "position":  190,
@@ -13126,7 +13699,8 @@
                                                                                  "points":  73,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  371
                                            },
                                            {
                                                "position":  191,
@@ -13139,7 +13713,8 @@
                                                                                  "points":  77,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  381
                                            },
                                            {
                                                "position":  192,
@@ -13152,7 +13727,8 @@
                                                                               "points":  78,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  546
                                            },
                                            {
                                                "position":  193,
@@ -13165,7 +13741,8 @@
                                                                               "points":  79,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  547
                                            },
                                            {
                                                "position":  194,
@@ -13178,7 +13755,8 @@
                                                                                  "points":  82,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  390
                                            },
                                            {
                                                "position":  195,
@@ -13191,7 +13769,8 @@
                                                                               "points":  86,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  648
                                            },
                                            {
                                                "position":  196,
@@ -13204,7 +13783,8 @@
                                                                                  "points":  88,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  400
                                            },
                                            {
                                                "position":  197,
@@ -13217,7 +13797,8 @@
                                                                               "points":  88,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  649
                                            },
                                            {
                                                "position":  198,
@@ -13230,7 +13811,8 @@
                                                                               "points":  89,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  650
                                            },
                                            {
                                                "position":  199,
@@ -13243,7 +13825,8 @@
                                                                                  "points":  90,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  402
                                            },
                                            {
                                                "position":  200,
@@ -13256,7 +13839,8 @@
                                                                                  "points":  93,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  405
                                            },
                                            {
                                                "position":  201,
@@ -13269,7 +13853,8 @@
                                                                               "points":  93,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  558
                                            },
                                            {
                                                "position":  202,
@@ -13282,7 +13867,8 @@
                                                                               "points":  95,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  560
                                            },
                                            {
                                                "position":  203,
@@ -13295,7 +13881,8 @@
                                                                                  "points":  98,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  414
                                            },
                                            {
                                                "position":  204,
@@ -13308,7 +13895,8 @@
                                                                                  "points":  100,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  419
                                            },
                                            {
                                                "position":  205,
@@ -13321,7 +13909,8 @@
                                                                               "points":  101,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  563
                                            },
                                            {
                                                "position":  206,
@@ -13334,7 +13923,8 @@
                                                                                  "points":  103,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  424
                                            },
                                            {
                                                "position":  207,
@@ -13347,7 +13937,8 @@
                                                                               "points":  105,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  566
                                            },
                                            {
                                                "position":  208,
@@ -13360,7 +13951,8 @@
                                                                                  "points":  105,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  426
                                            },
                                            {
                                                "position":  209,
@@ -13373,7 +13965,8 @@
                                                                                  "points":  106,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  429
                                            },
                                            {
                                                "position":  210,
@@ -13386,7 +13979,8 @@
                                                                                  "points":  113,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  441
                                            },
                                            {
                                                "position":  211,
@@ -13399,7 +13993,8 @@
                                                                                  "points":  115,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  444
                                            },
                                            {
                                                "position":  212,
@@ -13412,7 +14007,8 @@
                                                                                  "points":  121,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  456
                                            },
                                            {
                                                "position":  213,
@@ -13425,7 +14021,8 @@
                                                                                  "points":  125,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  460
                                            },
                                            {
                                                "position":  214,
@@ -13438,7 +14035,8 @@
                                                                                  "points":  127,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  462
                                            }
                                        ]
                        },
@@ -13473,7 +14071,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  163
                                            },
                                            {
                                                "position":  2,
@@ -13505,7 +14104,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  204
                                            },
                                            {
                                                "position":  3,
@@ -13529,7 +14129,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  239
                                            },
                                            {
                                                "position":  4,
@@ -13565,7 +14166,8 @@
                                                                                 "points":  5,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  292
                                            },
                                            {
                                                "position":  5,
@@ -13589,7 +14191,8 @@
                                                                                "points":  6,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  587
                                            },
                                            {
                                                "position":  6,
@@ -13617,7 +14220,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  531
                                            },
                                            {
                                                "position":  7,
@@ -13641,7 +14245,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  359
                                            },
                                            {
                                                "position":  8,
@@ -13673,7 +14278,8 @@
                                                                                "points":  12,
                                                                                "counting":  false
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  403
                                            },
                                            {
                                                "position":  9,
@@ -13701,7 +14307,8 @@
                                                                                 "points":  8,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  561
                                            },
                                            {
                                                "position":  10,
@@ -13721,7 +14328,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  644
                                            },
                                            {
                                                "position":  11,
@@ -13737,7 +14345,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  569
                                            },
                                            {
                                                "position":  12,
@@ -13753,7 +14362,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  510
                                            },
                                            {
                                                "position":  13,
@@ -13769,7 +14379,8 @@
                                                                                "points":  3,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  581
                                            },
                                            {
                                                "position":  14,
@@ -13785,7 +14396,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  659
                                            },
                                            {
                                                "position":  15,
@@ -13801,7 +14413,8 @@
                                                                               "points":  4,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  277
                                            },
                                            {
                                                "position":  16,
@@ -13817,7 +14430,8 @@
                                                                               "points":  8,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  611
                                            },
                                            {
                                                "position":  17,
@@ -13833,7 +14447,8 @@
                                                                                 "points":  9,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  668
                                            },
                                            {
                                                "position":  18,
@@ -13845,7 +14460,8 @@
                                                                                  "points":  1,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  145
                                            },
                                            {
                                                "position":  19,
@@ -13857,7 +14473,8 @@
                                                                                "points":  7,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  662
                                            },
                                            {
                                                "position":  20,
@@ -13869,7 +14486,8 @@
                                                                                  "points":  7,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  314
                                            },
                                            {
                                                "position":  21,
@@ -13881,7 +14499,8 @@
                                                                                  "points":  8,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  316
                                            },
                                            {
                                                "position":  22,
@@ -13893,7 +14512,8 @@
                                                                                 "points":  8,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  619
                                            },
                                            {
                                                "position":  23,
@@ -13905,7 +14525,8 @@
                                                                                  "points":  10,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  371
                                            },
                                            {
                                                "position":  24,
@@ -13917,7 +14538,8 @@
                                                                                "points":  11,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  665
                                            },
                                            {
                                                "position":  25,
@@ -13929,7 +14551,8 @@
                                                                                  "points":  12,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  419
                                            },
                                            {
                                                "position":  26,
@@ -13941,7 +14564,8 @@
                                                                                  "points":  13,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  441
                                            }
                                        ]
                        },
@@ -13980,7 +14604,8 @@
                                                                                "points":  1,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  106
                                            },
                                            {
                                                "position":  2,
@@ -14012,7 +14637,8 @@
                                                                                "points":  4,
                                                                                "counting":  false
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  110
                                            },
                                            {
                                                "position":  3,
@@ -14040,7 +14666,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  117
                                            },
                                            {
                                                "position":  4,
@@ -14072,7 +14699,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  130
                                            },
                                            {
                                                "position":  5,
@@ -14096,7 +14724,8 @@
                                                                               "points":  7,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  127
                                            },
                                            {
                                                "position":  6,
@@ -14124,7 +14753,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  123
                                            },
                                            {
                                                "position":  7,
@@ -14148,7 +14778,8 @@
                                                                                "points":  6,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  140
                                            },
                                            {
                                                "position":  8,
@@ -14184,7 +14815,8 @@
                                                                                 "points":  5,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  134
                                            },
                                            {
                                                "position":  9,
@@ -14212,7 +14844,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  161
                                            },
                                            {
                                                "position":  10,
@@ -14248,7 +14881,8 @@
                                                                                 "points":  9,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  166
                                            },
                                            {
                                                "position":  11,
@@ -14276,7 +14910,8 @@
                                                                                "points":  12,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  182
                                            },
                                            {
                                                "position":  12,
@@ -14304,7 +14939,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  211
                                            },
                                            {
                                                "position":  13,
@@ -14340,7 +14976,8 @@
                                                                                 "points":  10,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  205
                                            },
                                            {
                                                "position":  14,
@@ -14376,7 +15013,8 @@
                                                                                 "points":  12,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  252
                                            },
                                            {
                                                "position":  15,
@@ -14400,7 +15038,8 @@
                                                                                "points":  16,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  178
                                            },
                                            {
                                                "position":  16,
@@ -14428,7 +15067,8 @@
                                                                               "points":  15,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  283
                                            },
                                            {
                                                "position":  17,
@@ -14452,7 +15092,8 @@
                                                                               "points":  16,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  233
                                            },
                                            {
                                                "position":  18,
@@ -14476,7 +15117,8 @@
                                                                               "points":  18,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  518
                                            },
                                            {
                                                "position":  19,
@@ -14504,7 +15146,8 @@
                                                                                 "points":  15,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  344
                                            },
                                            {
                                                "position":  20,
@@ -14528,7 +15171,8 @@
                                                                                "points":  17,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  337
                                            },
                                            {
                                                "position":  21,
@@ -14548,7 +15192,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  621
                                            },
                                            {
                                                "position":  22,
@@ -14568,7 +15213,8 @@
                                                                                "points":  3,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  472
                                            },
                                            {
                                                "position":  23,
@@ -14588,7 +15234,8 @@
                                                                                 "points":  8,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  482
                                            },
                                            {
                                                "position":  24,
@@ -14608,7 +15255,8 @@
                                                                                 "points":  17,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  522
                                            },
                                            {
                                                "position":  25,
@@ -14628,7 +15276,8 @@
                                                                                 "points":  19,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  537
                                            },
                                            {
                                                "position":  26,
@@ -14648,7 +15297,8 @@
                                                                               "points":  22,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  434
                                            },
                                            {
                                                "position":  27,
@@ -14664,7 +15314,8 @@
                                                                               "points":  3,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  109
                                            },
                                            {
                                                "position":  28,
@@ -14680,7 +15331,8 @@
                                                                                "points":  10,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  571
                                            },
                                            {
                                                "position":  29,
@@ -14696,7 +15348,8 @@
                                                                               "points":  10,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  573
                                            },
                                            {
                                                "position":  30,
@@ -14712,7 +15365,8 @@
                                                                                "points":  12,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  483
                                            },
                                            {
                                                "position":  31,
@@ -14728,7 +15382,8 @@
                                                                               "points":  9,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  169
                                            },
                                            {
                                                "position":  32,
@@ -14744,7 +15399,8 @@
                                                                                "points":  13,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  149
                                            },
                                            {
                                                "position":  33,
@@ -14760,7 +15416,8 @@
                                                                                 "points":  11,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  186
                                            },
                                            {
                                                "position":  34,
@@ -14776,7 +15433,8 @@
                                                                                 "points":  11,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  641
                                            },
                                            {
                                                "position":  35,
@@ -14792,7 +15450,8 @@
                                                                               "points":  16,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  200
                                            },
                                            {
                                                "position":  36,
@@ -14808,7 +15467,8 @@
                                                                                 "points":  14,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  216
                                            },
                                            {
                                                "position":  37,
@@ -14824,7 +15484,8 @@
                                                                                 "points":  13,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  589
                                            },
                                            {
                                                "position":  38,
@@ -14840,7 +15501,8 @@
                                                                                "points":  17,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  214
                                            },
                                            {
                                                "position":  39,
@@ -14856,7 +15518,8 @@
                                                                               "points":  26,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  351
                                            },
                                            {
                                                "position":  40,
@@ -14872,7 +15535,8 @@
                                                                               "points":  30,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  450
                                            },
                                            {
                                                "position":  41,
@@ -14884,7 +15548,8 @@
                                                                                "points":  2,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  568
                                            },
                                            {
                                                "position":  42,
@@ -14896,7 +15561,8 @@
                                                                                "points":  7,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  657
                                            },
                                            {
                                                "position":  43,
@@ -14908,7 +15574,8 @@
                                                                               "points":  12,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  626
                                            },
                                            {
                                                "position":  44,
@@ -14920,7 +15587,8 @@
                                                                                 "points":  14,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  676
                                            },
                                            {
                                                "position":  45,
@@ -14932,7 +15600,8 @@
                                                                               "points":  18,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  501
                                            },
                                            {
                                                "position":  46,
@@ -14944,7 +15613,8 @@
                                                                               "points":  21,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  509
                                            },
                                            {
                                                "position":  47,
@@ -14956,7 +15626,8 @@
                                                                                  "points":  25,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  291
                                            },
                                            {
                                                "position":  48,
@@ -14968,7 +15639,8 @@
                                                                                  "points":  26,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  327
                                            },
                                            {
                                                "position":  49,
@@ -14980,7 +15652,8 @@
                                                                                  "points":  30,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  379
                                            }
                                        ]
                        },
@@ -15015,7 +15688,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  506
                                            },
                                            {
                                                "position":  2,
@@ -15043,7 +15717,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  286
                                            },
                                            {
                                                "position":  3,
@@ -15075,7 +15750,8 @@
                                                                                "points":  5,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  340
                                            },
                                            {
                                                "position":  4,
@@ -15111,7 +15787,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  336
                                            },
                                            {
                                                "position":  5,
@@ -15135,7 +15812,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  319
                                            },
                                            {
                                                "position":  6,
@@ -15159,7 +15837,8 @@
                                                                               "points":  7,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  333
                                            },
                                            {
                                                "position":  7,
@@ -15191,7 +15870,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  443
                                            },
                                            {
                                                "position":  8,
@@ -15223,7 +15903,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  457
                                            },
                                            {
                                                "position":  9,
@@ -15247,7 +15928,8 @@
                                                                               "points":  9,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  423
                                            },
                                            {
                                                "position":  10,
@@ -15267,7 +15949,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  500
                                            },
                                            {
                                                "position":  11,
@@ -15283,7 +15966,8 @@
                                                                                "points":  1,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  511
                                            },
                                            {
                                                "position":  12,
@@ -15299,7 +15983,8 @@
                                                                               "points":  6,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  275
                                            },
                                            {
                                                "position":  13,
@@ -15315,7 +16000,8 @@
                                                                               "points":  5,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  338
                                            },
                                            {
                                                "position":  14,
@@ -15331,7 +16017,8 @@
                                                                                 "points":  8,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  423
                                            },
                                            {
                                                "position":  15,
@@ -15347,7 +16034,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  397
                                            },
                                            {
                                                "position":  16,
@@ -15363,7 +16051,8 @@
                                                                                "points":  7,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  539
                                            },
                                            {
                                                "position":  17,
@@ -15379,7 +16068,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  461
                                            },
                                            {
                                                "position":  18,
@@ -15395,7 +16085,8 @@
                                                                               "points":  15,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  458
                                            },
                                            {
                                                "position":  19,
@@ -15407,7 +16098,8 @@
                                                                                  "points":  1,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  207
                                            },
                                            {
                                                "position":  20,
@@ -15419,7 +16111,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  481
                                            },
                                            {
                                                "position":  21,
@@ -15431,7 +16124,8 @@
                                                                                "points":  3,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  584
                                            },
                                            {
                                                "position":  22,
@@ -15443,7 +16137,8 @@
                                                                                  "points":  5,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  330
                                            },
                                            {
                                                "position":  23,
@@ -15455,7 +16150,8 @@
                                                                                 "points":  5,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  678
                                            },
                                            {
                                                "position":  24,
@@ -15467,7 +16163,8 @@
                                                                                  "points":  11,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  405
                                            },
                                            {
                                                "position":  25,
@@ -15479,7 +16176,8 @@
                                                                               "points":  12,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  542
                                            },
                                            {
                                                "position":  26,
@@ -15491,7 +16189,8 @@
                                                                               "points":  13,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  547
                                            }
                                        ]
                        },
@@ -15530,7 +16229,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  112
                                            },
                                            {
                                                "position":  2,
@@ -15566,7 +16266,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  124
                                            },
                                            {
                                                "position":  3,
@@ -15598,7 +16299,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  139
                                            },
                                            {
                                                "position":  4,
@@ -15630,7 +16332,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  158
                                            },
                                            {
                                                "position":  5,
@@ -15662,7 +16365,8 @@
                                                                                "points":  4,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  155
                                            },
                                            {
                                                "position":  6,
@@ -15694,7 +16398,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  209
                                            },
                                            {
                                                "position":  7,
@@ -15718,7 +16423,8 @@
                                                                                 "points":  5,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  492
                                            },
                                            {
                                                "position":  8,
@@ -15750,7 +16456,8 @@
                                                                                 "points":  8,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  201
                                            },
                                            {
                                                "position":  9,
@@ -15778,7 +16485,8 @@
                                                                                 "points":  10,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  490
                                            },
                                            {
                                                "position":  10,
@@ -15810,7 +16518,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  256
                                            },
                                            {
                                                "position":  11,
@@ -15846,7 +16555,8 @@
                                                                                 "points":  9,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  234
                                            },
                                            {
                                                "position":  12,
@@ -15874,7 +16584,8 @@
                                                                                 "points":  12,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  303
                                            },
                                            {
                                                "position":  13,
@@ -15910,7 +16621,8 @@
                                                                                 "points":  13,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  421
                                            },
                                            {
                                                "position":  14,
@@ -15934,7 +16646,8 @@
                                                                                "points":  10,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  521
                                            },
                                            {
                                                "position":  15,
@@ -15958,7 +16671,8 @@
                                                                               "points":  20,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  370
                                            },
                                            {
                                                "position":  16,
@@ -15978,7 +16692,8 @@
                                                                                "points":  1,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  114
                                            },
                                            {
                                                "position":  17,
@@ -15998,7 +16713,8 @@
                                                                                "points":  11,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  198
                                            },
                                            {
                                                "position":  18,
@@ -16018,7 +16734,8 @@
                                                                               "points":  10,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  508
                                            },
                                            {
                                                "position":  19,
@@ -16038,7 +16755,8 @@
                                                                                "points":  12,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  357
                                            },
                                            {
                                                "position":  20,
@@ -16054,7 +16772,8 @@
                                                                                "points":  2,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  474
                                            },
                                            {
                                                "position":  21,
@@ -16070,7 +16789,8 @@
                                                                               "points":  7,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  159
                                            },
                                            {
                                                "position":  22,
@@ -16086,7 +16806,8 @@
                                                                                "points":  6,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  629
                                            },
                                            {
                                                "position":  23,
@@ -16102,7 +16823,8 @@
                                                                               "points":  9,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  187
                                            },
                                            {
                                                "position":  24,
@@ -16118,7 +16840,8 @@
                                                                                 "points":  11,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  637
                                            },
                                            {
                                                "position":  25,
@@ -16134,7 +16857,8 @@
                                                                               "points":  13,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  420
                                            },
                                            {
                                                "position":  26,
@@ -16150,7 +16874,8 @@
                                                                               "points":  19,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  516
                                            },
                                            {
                                                "position":  27,
@@ -16162,7 +16887,8 @@
                                                                               "points":  2,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  623
                                            },
                                            {
                                                "position":  28,
@@ -16174,7 +16900,8 @@
                                                                               "points":  6,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  479
                                            },
                                            {
                                                "position":  29,
@@ -16186,7 +16913,8 @@
                                                                               "points":  12,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  495
                                            },
                                            {
                                                "position":  30,
@@ -16198,7 +16926,8 @@
                                                                               "points":  14,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  633
                                            },
                                            {
                                                "position":  31,
@@ -16210,7 +16939,8 @@
                                                                               "points":  15,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  496
                                            },
                                            {
                                                "position":  32,
@@ -16222,7 +16952,8 @@
                                                                               "points":  22,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  541
                                            }
                                        ]
                        },
@@ -16253,7 +16984,8 @@
                                                                                "points":  2,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  491
                                            },
                                            {
                                                "position":  2,
@@ -16281,7 +17013,8 @@
                                                                               "points":  2,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  241
                                            },
                                            {
                                                "position":  3,
@@ -16309,7 +17042,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  231
                                            },
                                            {
                                                "position":  4,
@@ -16337,7 +17071,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  520
                                            },
                                            {
                                                "position":  5,
@@ -16369,7 +17104,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  347
                                            },
                                            {
                                                "position":  6,
@@ -16401,7 +17137,8 @@
                                                                                 "points":  5,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  290
                                            },
                                            {
                                                "position":  7,
@@ -16429,7 +17166,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  304
                                            },
                                            {
                                                "position":  8,
@@ -16457,7 +17195,8 @@
                                                                                "points":  5,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  358
                                            },
                                            {
                                                "position":  9,
@@ -16481,7 +17220,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  540
                                            },
                                            {
                                                "position":  10,
@@ -16513,7 +17253,8 @@
                                                                                 "points":  10,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  334
                                            },
                                            {
                                                "position":  11,
@@ -16549,7 +17290,8 @@
                                                                                 "points":  12,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  384
                                            },
                                            {
                                                "position":  12,
@@ -16577,7 +17319,8 @@
                                                                                "points":  6,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  401
                                            },
                                            {
                                                "position":  13,
@@ -16605,7 +17348,8 @@
                                                                               "points":  12,
                                                                               "counting":  false
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  374
                                            },
                                            {
                                                "position":  14,
@@ -16641,7 +17385,8 @@
                                                                                 "points":  13,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  382
                                            },
                                            {
                                                "position":  15,
@@ -16665,7 +17410,8 @@
                                                                                 "points":  11,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  617
                                            },
                                            {
                                                "position":  16,
@@ -16689,7 +17435,8 @@
                                                                                 "points":  14,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  451
                                            },
                                            {
                                                "position":  17,
@@ -16713,7 +17460,8 @@
                                                                                 "points":  15,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  385
                                            },
                                            {
                                                "position":  18,
@@ -16737,7 +17485,8 @@
                                                                                 "points":  18,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  440
                                            },
                                            {
                                                "position":  19,
@@ -16761,7 +17510,8 @@
                                                                               "points":  21,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  455
                                            },
                                            {
                                                "position":  20,
@@ -16781,7 +17531,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  632
                                            },
                                            {
                                                "position":  21,
@@ -16801,7 +17552,8 @@
                                                                                 "points":  8,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  590
                                            },
                                            {
                                                "position":  22,
@@ -16821,7 +17573,8 @@
                                                                               "points":  18,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  438
                                            },
                                            {
                                                "position":  23,
@@ -16837,7 +17590,8 @@
                                                                                "points":  3,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  285
                                            },
                                            {
                                                "position":  24,
@@ -16853,7 +17607,8 @@
                                                                                 "points":  9,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  643
                                            },
                                            {
                                                "position":  25,
@@ -16869,7 +17624,8 @@
                                                                               "points":  15,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  352
                                            },
                                            {
                                                "position":  26,
@@ -16885,7 +17641,8 @@
                                                                               "points":  13,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  377
                                            },
                                            {
                                                "position":  27,
@@ -16901,7 +17658,8 @@
                                                                               "points":  12,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  395
                                            },
                                            {
                                                "position":  28,
@@ -16917,7 +17675,8 @@
                                                                               "points":  17,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  616
                                            },
                                            {
                                                "position":  29,
@@ -16929,7 +17688,8 @@
                                                                               "points":  2,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  505
                                            },
                                            {
                                                "position":  30,
@@ -16941,7 +17701,8 @@
                                                                                  "points":  5,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  297
                                            },
                                            {
                                                "position":  31,
@@ -16953,7 +17714,8 @@
                                                                                "points":  11,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  594
                                            },
                                            {
                                                "position":  32,
@@ -16965,7 +17727,8 @@
                                                                               "points":  19,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  649
                                            },
                                            {
                                                "position":  33,
@@ -16977,7 +17740,8 @@
                                                                               "points":  20,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  650
                                            }
                                        ]
                        },
@@ -17012,7 +17776,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  131
                                            },
                                            {
                                                "position":  2,
@@ -17040,7 +17805,8 @@
                                                                               "points":  2,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  157
                                            },
                                            {
                                                "position":  3,
@@ -17076,7 +17842,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  189
                                            },
                                            {
                                                "position":  4,
@@ -17100,7 +17867,8 @@
                                                                               "points":  3,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  485
                                            },
                                            {
                                                "position":  5,
@@ -17128,7 +17896,8 @@
                                                                               "points":  5,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  177
                                            },
                                            {
                                                "position":  6,
@@ -17156,7 +17925,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  488
                                            },
                                            {
                                                "position":  7,
@@ -17184,7 +17954,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  190
                                            },
                                            {
                                                "position":  8,
@@ -17208,7 +17979,8 @@
                                                                                "points":  5,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  579
                                            },
                                            {
                                                "position":  9,
@@ -17236,7 +18008,8 @@
                                                                                 "points":  5,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  249
                                            },
                                            {
                                                "position":  10,
@@ -17260,7 +18033,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  203
                                            },
                                            {
                                                "position":  11,
@@ -17292,7 +18066,8 @@
                                                                                 "points":  9,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  197
                                            },
                                            {
                                                "position":  12,
@@ -17320,7 +18095,8 @@
                                                                                 "points":  10,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  226
                                            },
                                            {
                                                "position":  13,
@@ -17348,7 +18124,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  238
                                            },
                                            {
                                                "position":  14,
@@ -17384,7 +18161,8 @@
                                                                                 "points":  11,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  298
                                            },
                                            {
                                                "position":  15,
@@ -17412,7 +18190,8 @@
                                                                                "points":  10,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  287
                                            },
                                            {
                                                "position":  16,
@@ -17440,7 +18219,8 @@
                                                                                 "points":  14,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  321
                                            },
                                            {
                                                "position":  17,
@@ -17464,7 +18244,8 @@
                                                                                "points":  14,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  527
                                            },
                                            {
                                                "position":  18,
@@ -17492,7 +18273,8 @@
                                                                               "points":  20,
                                                                               "counting":  false
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  282
                                            },
                                            {
                                                "position":  19,
@@ -17524,7 +18306,8 @@
                                                                                 "points":  16,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  293
                                            },
                                            {
                                                "position":  20,
@@ -17548,7 +18331,8 @@
                                                                                 "points":  12,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  307
                                            },
                                            {
                                                "position":  21,
@@ -17572,7 +18356,8 @@
                                                                                 "points":  13,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  350
                                            },
                                            {
                                                "position":  22,
@@ -17608,7 +18393,8 @@
                                                                                 "points":  18,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  368
                                            },
                                            {
                                                "position":  23,
@@ -17640,7 +18426,8 @@
                                                                                 "points":  19,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  361
                                            },
                                            {
                                                "position":  24,
@@ -17664,7 +18451,8 @@
                                                                               "points":  23,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  331
                                            },
                                            {
                                                "position":  25,
@@ -17688,7 +18476,8 @@
                                                                               "points":  29,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  552
                                            },
                                            {
                                                "position":  26,
@@ -17708,7 +18497,8 @@
                                                                                 "points":  8,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  582
                                            },
                                            {
                                                "position":  27,
@@ -17728,7 +18518,8 @@
                                                                                "points":  6,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  603
                                            },
                                            {
                                                "position":  28,
@@ -17748,7 +18539,8 @@
                                                                                 "points":  10,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  258
                                            },
                                            {
                                                "position":  29,
@@ -17768,7 +18560,8 @@
                                                                                 "points":  15,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  313
                                            },
                                            {
                                                "position":  30,
@@ -17788,7 +18581,8 @@
                                                                                "points":  18,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  296
                                            },
                                            {
                                                "position":  31,
@@ -17808,7 +18602,8 @@
                                                                                 "points":  17,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  592
                                            },
                                            {
                                                "position":  32,
@@ -17824,7 +18619,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  658
                                            },
                                            {
                                                "position":  33,
@@ -17840,7 +18636,8 @@
                                                                                "points":  2,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  141
                                            },
                                            {
                                                "position":  34,
@@ -17856,7 +18653,8 @@
                                                                               "points":  10,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  193
                                            },
                                            {
                                                "position":  35,
@@ -17872,7 +18670,8 @@
                                                                               "points":  15,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  227
                                            },
                                            {
                                                "position":  36,
@@ -17888,7 +18687,8 @@
                                                                               "points":  14,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  242
                                            },
                                            {
                                                "position":  37,
@@ -17904,7 +18704,8 @@
                                                                               "points":  28,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  609
                                            },
                                            {
                                                "position":  38,
@@ -17920,7 +18721,8 @@
                                                                               "points":  26,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  614
                                            },
                                            {
                                                "position":  39,
@@ -17932,7 +18734,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  475
                                            },
                                            {
                                                "position":  40,
@@ -17944,7 +18747,8 @@
                                                                               "points":  2,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  476
                                            },
                                            {
                                                "position":  41,
@@ -17956,7 +18760,8 @@
                                                                                  "points":  4,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  164
                                            },
                                            {
                                                "position":  42,
@@ -17968,7 +18773,8 @@
                                                                                  "points":  5,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  165
                                            },
                                            {
                                                "position":  43,
@@ -17980,7 +18786,8 @@
                                                                               "points":  11,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  630
                                            },
                                            {
                                                "position":  44,
@@ -17992,7 +18799,8 @@
                                                                                  "points":  14,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  230
                                            },
                                            {
                                                "position":  45,
@@ -18004,7 +18812,8 @@
                                                                               "points":  18,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  638
                                            },
                                            {
                                                "position":  46,
@@ -18016,7 +18825,8 @@
                                                                               "points":  25,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  545
                                            },
                                            {
                                                "position":  47,
@@ -18028,7 +18838,8 @@
                                                                                  "points":  25,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  308
                                            },
                                            {
                                                "position":  48,
@@ -18040,7 +18851,8 @@
                                                                               "points":  27,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  556
                                            },
                                            {
                                                "position":  49,
@@ -18052,7 +18864,8 @@
                                                                                "points":  28,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  596
                                            },
                                            {
                                                "position":  50,
@@ -18064,7 +18877,8 @@
                                                                               "points":  30,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  647
                                            },
                                            {
                                                "position":  51,
@@ -18076,7 +18890,8 @@
                                                                                  "points":  32,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  375
                                            },
                                            {
                                                "position":  52,
@@ -18088,7 +18903,8 @@
                                                                                  "points":  33,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  428
                                            }
                                        ]
                        },
@@ -18131,7 +18947,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  254
                                            },
                                            {
                                                "position":  2,
@@ -18163,7 +18980,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  514
                                            },
                                            {
                                                "position":  3,
@@ -18195,7 +19013,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  262
                                            },
                                            {
                                                "position":  4,
@@ -18219,7 +19038,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  586
                                            },
                                            {
                                                "position":  5,
@@ -18247,7 +19067,8 @@
                                                                                "points":  5,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  422
                                            },
                                            {
                                                "position":  6,
@@ -18275,7 +19096,8 @@
                                                                               "points":  6,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  366
                                            },
                                            {
                                                "position":  7,
@@ -18299,7 +19121,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  425
                                            },
                                            {
                                                "position":  8,
@@ -18323,7 +19146,8 @@
                                                                               "points":  10,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  453
                                            },
                                            {
                                                "position":  9,
@@ -18343,7 +19167,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  170
                                            },
                                            {
                                                "position":  10,
@@ -18363,7 +19188,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  248
                                            },
                                            {
                                                "position":  11,
@@ -18383,7 +19209,8 @@
                                                                               "points":  3,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  280
                                            },
                                            {
                                                "position":  12,
@@ -18403,7 +19230,8 @@
                                                                               "points":  11,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  562
                                            },
                                            {
                                                "position":  13,
@@ -18423,7 +19251,8 @@
                                                                                "points":  7,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  564
                                            },
                                            {
                                                "position":  14,
@@ -18439,7 +19268,8 @@
                                                                               "points":  2,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  261
                                            },
                                            {
                                                "position":  15,
@@ -18455,7 +19285,8 @@
                                                                                "points":  6,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  612
                                            },
                                            {
                                                "position":  16,
@@ -18471,7 +19302,8 @@
                                                                               "points":  6,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  268
                                            },
                                            {
                                                "position":  17,
@@ -18487,7 +19319,8 @@
                                                                                 "points":  5,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  294
                                            },
                                            {
                                                "position":  18,
@@ -18503,7 +19336,8 @@
                                                                               "points":  8,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  597
                                            },
                                            {
                                                "position":  19,
@@ -18519,7 +19353,8 @@
                                                                               "points":  8,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  391
                                            },
                                            {
                                                "position":  20,
@@ -18535,7 +19370,8 @@
                                                                               "points":  13,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  467
                                            },
                                            {
                                                "position":  21,
@@ -18547,7 +19383,8 @@
                                                                                  "points":  2,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  202
                                            },
                                            {
                                                "position":  22,
@@ -18559,7 +19396,8 @@
                                                                                  "points":  3,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  218
                                            },
                                            {
                                                "position":  23,
@@ -18571,7 +19409,8 @@
                                                                                  "points":  4,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  229
                                            },
                                            {
                                                "position":  24,
@@ -18583,7 +19422,8 @@
                                                                               "points":  5,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  634
                                            },
                                            {
                                                "position":  25,
@@ -18595,7 +19435,8 @@
                                                                               "points":  10,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  560
                                            },
                                            {
                                                "position":  26,
@@ -18607,7 +19448,8 @@
                                                                                  "points":  12,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  365
                                            },
                                            {
                                                "position":  27,
@@ -18619,7 +19461,8 @@
                                                                                  "points":  15,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  402
                                            }
                                        ]
                        },
@@ -18654,7 +19497,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  473
                                            },
                                            {
                                                "position":  2,
@@ -18690,7 +19534,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  138
                                            },
                                            {
                                                "position":  3,
@@ -18718,7 +19563,8 @@
                                                                                "points":  3,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  147
                                            },
                                            {
                                                "position":  4,
@@ -18742,7 +19588,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  173
                                            },
                                            {
                                                "position":  5,
@@ -18770,7 +19617,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  174
                                            },
                                            {
                                                "position":  6,
@@ -18802,7 +19650,8 @@
                                                                                "points":  5,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  208
                                            },
                                            {
                                                "position":  7,
@@ -18826,7 +19675,8 @@
                                                                                "points":  6,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  489
                                            },
                                            {
                                                "position":  8,
@@ -18850,7 +19700,8 @@
                                                                                 "points":  5,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  606
                                            },
                                            {
                                                "position":  9,
@@ -18882,7 +19733,8 @@
                                                                                "points":  10,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  251
                                            },
                                            {
                                                "position":  10,
@@ -18914,7 +19766,8 @@
                                                                                 "points":  11,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  255
                                            },
                                            {
                                                "position":  11,
@@ -18938,7 +19791,8 @@
                                                                                 "points":  8,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  523
                                            },
                                            {
                                                "position":  12,
@@ -18974,7 +19828,8 @@
                                                                                 "points":  12,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  272
                                            },
                                            {
                                                "position":  13,
@@ -19002,7 +19857,8 @@
                                                                                "points":  12,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  215
                                            },
                                            {
                                                "position":  14,
@@ -19034,7 +19890,8 @@
                                                                                "points":  14,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  320
                                            },
                                            {
                                                "position":  15,
@@ -19062,7 +19919,8 @@
                                                                                 "points":  9,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  289
                                            },
                                            {
                                                "position":  16,
@@ -19090,7 +19948,8 @@
                                                                               "points":  19,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  329
                                            },
                                            {
                                                "position":  17,
@@ -19126,7 +19985,8 @@
                                                                                 "points":  14,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  325
                                            },
                                            {
                                                "position":  18,
@@ -19154,7 +20014,8 @@
                                                                                 "points":  13,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  301
                                            },
                                            {
                                                "position":  19,
@@ -19182,7 +20043,8 @@
                                                                                 "points":  17,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  309
                                            },
                                            {
                                                "position":  20,
@@ -19218,7 +20080,8 @@
                                                                                 "points":  16,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  373
                                            },
                                            {
                                                "position":  21,
@@ -19254,7 +20117,8 @@
                                                                                 "points":  15,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  398
                                            },
                                            {
                                                "position":  22,
@@ -19286,7 +20150,8 @@
                                                                                "points":  16,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  378
                                            },
                                            {
                                                "position":  23,
@@ -19310,7 +20175,8 @@
                                                                                 "points":  19,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  392
                                            },
                                            {
                                                "position":  24,
@@ -19334,7 +20200,8 @@
                                                                                 "points":  18,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  544
                                            },
                                            {
                                                "position":  25,
@@ -19358,7 +20225,8 @@
                                                                               "points":  27,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  386
                                            },
                                            {
                                                "position":  26,
@@ -19386,7 +20254,8 @@
                                                                                "points":  24,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  363
                                            },
                                            {
                                                "position":  27,
@@ -19418,7 +20287,8 @@
                                                                                "points":  25,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  449
                                            },
                                            {
                                                "position":  28,
@@ -19442,7 +20312,8 @@
                                                                               "points":  34,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  442
                                            },
                                            {
                                                "position":  29,
@@ -19462,7 +20333,8 @@
                                                                               "points":  4,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  148
                                            },
                                            {
                                                "position":  30,
@@ -19482,7 +20354,8 @@
                                                                                "points":  7,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  577
                                            },
                                            {
                                                "position":  31,
@@ -19502,7 +20375,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  240
                                            },
                                            {
                                                "position":  32,
@@ -19522,7 +20396,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  206
                                            },
                                            {
                                                "position":  33,
@@ -19542,7 +20417,8 @@
                                                                               "points":  11,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  266
                                            },
                                            {
                                                "position":  34,
@@ -19562,7 +20438,8 @@
                                                                                 "points":  15,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  305
                                            },
                                            {
                                                "position":  35,
@@ -19582,7 +20459,8 @@
                                                                                "points":  23,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  615
                                            },
                                            {
                                                "position":  36,
@@ -19602,7 +20480,8 @@
                                                                                "points":  20,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  360
                                            },
                                            {
                                                "position":  37,
@@ -19622,7 +20501,8 @@
                                                                               "points":  32,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  417
                                            },
                                            {
                                                "position":  38,
@@ -19642,7 +20522,8 @@
                                                                               "points":  35,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  598
                                            },
                                            {
                                                "position":  39,
@@ -19658,7 +20539,8 @@
                                                                                "points":  2,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  572
                                            },
                                            {
                                                "position":  40,
@@ -19674,7 +20556,8 @@
                                                                                "points":  9,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  519
                                            },
                                            {
                                                "position":  41,
@@ -19690,7 +20573,8 @@
                                                                               "points":  7,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  263
                                            },
                                            {
                                                "position":  42,
@@ -19706,7 +20590,8 @@
                                                                                 "points":  10,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  661
                                            },
                                            {
                                                "position":  43,
@@ -19722,7 +20607,8 @@
                                                                               "points":  28,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  273
                                            },
                                            {
                                                "position":  44,
@@ -19738,7 +20624,8 @@
                                                                               "points":  26,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  315
                                            },
                                            {
                                                "position":  45,
@@ -19754,7 +20641,8 @@
                                                                                "points":  29,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  447
                                            },
                                            {
                                                "position":  46,
@@ -19766,7 +20654,8 @@
                                                                               "points":  7,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  628
                                            },
                                            {
                                                "position":  47,
@@ -19778,7 +20667,8 @@
                                                                                  "points":  9,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  235
                                            },
                                            {
                                                "position":  48,
@@ -19790,7 +20680,8 @@
                                                                                  "points":  11,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  243
                                            },
                                            {
                                                "position":  49,
@@ -19802,7 +20693,8 @@
                                                                               "points":  18,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  535
                                            },
                                            {
                                                "position":  50,
@@ -19814,7 +20706,8 @@
                                                                                 "points":  20,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  613
                                            },
                                            {
                                                "position":  51,
@@ -19826,7 +20719,8 @@
                                                                                "points":  22,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  666
                                            },
                                            {
                                                "position":  52,
@@ -19838,7 +20732,8 @@
                                                                                  "points":  33,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  406
                                            },
                                            {
                                                "position":  53,
@@ -19850,7 +20745,8 @@
                                                                                  "points":  34,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  415
                                            },
                                            {
                                                "position":  54,
@@ -19862,7 +20758,8 @@
                                                                                  "points":  39,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  452
                                            }
                                        ]
                        },
@@ -19901,7 +20798,8 @@
                                                                                "points":  1,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  236
                                            },
                                            {
                                                "position":  2,
@@ -19925,7 +20823,8 @@
                                                                               "points":  2,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  502
                                            },
                                            {
                                                "position":  3,
@@ -19957,7 +20856,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  328
                                            },
                                            {
                                                "position":  4,
@@ -19981,7 +20881,8 @@
                                                                                "points":  2,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  278
                                            },
                                            {
                                                "position":  5,
@@ -20009,7 +20910,8 @@
                                                                                "points":  3,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  302
                                            },
                                            {
                                                "position":  6,
@@ -20037,7 +20939,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  353
                                            },
                                            {
                                                "position":  7,
@@ -20061,7 +20964,8 @@
                                                                                "points":  6,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  532
                                            },
                                            {
                                                "position":  8,
@@ -20089,7 +20993,8 @@
                                                                               "points":  5,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  367
                                            },
                                            {
                                                "position":  9,
@@ -20113,7 +21018,8 @@
                                                                                "points":  8,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  339
                                            },
                                            {
                                                "position":  10,
@@ -20141,7 +21047,8 @@
                                                                                "points":  12,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  446
                                            },
                                            {
                                                "position":  11,
@@ -20169,7 +21076,8 @@
                                                                                "points":  14,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  439
                                            },
                                            {
                                                "position":  12,
@@ -20193,7 +21101,8 @@
                                                                                 "points":  11,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  396
                                            },
                                            {
                                                "position":  13,
@@ -20217,7 +21126,8 @@
                                                                                "points":  10,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  463
                                            },
                                            {
                                                "position":  14,
@@ -20237,7 +21147,8 @@
                                                                                "points":  5,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  322
                                            },
                                            {
                                                "position":  15,
@@ -20257,7 +21168,8 @@
                                                                               "points":  6,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  376
                                            },
                                            {
                                                "position":  16,
@@ -20277,7 +21189,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  459
                                            },
                                            {
                                                "position":  17,
@@ -20293,7 +21206,8 @@
                                                                               "points":  2,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  265
                                            },
                                            {
                                                "position":  18,
@@ -20309,7 +21223,8 @@
                                                                               "points":  4,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  271
                                            },
                                            {
                                                "position":  19,
@@ -20325,7 +21240,8 @@
                                                                                "points":  5,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  317
                                            },
                                            {
                                                "position":  20,
@@ -20341,7 +21257,8 @@
                                                                               "points":  8,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  595
                                            },
                                            {
                                                "position":  21,
@@ -20357,7 +21274,8 @@
                                                                                "points":  11,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  646
                                            },
                                            {
                                                "position":  22,
@@ -20373,7 +21291,8 @@
                                                                                "points":  13,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  651
                                            },
                                            {
                                                "position":  23,
@@ -20385,7 +21304,8 @@
                                                                                "points":  7,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  663
                                            },
                                            {
                                                "position":  24,
@@ -20397,7 +21317,8 @@
                                                                                "points":  9,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  664
                                            },
                                            {
                                                "position":  25,
@@ -20409,7 +21330,8 @@
                                                                               "points":  12,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  648
                                            },
                                            {
                                                "position":  26,
@@ -20421,7 +21343,8 @@
                                                                                 "points":  12,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  618
                                            },
                                            {
                                                "position":  27,
@@ -20433,7 +21356,8 @@
                                                                                  "points":  13,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  390
                                            },
                                            {
                                                "position":  28,
@@ -20445,7 +21369,8 @@
                                                                               "points":  14,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  566
                                            },
                                            {
                                                "position":  29,
@@ -20457,7 +21382,8 @@
                                                                                  "points":  15,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  414
                                            },
                                            {
                                                "position":  30,
@@ -20469,7 +21395,8 @@
                                                                                  "points":  18,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  456
                                            },
                                            {
                                                "position":  31,
@@ -20481,7 +21408,8 @@
                                                                                  "points":  20,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  460
                                            },
                                            {
                                                "position":  32,
@@ -20493,7 +21421,8 @@
                                                                                  "points":  21,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  462
                                            }
                                        ]
                        },
@@ -20536,7 +21465,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  184
                                            },
                                            {
                                                "position":  2,
@@ -20572,7 +21502,8 @@
                                                                                 "points":  5,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  225
                                            },
                                            {
                                                "position":  3,
@@ -20596,7 +21527,8 @@
                                                                               "points":  4,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  498
                                            },
                                            {
                                                "position":  4,
@@ -20620,7 +21552,8 @@
                                                                               "points":  5,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  503
                                            },
                                            {
                                                "position":  5,
@@ -20648,7 +21581,8 @@
                                                                                "points":  8,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  245
                                            },
                                            {
                                                "position":  6,
@@ -20680,7 +21614,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  264
                                            },
                                            {
                                                "position":  7,
@@ -20708,7 +21643,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  312
                                            },
                                            {
                                                "position":  8,
@@ -20740,7 +21676,8 @@
                                                                                 "points":  8,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  528
                                            },
                                            {
                                                "position":  9,
@@ -20776,7 +21713,8 @@
                                                                                 "points":  11,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  355
                                            },
                                            {
                                                "position":  10,
@@ -20800,7 +21738,8 @@
                                                                               "points":  9,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  284
                                            },
                                            {
                                                "position":  11,
@@ -20828,7 +21767,8 @@
                                                                                 "points":  10,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  534
                                            },
                                            {
                                                "position":  12,
@@ -20856,7 +21796,8 @@
                                                                                 "points":  12,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  356
                                            },
                                            {
                                                "position":  13,
@@ -20880,7 +21821,8 @@
                                                                                 "points":  15,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  335
                                            },
                                            {
                                                "position":  14,
@@ -20912,7 +21854,8 @@
                                                                                 "points":  13,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  364
                                            },
                                            {
                                                "position":  15,
@@ -20944,7 +21887,8 @@
                                                                                 "points":  15,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  380
                                            },
                                            {
                                                "position":  16,
@@ -20968,7 +21912,8 @@
                                                                                "points":  13,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  432
                                            },
                                            {
                                                "position":  17,
@@ -20988,7 +21933,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  602
                                            },
                                            {
                                                "position":  18,
@@ -21008,7 +21954,8 @@
                                                                                 "points":  16,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  388
                                            },
                                            {
                                                "position":  19,
@@ -21024,7 +21971,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  627
                                            },
                                            {
                                                "position":  20,
@@ -21040,7 +21988,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  195
                                            },
                                            {
                                                "position":  21,
@@ -21056,7 +22005,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  583
                                            },
                                            {
                                                "position":  22,
@@ -21072,7 +22022,8 @@
                                                                               "points":  6,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  246
                                            },
                                            {
                                                "position":  23,
@@ -21088,7 +22039,8 @@
                                                                                 "points":  9,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  281
                                            },
                                            {
                                                "position":  24,
@@ -21104,7 +22056,8 @@
                                                                                 "points":  14,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  640
                                            },
                                            {
                                                "position":  25,
@@ -21120,7 +22073,8 @@
                                                                               "points":  13,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  554
                                            },
                                            {
                                                "position":  26,
@@ -21132,7 +22086,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  601
                                            },
                                            {
                                                "position":  27,
@@ -21144,7 +22099,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  671
                                            },
                                            {
                                                "position":  28,
@@ -21156,7 +22112,8 @@
                                                                               "points":  8,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  635
                                            },
                                            {
                                                "position":  29,
@@ -21168,7 +22125,8 @@
                                                                                  "points":  17,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  418
                                            },
                                            {
                                                "position":  30,
@@ -21180,7 +22138,8 @@
                                                                                  "points":  19,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  433
                                            }
                                        ]
                        },
@@ -21211,7 +22170,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  610
                                            },
                                            {
                                                "position":  2,
@@ -21235,7 +22195,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  348
                                            },
                                            {
                                                "position":  3,
@@ -21263,7 +22224,8 @@
                                                                                "points":  3,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  408
                                            },
                                            {
                                                "position":  4,
@@ -21291,7 +22253,8 @@
                                                                                "points":  5,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  416
                                            },
                                            {
                                                "position":  5,
@@ -21315,7 +22278,8 @@
                                                                                "points":  7,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  557
                                            },
                                            {
                                                "position":  6,
@@ -21335,7 +22299,8 @@
                                                                               "points":  3,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  354
                                            },
                                            {
                                                "position":  7,
@@ -21355,7 +22320,8 @@
                                                                               "points":  2,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  536
                                            },
                                            {
                                                "position":  8,
@@ -21375,7 +22341,8 @@
                                                                                "points":  6,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  431
                                            },
                                            {
                                                "position":  9,
@@ -21395,7 +22362,8 @@
                                                                                "points":  8,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  454
                                            },
                                            {
                                                "position":  10,
@@ -21411,7 +22379,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  228
                                            },
                                            {
                                                "position":  11,
@@ -21427,7 +22396,8 @@
                                                                                "points":  2,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  591
                                            },
                                            {
                                                "position":  12,
@@ -21443,7 +22413,8 @@
                                                                               "points":  4,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  404
                                            },
                                            {
                                                "position":  13,
@@ -21459,7 +22430,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  549
                                            },
                                            {
                                                "position":  14,
@@ -21475,7 +22447,8 @@
                                                                               "points":  5,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  411
                                            },
                                            {
                                                "position":  15,
@@ -21487,7 +22460,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  674
                                            },
                                            {
                                                "position":  16,
@@ -21499,7 +22473,8 @@
                                                                                "points":  4,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  667
                                            },
                                            {
                                                "position":  17,
@@ -21511,7 +22486,8 @@
                                                                                  "points":  8,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  426
                                            },
                                            {
                                                "position":  18,
@@ -21523,7 +22499,8 @@
                                                                                  "points":  9,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  429
                                            }
                                        ]
                        },
@@ -21562,7 +22539,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  194
                                            },
                                            {
                                                "position":  2,
@@ -21590,7 +22568,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  257
                                            },
                                            {
                                                "position":  3,
@@ -21618,7 +22597,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  219
                                            },
                                            {
                                                "position":  4,
@@ -21646,7 +22626,8 @@
                                                                                "points":  4,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  224
                                            },
                                            {
                                                "position":  5,
@@ -21678,7 +22659,8 @@
                                                                                "points":  6,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  345
                                            },
                                            {
                                                "position":  6,
@@ -21710,7 +22692,8 @@
                                                                                "points":  5,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  279
                                            },
                                            {
                                                "position":  7,
@@ -21738,7 +22721,8 @@
                                                                                 "points":  5,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  538
                                            },
                                            {
                                                "position":  8,
@@ -21770,7 +22754,8 @@
                                                                                 "points":  6,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  310
                                            },
                                            {
                                                "position":  9,
@@ -21798,7 +22783,8 @@
                                                                                 "points":  7,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  324
                                            },
                                            {
                                                "position":  10,
@@ -21834,7 +22820,8 @@
                                                                                 "points":  10,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  372
                                            },
                                            {
                                                "position":  11,
@@ -21866,7 +22853,8 @@
                                                                                 "points":  9,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  548
                                            },
                                            {
                                                "position":  12,
@@ -21894,7 +22882,8 @@
                                                                                "points":  13,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  553
                                            },
                                            {
                                                "position":  13,
@@ -21918,7 +22907,8 @@
                                                                                 "points":  11,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  410
                                            },
                                            {
                                                "position":  14,
@@ -21938,7 +22928,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  493
                                            },
                                            {
                                                "position":  15,
@@ -21958,7 +22949,8 @@
                                                                                "points":  3,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  605
                                            },
                                            {
                                                "position":  16,
@@ -21978,7 +22970,8 @@
                                                                                 "points":  10,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  369
                                            },
                                            {
                                                "position":  17,
@@ -21998,7 +22991,8 @@
                                                                               "points":  16,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  559
                                            },
                                            {
                                                "position":  18,
@@ -22018,7 +23012,8 @@
                                                                                "points":  14,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  430
                                            },
                                            {
                                                "position":  19,
@@ -22034,7 +23029,8 @@
                                                                                 "points":  4,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  260
                                            },
                                            {
                                                "position":  20,
@@ -22050,7 +23046,8 @@
                                                                               "points":  7,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  342
                                            },
                                            {
                                                "position":  21,
@@ -22066,7 +23063,8 @@
                                                                               "points":  16,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  409
                                            },
                                            {
                                                "position":  22,
@@ -22082,7 +23080,8 @@
                                                                               "points":  18,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  445
                                            },
                                            {
                                                "position":  23,
@@ -22094,7 +23093,8 @@
                                                                                  "points":  5,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  267
                                            },
                                            {
                                                "position":  24,
@@ -22106,7 +23106,8 @@
                                                                                  "points":  6,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  274
                                            },
                                            {
                                                "position":  25,
@@ -22118,7 +23119,8 @@
                                                                                 "points":  8,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  677
                                            },
                                            {
                                                "position":  26,
@@ -22130,7 +23132,8 @@
                                                                               "points":  11,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  642
                                            }
                                        ]
                        },
@@ -22153,7 +23156,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  343
                                            },
                                            {
                                                "position":  2,
@@ -22169,7 +23173,8 @@
                                                                               "points":  2,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  412
                                            },
                                            {
                                                "position":  3,
@@ -22181,7 +23186,8 @@
                                                                                  "points":  3,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  424
                                            }
                                        ]
                        },
@@ -22212,7 +23218,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  341
                                            },
                                            {
                                                "position":  2,
@@ -22228,7 +23235,8 @@
                                                                                "points":  1,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  645
                                            },
                                            {
                                                "position":  3,
@@ -22244,7 +23252,8 @@
                                                                               "points":  2,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  448
                                            },
                                            {
                                                "position":  4,
@@ -22256,7 +23265,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  673
                                            },
                                            {
                                                "position":  5,
@@ -22268,7 +23278,8 @@
                                                                                  "points":  1,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  299
                                            },
                                            {
                                                "position":  6,
@@ -22280,7 +23291,8 @@
                                                                               "points":  3,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  652
                                            },
                                            {
                                                "position":  7,
@@ -22292,7 +23304,8 @@
                                                                                  "points":  3,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  437
                                            }
                                        ]
                        },
@@ -22315,7 +23328,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  435
                                            }
                                        ]
                        },
@@ -22350,7 +23364,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  529
                                            },
                                            {
                                                "position":  2,
@@ -22374,7 +23389,8 @@
                                                                                 "points":  2,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  346
                                            },
                                            {
                                                "position":  3,
@@ -22410,7 +23426,8 @@
                                                                                 "points":  3,
                                                                                 "counting":  false
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  465
                                            },
                                            {
                                                "position":  4,
@@ -22422,7 +23439,8 @@
                                                                                  "points":  3,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  468
                                            }
                                        ]
                        },
@@ -22453,7 +23471,8 @@
                                                                                "points":  1,
                                                                                "counting":  true
                                                                            }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  466
                                            },
                                            {
                                                "position":  2,
@@ -22465,7 +23484,8 @@
                                                                                  "points":  1,
                                                                                  "counting":  true
                                                                              }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  444
                                            },
                                            {
                                                "position":  3,
@@ -22477,7 +23497,8 @@
                                                                               "points":  1,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  558
                                            },
                                            {
                                                "position":  4,
@@ -22489,7 +23510,8 @@
                                                                               "points":  2,
                                                                               "counting":  true
                                                                           }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  563
                                            }
                                        ]
                        },
@@ -22512,7 +23534,8 @@
                                                                                 "points":  1,
                                                                                 "counting":  true
                                                                             }
-                                                           }
+                                                           },
+                                               "seriesRunnerId":  565
                                            }
                                        ]
                        }


### PR DESCRIPTION
## Summary
- Adds `seriesRunnerId` to runner entries in `src/data/2023/road-gp/individual-standings.json` so standings rows link through to runner profile pages.
- Automated correlation (name/club/age-category match) resolved 1007 entries directly.
- Manually resolved 13 further entries with name variants/typos: Goolden/Goulden, Millward/Milward, McAfee/McAffee, Mullan/Mullen, Sue/Susan Hawitt & Coulthurst, Rebecca/Beckie Wells, Leah Nelson Verrechi/Verrechia.
- Manually resolved 2 more per user confirmation: Dave Aspin → Dave Aspen, Melissa Scott → Melissa Houghton.

## Notes for reviewer
- 3 entries remain unlinked: Harvey Atkins, Steve Perry, Debbie Barry. All raced as `club=Guest`, and there are no `Guest`-club entries anywhere in `src/data/2023/road-gp/runners.json` — guests are never assigned series-local ids, so no candidate exists to match against. These rows degrade gracefully (no profile link, everything else renders normally).
- Verified with `npm run build` — site builds cleanly with 1700 pages, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)