### PR TITLE
fix: fell race name truncation on mobile runner profiles

### DIFF
--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -316,8 +316,9 @@ const totalRaces  = totalRoadGp + totalFell;
                             {race.hasResults
                               ? <a href={siteUrl(`/fell/${block.year}/${race.raceId}/results`)} class="link link-hover">{race.raceName}</a>
                               : <span class="text-muted">{race.raceName}</span>}
+                            {race.distance && <div class="sm:hidden font-mono text-xs text-muted mt-0.5">{race.distance}</div>}
                           </td>
-                          <td class="py-2 px-3 font-mono text-xs text-muted text-left align-middle w-32">
+                          <td class="hidden sm:table-cell py-2 px-3 font-mono text-xs text-muted text-left align-middle w-32">
                             {race.distance ?? ''}
                           </td>
                           <td class:list={[


### PR DESCRIPTION
## Summary
- The fell races table on the runner profile page ([slug].astro) rendered a fixed-width distance column that was always visible, which squeezed the race-name column under `table-fixed` layout on small viewports and caused long race names (e.g. "Darren Jones Clougha Pike") to truncate.
- Hide the distance column on mobile (`hidden sm:table-cell`) and show the distance inline under the race name instead, matching the existing Road GP table treatment.

## Test plan
- [x] Ran dev server, resized preview to 375x812 (mobile), and confirmed long fell race names now render in full instead of truncating.
- [x] Confirmed distance still displays (below the race name) on mobile, and in its own column on desktop widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)