### PR TITLE
fix: hide empty series section on runner profile pages

### DIFF
--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -238,7 +238,7 @@ const totalRaces  = totalRoadGp + totalFell;
               </div>
 
               <!-- Road GP races -->
-              {block.roadGp && (
+              {block.roadGp && block.roadGp.races.length > 0 && (
                 <div data-series="road-gp" class="mb-5">
                   <h3 class="flex items-center gap-2 flex-wrap font-head font-bold text-xs uppercase tracking-widest text-amber mb-2">
                     Road GP
@@ -287,7 +287,7 @@ const totalRaces  = totalRoadGp + totalFell;
               )}
 
               <!-- Fell races -->
-              {block.fell && (
+              {block.fell && block.fell.races.length > 0 && (
                 <div data-series="fell" class="mb-5">
                   <h3 class="flex items-center gap-2 flex-wrap font-head font-bold text-xs uppercase tracking-widest text-teal mb-2">
                     Fell


### PR DESCRIPTION
## Summary
- The Fell/Road GP section on a runner's profile page (e.g. `/runners/10297-paula-plowman/`) could render with an empty race table when the runner has a `runners.json` registration for a series/year but no CSV results actually link to that `series_runner_id`.
- Now each series section only renders when it has at least one race with results.

## Test plan
- [x] `npm run build` succeeds
- [x] Verified built output for `10297-paula-plowman`: Fell section count drops from 4 (one empty) to 3 (all with results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)