### PR TITLE
Ensure unique sequential positions in 2016 fell individual standings

### DIFF
--- a/src/data/2016/fell/individual-standings.json
+++ b/src/data/2016/fell/individual-standings.json
@@ -209,29 +209,6 @@
         },
         {
           "position": 9,
-          "name": "Philip Butler",
-          "club": "red-rose",
-          "sex": "M",
-          "ageCategory": "V50",
-          "total": 46,
-          "results": {
-            "hutton-roof-crags": {
-              "points": 10,
-              "counting": true
-            },
-            "aggies-staircase": {
-              "points": 19,
-              "counting": true
-            },
-            "20-barriers": {
-              "points": 17,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 109
-        },
-        {
-          "position": 9,
           "name": "Andrew Christie",
           "club": "red-rose",
           "sex": "M",
@@ -252,6 +229,29 @@
             }
           },
           "seriesRunnerId": 111
+        },
+        {
+          "position": 10,
+          "name": "Philip Butler",
+          "club": "red-rose",
+          "sex": "M",
+          "ageCategory": "V50",
+          "total": 46,
+          "results": {
+            "hutton-roof-crags": {
+              "points": 10,
+              "counting": true
+            },
+            "aggies-staircase": {
+              "points": 19,
+              "counting": true
+            },
+            "20-barriers": {
+              "points": 17,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 109
         },
         {
           "position": 11,
@@ -282,29 +282,6 @@
         },
         {
           "position": 12,
-          "name": "Steve Myerscough",
-          "club": "wesham",
-          "sex": "M",
-          "ageCategory": "V40",
-          "total": 53,
-          "results": {
-            "aggies-staircase": {
-              "points": 22,
-              "counting": true
-            },
-            "20-barriers": {
-              "points": 12,
-              "counting": true
-            },
-            "harrock-hill": {
-              "points": 19,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 178
-        },
-        {
-          "position": 12,
           "name": "John Bradley",
           "club": "preston",
           "sex": "M",
@@ -329,6 +306,29 @@
             }
           },
           "seriesRunnerId": 117
+        },
+        {
+          "position": 13,
+          "name": "Steve Myerscough",
+          "club": "wesham",
+          "sex": "M",
+          "ageCategory": "V40",
+          "total": 53,
+          "results": {
+            "aggies-staircase": {
+              "points": 22,
+              "counting": true
+            },
+            "20-barriers": {
+              "points": 12,
+              "counting": true
+            },
+            "harrock-hill": {
+              "points": 19,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 178
         },
         {
           "position": 14,
@@ -409,29 +409,6 @@
         },
         {
           "position": 17,
-          "name": "Bill Beckett",
-          "club": "chorley",
-          "sex": "M",
-          "ageCategory": "V50",
-          "total": 77,
-          "results": {
-            "hutton-roof-crags": {
-              "points": 32,
-              "counting": true
-            },
-            "aggies-staircase": {
-              "points": 24,
-              "counting": true
-            },
-            "harrock-hill": {
-              "points": 21,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 131
-        },
-        {
-          "position": 17,
           "name": "Mark McCrea",
           "club": "red-rose",
           "sex": "M",
@@ -456,6 +433,29 @@
             }
           },
           "seriesRunnerId": 116
+        },
+        {
+          "position": 18,
+          "name": "Bill Beckett",
+          "club": "chorley",
+          "sex": "M",
+          "ageCategory": "V50",
+          "total": 77,
+          "results": {
+            "hutton-roof-crags": {
+              "points": 32,
+              "counting": true
+            },
+            "aggies-staircase": {
+              "points": 24,
+              "counting": true
+            },
+            "harrock-hill": {
+              "points": 21,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 131
         },
         {
           "position": 19,
@@ -720,29 +720,6 @@
         },
         {
           "position": 30,
-          "name": "Vicki Sherrington",
-          "club": "preston",
-          "sex": "F",
-          "ageCategory": "V40",
-          "total": 158,
-          "results": {
-            "hutton-roof-crags": {
-              "points": 48,
-              "counting": true
-            },
-            "aggies-staircase": {
-              "points": 49,
-              "counting": true
-            },
-            "harrock-hill": {
-              "points": 61,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 147
-        },
-        {
-          "position": 30,
           "name": "Debbie Porter",
           "club": "red-rose",
           "sex": "F",
@@ -763,6 +740,29 @@
             }
           },
           "seriesRunnerId": 140
+        },
+        {
+          "position": 31,
+          "name": "Vicki Sherrington",
+          "club": "preston",
+          "sex": "F",
+          "ageCategory": "V40",
+          "total": 158,
+          "results": {
+            "hutton-roof-crags": {
+              "points": 48,
+              "counting": true
+            },
+            "aggies-staircase": {
+              "points": 49,
+              "counting": true
+            },
+            "harrock-hill": {
+              "points": 61,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 147
         },
         {
           "position": 32,
@@ -1068,25 +1068,6 @@
         },
         {
           "position": 46,
-          "name": "John Naylor",
-          "club": "red-rose",
-          "sex": "M",
-          "ageCategory": "SEN",
-          "total": 44,
-          "results": {
-            "hutton-roof-crags": {
-              "points": 22,
-              "counting": true
-            },
-            "harrock-hill": {
-              "points": 22,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 121
-        },
-        {
-          "position": 46,
           "name": "Peter Singleton",
           "club": "blackpool",
           "sex": "M",
@@ -1103,6 +1084,25 @@
             }
           },
           "seriesRunnerId": 119
+        },
+        {
+          "position": 47,
+          "name": "John Naylor",
+          "club": "red-rose",
+          "sex": "M",
+          "ageCategory": "SEN",
+          "total": 44,
+          "results": {
+            "hutton-roof-crags": {
+              "points": 22,
+              "counting": true
+            },
+            "harrock-hill": {
+              "points": 22,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 121
         },
         {
           "position": 48,
@@ -1201,25 +1201,6 @@
         },
         {
           "position": 53,
-          "name": "Paul Jackson",
-          "club": "chorley",
-          "sex": "M",
-          "ageCategory": "V40",
-          "total": 82,
-          "results": {
-            "hutton-roof-crags": {
-              "points": 39,
-              "counting": true
-            },
-            "harrock-hill": {
-              "points": 43,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 138
-        },
-        {
-          "position": 53,
           "name": "Stephen Baker",
           "club": "chorley",
           "sex": "M",
@@ -1236,6 +1217,25 @@
             }
           },
           "seriesRunnerId": 184
+        },
+        {
+          "position": 54,
+          "name": "Paul Jackson",
+          "club": "chorley",
+          "sex": "M",
+          "ageCategory": "V40",
+          "total": 82,
+          "results": {
+            "hutton-roof-crags": {
+              "points": 39,
+              "counting": true
+            },
+            "harrock-hill": {
+              "points": 43,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 138
         },
         {
           "position": 55,
@@ -1296,25 +1296,25 @@
         },
         {
           "position": 58,
-          "name": "Philip Hayes",
-          "club": "thornton",
-          "sex": "M",
+          "name": "Melanie Haworth",
+          "club": "preston",
+          "sex": "F",
           "ageCategory": "V40",
           "total": 108,
           "results": {
             "hutton-roof-crags": {
-              "points": 50,
+              "points": 53,
               "counting": true
             },
-            "harrock-hill": {
-              "points": 58,
+            "aggies-staircase": {
+              "points": 55,
               "counting": true
             }
           },
-          "seriesRunnerId": 275
+          "seriesRunnerId": 152
         },
         {
-          "position": 58,
+          "position": 59,
           "name": "Jim Robinson",
           "club": "red-rose",
           "sex": "M",
@@ -1333,23 +1333,23 @@
           "seriesRunnerId": 233
         },
         {
-          "position": 58,
-          "name": "Melanie Haworth",
-          "club": "preston",
-          "sex": "F",
+          "position": 60,
+          "name": "Philip Hayes",
+          "club": "thornton",
+          "sex": "M",
           "ageCategory": "V40",
           "total": 108,
           "results": {
             "hutton-roof-crags": {
-              "points": 53,
+              "points": 50,
               "counting": true
             },
-            "aggies-staircase": {
-              "points": 55,
+            "harrock-hill": {
+              "points": 58,
               "counting": true
             }
           },
-          "seriesRunnerId": 152
+          "seriesRunnerId": 275
         },
         {
           "position": 61,
@@ -1558,21 +1558,6 @@
         },
         {
           "position": 72,
-          "name": "Joe Greenwood",
-          "club": "lytham",
-          "sex": "M",
-          "ageCategory": "SEN",
-          "total": 3,
-          "results": {
-            "harrock-hill": {
-              "points": 3,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 253
-        },
-        {
-          "position": 72,
           "name": "Chris McCarthy",
           "club": "lytham",
           "sex": "M",
@@ -1585,6 +1570,21 @@
             }
           },
           "seriesRunnerId": 201
+        },
+        {
+          "position": 73,
+          "name": "Joe Greenwood",
+          "club": "lytham",
+          "sex": "M",
+          "ageCategory": "SEN",
+          "total": 3,
+          "results": {
+            "harrock-hill": {
+              "points": 3,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 253
         },
         {
           "position": 74,
@@ -1648,36 +1648,6 @@
         },
         {
           "position": 78,
-          "name": "Martin Quinn",
-          "club": "chorley",
-          "sex": "M",
-          "ageCategory": "V40",
-          "total": 9,
-          "results": {
-            "aggies-staircase": {
-              "points": 9,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 169
-        },
-        {
-          "position": 78,
-          "name": "Ben Donoghue",
-          "club": "red-rose",
-          "sex": "M",
-          "ageCategory": "SEN",
-          "total": 9,
-          "results": {
-            "hutton-roof-crags": {
-              "points": 9,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 108
-        },
-        {
-          "position": 78,
           "name": "David Barras",
           "club": "thornton",
           "sex": "M",
@@ -1692,7 +1662,7 @@
           "seriesRunnerId": 204
         },
         {
-          "position": 78,
+          "position": 79,
           "name": "Andy Whaley",
           "club": "preston",
           "sex": "M",
@@ -1705,6 +1675,36 @@
             }
           },
           "seriesRunnerId": 255
+        },
+        {
+          "position": 80,
+          "name": "Martin Quinn",
+          "club": "chorley",
+          "sex": "M",
+          "ageCategory": "V40",
+          "total": 9,
+          "results": {
+            "aggies-staircase": {
+              "points": 9,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 169
+        },
+        {
+          "position": 81,
+          "name": "Ben Donoghue",
+          "club": "red-rose",
+          "sex": "M",
+          "ageCategory": "SEN",
+          "total": 9,
+          "results": {
+            "hutton-roof-crags": {
+              "points": 9,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 108
         },
         {
           "position": 82,
@@ -1738,21 +1738,21 @@
         },
         {
           "position": 84,
-          "name": "Mark Ellithorn",
-          "club": "chorley",
+          "name": "Neil Tate",
+          "club": "lytham",
           "sex": "M",
-          "ageCategory": "V50",
+          "ageCategory": "SEN",
           "total": 13,
           "results": {
-            "aggies-staircase": {
+            "20-barriers": {
               "points": 13,
               "counting": true
             }
           },
-          "seriesRunnerId": 172
+          "seriesRunnerId": 205
         },
         {
-          "position": 84,
+          "position": 85,
           "name": "Ken Addison",
           "club": "red-rose",
           "sex": "M",
@@ -1767,19 +1767,19 @@
           "seriesRunnerId": 257
         },
         {
-          "position": 84,
-          "name": "Neil Tate",
-          "club": "lytham",
+          "position": 86,
+          "name": "Mark Ellithorn",
+          "club": "chorley",
           "sex": "M",
-          "ageCategory": "SEN",
+          "ageCategory": "V50",
           "total": 13,
           "results": {
-            "20-barriers": {
+            "aggies-staircase": {
               "points": 13,
               "counting": true
             }
           },
-          "seriesRunnerId": 205
+          "seriesRunnerId": 172
         },
         {
           "position": 87,
@@ -1903,21 +1903,6 @@
         },
         {
           "position": 95,
-          "name": "Darran Bowles",
-          "club": "chorley",
-          "sex": "M",
-          "ageCategory": "V40",
-          "total": 28,
-          "results": {
-            "aggies-staircase": {
-              "points": 28,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 179
-        },
-        {
-          "position": 95,
           "name": "Gary Corcoran",
           "club": "red-rose",
           "sex": "M",
@@ -1930,6 +1915,21 @@
             }
           },
           "seriesRunnerId": 259
+        },
+        {
+          "position": 96,
+          "name": "Darran Bowles",
+          "club": "chorley",
+          "sex": "M",
+          "ageCategory": "V40",
+          "total": 28,
+          "results": {
+            "aggies-staircase": {
+              "points": 28,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 179
         },
         {
           "position": 97,
@@ -1963,21 +1963,6 @@
         },
         {
           "position": 99,
-          "name": "Jason Blagden",
-          "club": "wesham",
-          "sex": "M",
-          "ageCategory": "V40",
-          "total": 33,
-          "results": {
-            "hutton-roof-crags": {
-              "points": 33,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 132
-        },
-        {
-          "position": 99,
           "name": "Michael Thornborough",
           "club": "red-rose",
           "sex": "M",
@@ -1992,19 +1977,19 @@
           "seriesRunnerId": 212
         },
         {
-          "position": 101,
-          "name": "Mike Burnham",
-          "club": "preston",
+          "position": 100,
+          "name": "Jason Blagden",
+          "club": "wesham",
           "sex": "M",
-          "ageCategory": "SEN",
-          "total": 34,
+          "ageCategory": "V40",
+          "total": 33,
           "results": {
             "hutton-roof-crags": {
-              "points": 34,
+              "points": 33,
               "counting": true
             }
           },
-          "seriesRunnerId": 133
+          "seriesRunnerId": 132
         },
         {
           "position": 101,
@@ -2022,34 +2007,19 @@
           "seriesRunnerId": 262
         },
         {
-          "position": 103,
-          "name": "Ben Brennan",
-          "club": "thornton",
+          "position": 102,
+          "name": "Mike Burnham",
+          "club": "preston",
           "sex": "M",
-          "ageCategory": "V40",
-          "total": 35,
+          "ageCategory": "SEN",
+          "total": 34,
           "results": {
             "hutton-roof-crags": {
-              "points": 35,
+              "points": 34,
               "counting": true
             }
           },
-          "seriesRunnerId": 134
-        },
-        {
-          "position": 103,
-          "name": "Katie Jones",
-          "club": "chorley",
-          "sex": "F",
-          "ageCategory": "SEN",
-          "total": 35,
-          "results": {
-            "aggies-staircase": {
-              "points": 35,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 181
+          "seriesRunnerId": 133
         },
         {
           "position": 103,
@@ -2065,6 +2035,36 @@
             }
           },
           "seriesRunnerId": 263
+        },
+        {
+          "position": 104,
+          "name": "Katie Jones",
+          "club": "chorley",
+          "sex": "F",
+          "ageCategory": "SEN",
+          "total": 35,
+          "results": {
+            "aggies-staircase": {
+              "points": 35,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 181
+        },
+        {
+          "position": 105,
+          "name": "Ben Brennan",
+          "club": "thornton",
+          "sex": "M",
+          "ageCategory": "V40",
+          "total": 35,
+          "results": {
+            "hutton-roof-crags": {
+              "points": 35,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 134
         },
         {
           "position": 106,
@@ -2098,21 +2098,6 @@
         },
         {
           "position": 108,
-          "name": "Peter Broome",
-          "club": "blackpool",
-          "sex": "M",
-          "ageCategory": "V60",
-          "total": 38,
-          "results": {
-            "hutton-roof-crags": {
-              "points": 38,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 137
-        },
-        {
-          "position": 108,
           "name": "Peter Bolton",
           "club": "red-rose",
           "sex": "M",
@@ -2127,19 +2112,19 @@
           "seriesRunnerId": 214
         },
         {
-          "position": 110,
-          "name": "Jenny Wren",
-          "club": "preston",
-          "sex": "F",
-          "ageCategory": "SEN",
-          "total": 39,
+          "position": 109,
+          "name": "Peter Broome",
+          "club": "blackpool",
+          "sex": "M",
+          "ageCategory": "V60",
+          "total": 38,
           "results": {
-            "harrock-hill": {
-              "points": 39,
+            "hutton-roof-crags": {
+              "points": 38,
               "counting": true
             }
           },
-          "seriesRunnerId": 265
+          "seriesRunnerId": 137
         },
         {
           "position": 110,
@@ -2157,34 +2142,19 @@
           "seriesRunnerId": 215
         },
         {
-          "position": 112,
-          "name": "Lesley Gray",
-          "club": "thornton",
-          "sex": "F",
-          "ageCategory": "V40",
-          "total": 40,
-          "results": {
-            "hutton-roof-crags": {
-              "points": 40,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 139
-        },
-        {
-          "position": 112,
-          "name": "Sarah Hall",
-          "club": "red-rose",
+          "position": 111,
+          "name": "Jenny Wren",
+          "club": "preston",
           "sex": "F",
           "ageCategory": "SEN",
-          "total": 40,
+          "total": 39,
           "results": {
             "harrock-hill": {
-              "points": 40,
+              "points": 39,
               "counting": true
             }
           },
-          "seriesRunnerId": 266
+          "seriesRunnerId": 265
         },
         {
           "position": 112,
@@ -2202,19 +2172,34 @@
           "seriesRunnerId": 216
         },
         {
-          "position": 115,
-          "name": "Janine Needham",
+          "position": 113,
+          "name": "Sarah Hall",
           "club": "red-rose",
           "sex": "F",
-          "ageCategory": "V40",
-          "total": 42,
+          "ageCategory": "SEN",
+          "total": 40,
           "results": {
-            "aggies-staircase": {
-              "points": 42,
+            "harrock-hill": {
+              "points": 40,
               "counting": true
             }
           },
-          "seriesRunnerId": 185
+          "seriesRunnerId": 266
+        },
+        {
+          "position": 114,
+          "name": "Lesley Gray",
+          "club": "thornton",
+          "sex": "F",
+          "ageCategory": "V40",
+          "total": 40,
+          "results": {
+            "hutton-roof-crags": {
+              "points": 40,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 139
         },
         {
           "position": 115,
@@ -2232,34 +2217,19 @@
           "seriesRunnerId": 217
         },
         {
-          "position": 117,
-          "name": "Gordon Thompson",
-          "club": "preston",
-          "sex": "M",
-          "ageCategory": "V50",
-          "total": 43,
-          "results": {
-            "hutton-roof-crags": {
-              "points": 43,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 142
-        },
-        {
-          "position": 117,
-          "name": "Rob Mather",
+          "position": 116,
+          "name": "Janine Needham",
           "club": "red-rose",
-          "sex": "M",
+          "sex": "F",
           "ageCategory": "V40",
-          "total": 43,
+          "total": 42,
           "results": {
             "aggies-staircase": {
-              "points": 43,
+              "points": 42,
               "counting": true
             }
           },
-          "seriesRunnerId": 186
+          "seriesRunnerId": 185
         },
         {
           "position": 117,
@@ -2277,19 +2247,34 @@
           "seriesRunnerId": 218
         },
         {
-          "position": 120,
-          "name": "Ian Wharton",
+          "position": 118,
+          "name": "Rob Mather",
           "club": "red-rose",
           "sex": "M",
-          "ageCategory": "V50",
-          "total": 44,
+          "ageCategory": "V40",
+          "total": 43,
           "results": {
-            "harrock-hill": {
-              "points": 44,
+            "aggies-staircase": {
+              "points": 43,
               "counting": true
             }
           },
-          "seriesRunnerId": 267
+          "seriesRunnerId": 186
+        },
+        {
+          "position": 119,
+          "name": "Gordon Thompson",
+          "club": "preston",
+          "sex": "M",
+          "ageCategory": "V50",
+          "total": 43,
+          "results": {
+            "hutton-roof-crags": {
+              "points": 43,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 142
         },
         {
           "position": 120,
@@ -2307,19 +2292,19 @@
           "seriesRunnerId": 219
         },
         {
-          "position": 122,
-          "name": "Edmund Stewart",
-          "club": "preston",
+          "position": 121,
+          "name": "Ian Wharton",
+          "club": "red-rose",
           "sex": "M",
-          "ageCategory": "V70",
-          "total": 46,
+          "ageCategory": "V50",
+          "total": 44,
           "results": {
-            "hutton-roof-crags": {
-              "points": 46,
+            "harrock-hill": {
+              "points": 44,
               "counting": true
             }
           },
-          "seriesRunnerId": 145
+          "seriesRunnerId": 267
         },
         {
           "position": 122,
@@ -2337,34 +2322,19 @@
           "seriesRunnerId": 268
         },
         {
-          "position": 124,
-          "name": "Peter Gibson",
-          "club": "blackpool",
+          "position": 123,
+          "name": "Edmund Stewart",
+          "club": "preston",
           "sex": "M",
-          "ageCategory": "V60",
-          "total": 47,
+          "ageCategory": "V70",
+          "total": 46,
           "results": {
             "hutton-roof-crags": {
-              "points": 47,
+              "points": 46,
               "counting": true
             }
           },
-          "seriesRunnerId": 146
-        },
-        {
-          "position": 124,
-          "name": "Alison Parkinson",
-          "club": "red-rose",
-          "sex": "F",
-          "ageCategory": "V50",
-          "total": 47,
-          "results": {
-            "harrock-hill": {
-              "points": 47,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 269
+          "seriesRunnerId": 145
         },
         {
           "position": 124,
@@ -2382,19 +2352,34 @@
           "seriesRunnerId": 220
         },
         {
-          "position": 127,
-          "name": "David Maudsley",
+          "position": 125,
+          "name": "Alison Parkinson",
           "club": "red-rose",
-          "sex": "M",
+          "sex": "F",
           "ageCategory": "V50",
-          "total": 48,
+          "total": 47,
           "results": {
             "harrock-hill": {
-              "points": 48,
+              "points": 47,
               "counting": true
             }
           },
-          "seriesRunnerId": 270
+          "seriesRunnerId": 269
+        },
+        {
+          "position": 126,
+          "name": "Peter Gibson",
+          "club": "blackpool",
+          "sex": "M",
+          "ageCategory": "V60",
+          "total": 47,
+          "results": {
+            "hutton-roof-crags": {
+              "points": 47,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 146
         },
         {
           "position": 127,
@@ -2410,6 +2395,21 @@
             }
           },
           "seriesRunnerId": 221
+        },
+        {
+          "position": 128,
+          "name": "David Maudsley",
+          "club": "red-rose",
+          "sex": "M",
+          "ageCategory": "V50",
+          "total": 48,
+          "results": {
+            "harrock-hill": {
+              "points": 48,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 270
         },
         {
           "position": 129,
@@ -2428,36 +2428,6 @@
         },
         {
           "position": 130,
-          "name": "Julia Rolfe",
-          "club": "lytham",
-          "sex": "F",
-          "ageCategory": "V50",
-          "total": 50,
-          "results": {
-            "aggies-staircase": {
-              "points": 50,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 190
-        },
-        {
-          "position": 130,
-          "name": "Joan Gouldthorpe",
-          "club": "red-rose",
-          "sex": "F",
-          "ageCategory": "V60",
-          "total": 50,
-          "results": {
-            "harrock-hill": {
-              "points": 50,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 272
-        },
-        {
-          "position": 130,
           "name": "Claire England",
           "club": "lytham",
           "sex": "F",
@@ -2472,19 +2442,34 @@
           "seriesRunnerId": 222
         },
         {
-          "position": 133,
-          "name": "Bernie Mitchell",
+          "position": 131,
+          "name": "Joan Gouldthorpe",
           "club": "red-rose",
-          "sex": "M",
-          "ageCategory": "V50",
-          "total": 51,
+          "sex": "F",
+          "ageCategory": "V60",
+          "total": 50,
           "results": {
-            "aggies-staircase": {
-              "points": 51,
+            "harrock-hill": {
+              "points": 50,
               "counting": true
             }
           },
-          "seriesRunnerId": 191
+          "seriesRunnerId": 272
+        },
+        {
+          "position": 132,
+          "name": "Julia Rolfe",
+          "club": "lytham",
+          "sex": "F",
+          "ageCategory": "V50",
+          "total": 50,
+          "results": {
+            "aggies-staircase": {
+              "points": 50,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 190
         },
         {
           "position": 133,
@@ -2502,19 +2487,19 @@
           "seriesRunnerId": 223
         },
         {
-          "position": 135,
-          "name": "Wayne Hope",
+          "position": 134,
+          "name": "Bernie Mitchell",
           "club": "red-rose",
           "sex": "M",
           "ageCategory": "V50",
-          "total": 52,
+          "total": 51,
           "results": {
-            "harrock-hill": {
-              "points": 52,
+            "aggies-staircase": {
+              "points": 51,
               "counting": true
             }
           },
-          "seriesRunnerId": 273
+          "seriesRunnerId": 191
         },
         {
           "position": 135,
@@ -2532,34 +2517,19 @@
           "seriesRunnerId": 224
         },
         {
-          "position": 137,
-          "name": "Pete McDermott",
-          "club": "preston",
-          "sex": "M",
-          "ageCategory": "V70",
-          "total": 53,
-          "results": {
-            "aggies-staircase": {
-              "points": 53,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 193
-        },
-        {
-          "position": 137,
-          "name": "Phil Lakeland",
-          "club": "preston",
+          "position": 136,
+          "name": "Wayne Hope",
+          "club": "red-rose",
           "sex": "M",
           "ageCategory": "V50",
-          "total": 53,
+          "total": 52,
           "results": {
             "harrock-hill": {
-              "points": 53,
+              "points": 52,
               "counting": true
             }
           },
-          "seriesRunnerId": 274
+          "seriesRunnerId": 273
         },
         {
           "position": 137,
@@ -2577,19 +2547,34 @@
           "seriesRunnerId": 225
         },
         {
-          "position": 140,
-          "name": "Jeffrey Wright",
-          "club": "blackpool",
+          "position": 138,
+          "name": "Phil Lakeland",
+          "club": "preston",
           "sex": "M",
           "ageCategory": "V50",
-          "total": 54,
+          "total": 53,
           "results": {
-            "hutton-roof-crags": {
-              "points": 54,
+            "harrock-hill": {
+              "points": 53,
               "counting": true
             }
           },
-          "seriesRunnerId": 153
+          "seriesRunnerId": 274
+        },
+        {
+          "position": 139,
+          "name": "Pete McDermott",
+          "club": "preston",
+          "sex": "M",
+          "ageCategory": "V70",
+          "total": 53,
+          "results": {
+            "aggies-staircase": {
+              "points": 53,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 193
         },
         {
           "position": 140,
@@ -2607,19 +2592,19 @@
           "seriesRunnerId": 226
         },
         {
-          "position": 142,
-          "name": "Karl Lucas",
-          "club": "thornton",
+          "position": 141,
+          "name": "Jeffrey Wright",
+          "club": "blackpool",
           "sex": "M",
-          "ageCategory": "V40",
-          "total": 56,
+          "ageCategory": "V50",
+          "total": 54,
           "results": {
             "hutton-roof-crags": {
-              "points": 56,
+              "points": 54,
               "counting": true
             }
           },
-          "seriesRunnerId": 155
+          "seriesRunnerId": 153
         },
         {
           "position": 142,
@@ -2637,19 +2622,19 @@
           "seriesRunnerId": 227
         },
         {
-          "position": 144,
-          "name": "Michael Gray",
+          "position": 143,
+          "name": "Karl Lucas",
           "club": "thornton",
           "sex": "M",
           "ageCategory": "V40",
-          "total": 57,
+          "total": 56,
           "results": {
             "hutton-roof-crags": {
-              "points": 57,
+              "points": 56,
               "counting": true
             }
           },
-          "seriesRunnerId": 156
+          "seriesRunnerId": 155
         },
         {
           "position": 144,
@@ -2667,19 +2652,19 @@
           "seriesRunnerId": 228
         },
         {
-          "position": 146,
-          "name": "Diane Blagden",
-          "club": "wesham",
-          "sex": "F",
+          "position": 145,
+          "name": "Michael Gray",
+          "club": "thornton",
+          "sex": "M",
           "ageCategory": "V40",
-          "total": 59,
+          "total": 57,
           "results": {
             "hutton-roof-crags": {
-              "points": 59,
+              "points": 57,
               "counting": true
             }
           },
-          "seriesRunnerId": 158
+          "seriesRunnerId": 156
         },
         {
           "position": 146,
@@ -2697,19 +2682,19 @@
           "seriesRunnerId": 276
         },
         {
-          "position": 148,
-          "name": "Jeremy McCandless",
-          "club": "lytham",
-          "sex": "M",
-          "ageCategory": "V50",
-          "total": 60,
+          "position": 147,
+          "name": "Diane Blagden",
+          "club": "wesham",
+          "sex": "F",
+          "ageCategory": "V40",
+          "total": 59,
           "results": {
-            "aggies-staircase": {
-              "points": 60,
+            "hutton-roof-crags": {
+              "points": 59,
               "counting": true
             }
           },
-          "seriesRunnerId": 196
+          "seriesRunnerId": 158
         },
         {
           "position": 148,
@@ -2727,19 +2712,19 @@
           "seriesRunnerId": 277
         },
         {
-          "position": 150,
-          "name": "Joe Howard",
-          "club": "preston",
+          "position": 149,
+          "name": "Jeremy McCandless",
+          "club": "lytham",
           "sex": "M",
-          "ageCategory": "V70",
-          "total": 61,
+          "ageCategory": "V50",
+          "total": 60,
           "results": {
-            "hutton-roof-crags": {
-              "points": 61,
+            "aggies-staircase": {
+              "points": 60,
               "counting": true
             }
           },
-          "seriesRunnerId": 160
+          "seriesRunnerId": 196
         },
         {
           "position": 150,
@@ -2757,34 +2742,19 @@
           "seriesRunnerId": 231
         },
         {
-          "position": 152,
-          "name": "Sue Austin",
-          "club": "red-rose",
-          "sex": "F",
-          "ageCategory": "V50",
-          "total": 62,
+          "position": 151,
+          "name": "Joe Howard",
+          "club": "preston",
+          "sex": "M",
+          "ageCategory": "V70",
+          "total": 61,
           "results": {
             "hutton-roof-crags": {
-              "points": 62,
+              "points": 61,
               "counting": true
             }
           },
-          "seriesRunnerId": 161
-        },
-        {
-          "position": 152,
-          "name": "Shane Cliffe",
-          "club": "red-rose",
-          "sex": "M",
-          "ageCategory": "V50",
-          "total": 62,
-          "results": {
-            "aggies-staircase": {
-              "points": 62,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 197
+          "seriesRunnerId": 160
         },
         {
           "position": 152,
@@ -2802,19 +2772,34 @@
           "seriesRunnerId": 278
         },
         {
-          "position": 155,
-          "name": "David Jones",
-          "club": "thornton",
+          "position": 153,
+          "name": "Shane Cliffe",
+          "club": "red-rose",
           "sex": "M",
-          "ageCategory": "V60",
-          "total": 63,
+          "ageCategory": "V50",
+          "total": 62,
           "results": {
             "aggies-staircase": {
-              "points": 63,
+              "points": 62,
               "counting": true
             }
           },
-          "seriesRunnerId": 198
+          "seriesRunnerId": 197
+        },
+        {
+          "position": 154,
+          "name": "Sue Austin",
+          "club": "red-rose",
+          "sex": "F",
+          "ageCategory": "V50",
+          "total": 62,
+          "results": {
+            "hutton-roof-crags": {
+              "points": 62,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 161
         },
         {
           "position": 155,
@@ -2832,19 +2817,19 @@
           "seriesRunnerId": 232
         },
         {
-          "position": 157,
-          "name": "George Arnold",
-          "club": "preston",
+          "position": 156,
+          "name": "David Jones",
+          "club": "thornton",
           "sex": "M",
-          "ageCategory": "V70",
-          "total": 64,
+          "ageCategory": "V60",
+          "total": 63,
           "results": {
             "aggies-staircase": {
-              "points": 64,
+              "points": 63,
               "counting": true
             }
           },
-          "seriesRunnerId": 199
+          "seriesRunnerId": 198
         },
         {
           "position": 157,
@@ -2860,6 +2845,21 @@
             }
           },
           "seriesRunnerId": 279
+        },
+        {
+          "position": 158,
+          "name": "George Arnold",
+          "club": "preston",
+          "sex": "M",
+          "ageCategory": "V70",
+          "total": 64,
+          "results": {
+            "aggies-staircase": {
+              "points": 64,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 199
         },
         {
           "position": 159,
@@ -2878,21 +2878,6 @@
         },
         {
           "position": 160,
-          "name": "Catherine Karn",
-          "club": "red-rose",
-          "sex": "F",
-          "ageCategory": "V50",
-          "total": 67,
-          "results": {
-            "harrock-hill": {
-              "points": 67,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 281
-        },
-        {
-          "position": 160,
           "name": "Michael Hogarth",
           "club": "red-rose",
           "sex": "M",
@@ -2905,6 +2890,21 @@
             }
           },
           "seriesRunnerId": 235
+        },
+        {
+          "position": 161,
+          "name": "Catherine Karn",
+          "club": "red-rose",
+          "sex": "F",
+          "ageCategory": "V50",
+          "total": 67,
+          "results": {
+            "harrock-hill": {
+              "points": 67,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 281
         },
         {
           "position": 162,
@@ -2953,21 +2953,6 @@
         },
         {
           "position": 165,
-          "name": "David Anson",
-          "club": "red-rose",
-          "sex": "M",
-          "ageCategory": "V70",
-          "total": 73,
-          "results": {
-            "harrock-hill": {
-              "points": 73,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 282
-        },
-        {
-          "position": 165,
           "name": "Bernard Singleton",
           "club": "blackpool",
           "sex": "M",
@@ -2980,6 +2965,21 @@
             }
           },
           "seriesRunnerId": 240
+        },
+        {
+          "position": 166,
+          "name": "David Anson",
+          "club": "red-rose",
+          "sex": "M",
+          "ageCategory": "V70",
+          "total": 73,
+          "results": {
+            "harrock-hill": {
+              "points": 73,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 282
         },
         {
           "position": 167,
@@ -2998,21 +2998,6 @@
         },
         {
           "position": 168,
-          "name": "Sarah Haslam",
-          "club": "red-rose",
-          "sex": "F",
-          "ageCategory": "V40",
-          "total": 75,
-          "results": {
-            "harrock-hill": {
-              "points": 75,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 284
-        },
-        {
-          "position": 168,
           "name": "Cat Holden",
           "club": "red-rose",
           "sex": "F",
@@ -3027,19 +3012,19 @@
           "seriesRunnerId": 241
         },
         {
-          "position": 170,
-          "name": "Kari Edwards",
-          "club": "preston",
+          "position": 169,
+          "name": "Sarah Haslam",
+          "club": "red-rose",
           "sex": "F",
           "ageCategory": "V40",
-          "total": 77,
+          "total": 75,
           "results": {
             "harrock-hill": {
-              "points": 77,
+              "points": 75,
               "counting": true
             }
           },
-          "seriesRunnerId": 285
+          "seriesRunnerId": 284
         },
         {
           "position": 170,
@@ -3055,6 +3040,21 @@
             }
           },
           "seriesRunnerId": 242
+        },
+        {
+          "position": 171,
+          "name": "Kari Edwards",
+          "club": "preston",
+          "sex": "F",
+          "ageCategory": "V40",
+          "total": 77,
+          "results": {
+            "harrock-hill": {
+              "points": 77,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 285
         },
         {
           "position": 172,
@@ -3088,21 +3088,6 @@
         },
         {
           "position": 174,
-          "name": "Tom Hilton",
-          "club": "red-rose",
-          "sex": "M",
-          "ageCategory": "V60",
-          "total": 80,
-          "results": {
-            "harrock-hill": {
-              "points": 80,
-              "counting": true
-            }
-          },
-          "seriesRunnerId": 288
-        },
-        {
-          "position": 174,
           "name": "Chris Clark",
           "club": "red-rose",
           "sex": "M",
@@ -3115,6 +3100,21 @@
             }
           },
           "seriesRunnerId": 243
+        },
+        {
+          "position": 175,
+          "name": "Tom Hilton",
+          "club": "red-rose",
+          "sex": "M",
+          "ageCategory": "V60",
+          "total": 80,
+          "results": {
+            "harrock-hill": {
+              "points": 80,
+              "counting": true
+            }
+          },
+          "seriesRunnerId": 288
         },
         {
           "position": 176,
@@ -3658,7 +3658,7 @@
           "seriesRunnerId": 187
         },
         {
-          "position": 17,
+          "position": 18,
           "name": "Nigel Shepherd",
           "club": "wesham",
           "sex": "M",
@@ -3704,7 +3704,7 @@
           "seriesRunnerId": 151
         },
         {
-          "position": 19,
+          "position": 20,
           "name": "Vicki Sherrington",
           "club": "preston",
           "sex": "F",
@@ -3727,7 +3727,7 @@
           "seriesRunnerId": 147
         },
         {
-          "position": 19,
+          "position": 21,
           "name": "Debbie Porter",
           "club": "red-rose",
           "sex": "F",
@@ -3915,7 +3915,7 @@
           "seriesRunnerId": 102
         },
         {
-          "position": 28,
+          "position": 29,
           "name": "Jon Green",
           "club": "preston",
           "sex": "M",
@@ -3953,7 +3953,7 @@
           "seriesRunnerId": 104
         },
         {
-          "position": 30,
+          "position": 31,
           "name": "Alex Rowe",
           "club": "wesham",
           "sex": "M",
@@ -4352,7 +4352,7 @@
           "seriesRunnerId": 195
         },
         {
-          "position": 51,
+          "position": 52,
           "name": "John Plowman",
           "club": "red-rose",
           "sex": "M",
@@ -4462,7 +4462,7 @@
           "seriesRunnerId": 203
         },
         {
-          "position": 57,
+          "position": 58,
           "name": "Darren Fishwick",
           "club": "chorley",
           "sex": "M",
@@ -4522,7 +4522,7 @@
           "seriesRunnerId": 256
         },
         {
-          "position": 61,
+          "position": 62,
           "name": "Martin Quinn",
           "club": "chorley",
           "sex": "M",
@@ -4537,7 +4537,7 @@
           "seriesRunnerId": 169
         },
         {
-          "position": 61,
+          "position": 63,
           "name": "John Griffiths",
           "club": "preston",
           "sex": "M",
@@ -4597,7 +4597,7 @@
           "seriesRunnerId": 173
         },
         {
-          "position": 66,
+          "position": 67,
           "name": "Ken Addison",
           "club": "red-rose",
           "sex": "M",
@@ -4747,7 +4747,7 @@
           "seriesRunnerId": 213
         },
         {
-          "position": 76,
+          "position": 77,
           "name": "Raymond Taylor",
           "club": "red-rose",
           "sex": "M",
@@ -4777,7 +4777,7 @@
           "seriesRunnerId": 132
         },
         {
-          "position": 78,
+          "position": 79,
           "name": "Peter Bolton",
           "club": "red-rose",
           "sex": "M",
@@ -4807,7 +4807,7 @@
           "seriesRunnerId": 217
         },
         {
-          "position": 80,
+          "position": 81,
           "name": "Ben Brennan",
           "club": "thornton",
           "sex": "M",
@@ -4852,7 +4852,7 @@
           "seriesRunnerId": 219
         },
         {
-          "position": 83,
+          "position": 84,
           "name": "Peter Broome",
           "club": "blackpool",
           "sex": "M",
@@ -4882,7 +4882,7 @@
           "seriesRunnerId": 267
         },
         {
-          "position": 85,
+          "position": 86,
           "name": "Lesley Gray",
           "club": "thornton",
           "sex": "F",
@@ -4912,7 +4912,7 @@
           "seriesRunnerId": 220
         },
         {
-          "position": 87,
+          "position": 88,
           "name": "Janine Needham",
           "club": "red-rose",
           "sex": "F",
@@ -4942,7 +4942,7 @@
           "seriesRunnerId": 221
         },
         {
-          "position": 89,
+          "position": 90,
           "name": "Paul Cafferkey",
           "club": "red-rose",
           "sex": "M",
@@ -4957,7 +4957,7 @@
           "seriesRunnerId": 268
         },
         {
-          "position": 89,
+          "position": 91,
           "name": "Rob Mather",
           "club": "red-rose",
           "sex": "M",
@@ -4987,7 +4987,7 @@
           "seriesRunnerId": 142
         },
         {
-          "position": 92,
+          "position": 93,
           "name": "Alison Parkinson",
           "club": "red-rose",
           "sex": "F",
@@ -5017,7 +5017,7 @@
           "seriesRunnerId": 222
         },
         {
-          "position": 94,
+          "position": 95,
           "name": "David Maudsley",
           "club": "red-rose",
           "sex": "M",
@@ -5047,7 +5047,7 @@
           "seriesRunnerId": 272
         },
         {
-          "position": 96,
+          "position": 97,
           "name": "John Reason",
           "club": "blackpool",
           "sex": "M",
@@ -5077,7 +5077,7 @@
           "seriesRunnerId": 224
         },
         {
-          "position": 98,
+          "position": 99,
           "name": "Edmund Stewart",
           "club": "preston",
           "sex": "M",
@@ -5107,7 +5107,7 @@
           "seriesRunnerId": 273
         },
         {
-          "position": 100,
+          "position": 101,
           "name": "Paul Carter",
           "club": "wesham",
           "sex": "M",
@@ -5122,7 +5122,7 @@
           "seriesRunnerId": 225
         },
         {
-          "position": 100,
+          "position": 102,
           "name": "Peter Gibson",
           "club": "blackpool",
           "sex": "M",
@@ -5152,7 +5152,7 @@
           "seriesRunnerId": 274
         },
         {
-          "position": 103,
+          "position": 104,
           "name": "Sue Hawitt",
           "club": "lytham",
           "sex": "F",
@@ -5197,7 +5197,7 @@
           "seriesRunnerId": 227
         },
         {
-          "position": 106,
+          "position": 107,
           "name": "Bernie Mitchell",
           "club": "red-rose",
           "sex": "M",
@@ -5272,7 +5272,7 @@
           "seriesRunnerId": 277
         },
         {
-          "position": 111,
+          "position": 112,
           "name": "Jeffrey Wright",
           "club": "blackpool",
           "sex": "M",
@@ -5317,7 +5317,7 @@
           "seriesRunnerId": 278
         },
         {
-          "position": 114,
+          "position": 115,
           "name": "Karl Lucas",
           "club": "thornton",
           "sex": "M",
@@ -5362,7 +5362,7 @@
           "seriesRunnerId": 234
         },
         {
-          "position": 117,
+          "position": 118,
           "name": "John Wiseman",
           "club": "red-rose",
           "sex": "M",
@@ -5392,7 +5392,7 @@
           "seriesRunnerId": 196
         },
         {
-          "position": 119,
+          "position": 120,
           "name": "Diane Blagden",
           "club": "wesham",
           "sex": "F",
@@ -5437,7 +5437,7 @@
           "seriesRunnerId": 281
         },
         {
-          "position": 122,
+          "position": 123,
           "name": "Janine McNeil",
           "club": "thornton",
           "sex": "F",
@@ -5452,7 +5452,7 @@
           "seriesRunnerId": 236
         },
         {
-          "position": 122,
+          "position": 124,
           "name": "Joe Howard",
           "club": "preston",
           "sex": "M",
@@ -5467,7 +5467,7 @@
           "seriesRunnerId": 160
         },
         {
-          "position": 122,
+          "position": 125,
           "name": "Shane Cliffe",
           "club": "red-rose",
           "sex": "M",
@@ -5497,7 +5497,7 @@
           "seriesRunnerId": 237
         },
         {
-          "position": 126,
+          "position": 127,
           "name": "Sue Austin",
           "club": "red-rose",
           "sex": "F",
@@ -5512,7 +5512,7 @@
           "seriesRunnerId": 161
         },
         {
-          "position": 126,
+          "position": 128,
           "name": "David Jones",
           "club": "thornton",
           "sex": "M",
@@ -5602,7 +5602,7 @@
           "seriesRunnerId": 241
         },
         {
-          "position": 133,
+          "position": 134,
           "name": "Sue Whickham",
           "club": "preston",
           "sex": "F",
@@ -5692,7 +5692,7 @@
           "seriesRunnerId": 243
         },
         {
-          "position": 139,
+          "position": 140,
           "name": "Sharon Birkbeck",
           "club": "red-rose",
           "sex": "F",
@@ -5722,7 +5722,7 @@
           "seriesRunnerId": 244
         },
         {
-          "position": 141,
+          "position": 142,
           "name": "Tom Hilton",
           "club": "red-rose",
           "sex": "M",
@@ -6449,7 +6449,7 @@
           "seriesRunnerId": 229
         },
         {
-          "position": 28,
+          "position": 29,
           "name": "Jim Robinson",
           "club": "red-rose",
           "sex": "M",
@@ -6650,7 +6650,7 @@
           "seriesRunnerId": 172
         },
         {
-          "position": 39,
+          "position": 40,
           "name": "David Parkinson",
           "club": "chorley",
           "sex": "M",
@@ -6665,7 +6665,7 @@
           "seriesRunnerId": 254
         },
         {
-          "position": 39,
+          "position": 41,
           "name": "John Griffiths",
           "club": "preston",
           "sex": "M",
@@ -6740,7 +6740,7 @@
           "seriesRunnerId": 213
         },
         {
-          "position": 45,
+          "position": 46,
           "name": "Terry Hellings",
           "club": "lytham",
           "sex": "M",
@@ -6770,7 +6770,7 @@
           "seriesRunnerId": 214
         },
         {
-          "position": 47,
+          "position": 48,
           "name": "David Miller",
           "club": "chorley",
           "sex": "M",
@@ -6830,7 +6830,7 @@
           "seriesRunnerId": 137
         },
         {
-          "position": 51,
+          "position": 52,
           "name": "Claire England",
           "club": "lytham",
           "sex": "F",
@@ -6860,7 +6860,7 @@
           "seriesRunnerId": 223
         },
         {
-          "position": 53,
+          "position": 54,
           "name": "Julia Rolfe",
           "club": "lytham",
           "sex": "F",
@@ -6890,7 +6890,7 @@
           "seriesRunnerId": 142
         },
         {
-          "position": 55,
+          "position": 56,
           "name": "Ian Wharton",
           "club": "red-rose",
           "sex": "M",
@@ -6905,7 +6905,7 @@
           "seriesRunnerId": 267
         },
         {
-          "position": 55,
+          "position": 57,
           "name": "David Young",
           "club": "wesham",
           "sex": "M",
@@ -6920,7 +6920,7 @@
           "seriesRunnerId": 224
         },
         {
-          "position": 55,
+          "position": 58,
           "name": "Bernie Mitchell",
           "club": "red-rose",
           "sex": "M",
@@ -6950,7 +6950,7 @@
           "seriesRunnerId": 193
         },
         {
-          "position": 59,
+          "position": 60,
           "name": "Sue Hawitt",
           "club": "lytham",
           "sex": "F",
@@ -6965,7 +6965,7 @@
           "seriesRunnerId": 226
         },
         {
-          "position": 59,
+          "position": 61,
           "name": "Paul Cafferkey",
           "club": "red-rose",
           "sex": "M",
@@ -7010,7 +7010,7 @@
           "seriesRunnerId": 228
         },
         {
-          "position": 63,
+          "position": 64,
           "name": "Edmund Stewart",
           "club": "preston",
           "sex": "M",
@@ -7025,7 +7025,7 @@
           "seriesRunnerId": 145
         },
         {
-          "position": 63,
+          "position": 65,
           "name": "David Maudsley",
           "club": "red-rose",
           "sex": "M",
@@ -7055,7 +7055,7 @@
           "seriesRunnerId": 272
         },
         {
-          "position": 66,
+          "position": 67,
           "name": "Peter Gibson",
           "club": "blackpool",
           "sex": "M",
@@ -7085,7 +7085,7 @@
           "seriesRunnerId": 231
         },
         {
-          "position": 68,
+          "position": 69,
           "name": "Jeremy McCandless",
           "club": "lytham",
           "sex": "M",
@@ -7100,7 +7100,7 @@
           "seriesRunnerId": 196
         },
         {
-          "position": 68,
+          "position": 70,
           "name": "Wayne Hope",
           "club": "red-rose",
           "sex": "M",
@@ -7130,7 +7130,7 @@
           "seriesRunnerId": 274
         },
         {
-          "position": 71,
+          "position": 72,
           "name": "Shane Cliffe",
           "club": "red-rose",
           "sex": "M",
@@ -7145,7 +7145,7 @@
           "seriesRunnerId": 197
         },
         {
-          "position": 71,
+          "position": 73,
           "name": "Jeffrey Wright",
           "club": "blackpool",
           "sex": "M",
@@ -7190,7 +7190,7 @@
           "seriesRunnerId": 199
         },
         {
-          "position": 75,
+          "position": 76,
           "name": "Michael Hogarth",
           "club": "red-rose",
           "sex": "M",
@@ -7220,7 +7220,7 @@
           "seriesRunnerId": 237
         },
         {
-          "position": 77,
+          "position": 78,
           "name": "Joe Howard",
           "club": "preston",
           "sex": "M",
@@ -7235,7 +7235,7 @@
           "seriesRunnerId": 160
         },
         {
-          "position": 77,
+          "position": 79,
           "name": "Pamela Hardman",
           "club": "lytham",
           "sex": "F",
@@ -7265,7 +7265,7 @@
           "seriesRunnerId": 277
         },
         {
-          "position": 80,
+          "position": 81,
           "name": "Sue Austin",
           "club": "red-rose",
           "sex": "F",
@@ -7400,7 +7400,7 @@
           "seriesRunnerId": 246
         },
         {
-          "position": 89,
+          "position": 90,
           "name": "David Anson",
           "club": "red-rose",
           "sex": "M",
@@ -7430,7 +7430,7 @@
           "seriesRunnerId": 283
         },
         {
-          "position": 91,
+          "position": 92,
           "name": "Robert Massey",
           "club": "blackpool",
           "sex": "M",
@@ -7475,7 +7475,7 @@
           "seriesRunnerId": 249
         },
         {
-          "position": 94,
+          "position": 95,
           "name": "Andy Birkbeck",
           "club": "red-rose",
           "sex": "M",
@@ -7520,7 +7520,7 @@
           "seriesRunnerId": 251
         },
         {
-          "position": 97,
+          "position": 98,
           "name": "Tom Hilton",
           "club": "red-rose",
           "sex": "M",
@@ -7713,7 +7713,7 @@
           "seriesRunnerId": 200
         },
         {
-          "position": 8,
+          "position": 9,
           "name": "Dave Roberts",
           "club": "preston",
           "sex": "M",
@@ -7762,7 +7762,7 @@
           "seriesRunnerId": 221
         },
         {
-          "position": 11,
+          "position": 12,
           "name": "Terry Hellings",
           "club": "lytham",
           "sex": "M",
@@ -7792,7 +7792,7 @@
           "seriesRunnerId": 224
         },
         {
-          "position": 13,
+          "position": 14,
           "name": "Pete McDermott",
           "club": "preston",
           "sex": "M",
@@ -7807,7 +7807,7 @@
           "seriesRunnerId": 193
         },
         {
-          "position": 13,
+          "position": 15,
           "name": "David Miller",
           "club": "chorley",
           "sex": "M",
@@ -7837,7 +7837,7 @@
           "seriesRunnerId": 228
         },
         {
-          "position": 16,
+          "position": 17,
           "name": "Raymond Taylor",
           "club": "red-rose",
           "sex": "M",
@@ -7852,7 +7852,7 @@
           "seriesRunnerId": 263
         },
         {
-          "position": 16,
+          "position": 18,
           "name": "Peter Broome",
           "club": "blackpool",
           "sex": "M",
@@ -7897,7 +7897,7 @@
           "seriesRunnerId": 199
         },
         {
-          "position": 20,
+          "position": 21,
           "name": "Joan Gouldthorpe",
           "club": "red-rose",
           "sex": "F",
@@ -7927,7 +7927,7 @@
           "seriesRunnerId": 240
         },
         {
-          "position": 22,
+          "position": 23,
           "name": "Edmund Stewart",
           "club": "preston",
           "sex": "M",
@@ -7957,7 +7957,7 @@
           "seriesRunnerId": 246
         },
         {
-          "position": 24,
+          "position": 25,
           "name": "Peter Gibson",
           "club": "blackpool",
           "sex": "M",
@@ -8002,7 +8002,7 @@
           "seriesRunnerId": 248
         },
         {
-          "position": 27,
+          "position": 28,
           "name": "Joe Howard",
           "club": "preston",
           "sex": "M",
@@ -8017,7 +8017,7 @@
           "seriesRunnerId": 160
         },
         {
-          "position": 27,
+          "position": 29,
           "name": "David Anson",
           "club": "red-rose",
           "sex": "M",
@@ -8047,7 +8047,7 @@
           "seriesRunnerId": 249
         },
         {
-          "position": 30,
+          "position": 31,
           "name": "Tom Hilton",
           "club": "red-rose",
           "sex": "M",
@@ -8420,7 +8420,7 @@
           "seriesRunnerId": 150
         },
         {
-          "position": 15,
+          "position": 16,
           "name": "Aimee Midgley",
           "club": "red-rose",
           "sex": "F",
@@ -8564,7 +8564,7 @@
           "seriesRunnerId": 265
         },
         {
-          "position": 23,
+          "position": 24,
           "name": "Lesley Gray",
           "club": "thornton",
           "sex": "F",
@@ -8579,7 +8579,7 @@
           "seriesRunnerId": 139
         },
         {
-          "position": 23,
+          "position": 25,
           "name": "Jenny Clark",
           "club": "thornton",
           "sex": "F",
@@ -8609,7 +8609,7 @@
           "seriesRunnerId": 185
         },
         {
-          "position": 26,
+          "position": 27,
           "name": "Sarah Hall",
           "club": "red-rose",
           "sex": "F",
@@ -8654,7 +8654,7 @@
           "seriesRunnerId": 269
         },
         {
-          "position": 29,
+          "position": 30,
           "name": "Claire Shaw",
           "club": "red-rose",
           "sex": "F",
@@ -8699,7 +8699,7 @@
           "seriesRunnerId": 272
         },
         {
-          "position": 32,
+          "position": 33,
           "name": "Jenny Salt",
           "club": "wesham",
           "sex": "F",
@@ -8744,7 +8744,7 @@
           "seriesRunnerId": 276
         },
         {
-          "position": 35,
+          "position": 36,
           "name": "Maureen Laney",
           "club": "red-rose",
           "sex": "F",
@@ -8789,7 +8789,7 @@
           "seriesRunnerId": 161
         },
         {
-          "position": 38,
+          "position": 39,
           "name": "Claire England",
           "club": "lytham",
           "sex": "F",
@@ -8804,7 +8804,7 @@
           "seriesRunnerId": 222
         },
         {
-          "position": 38,
+          "position": 40,
           "name": "Mary Conway",
           "club": "red-rose",
           "sex": "F",
@@ -8849,7 +8849,7 @@
           "seriesRunnerId": 281
         },
         {
-          "position": 42,
+          "position": 43,
           "name": "Kerry Eccles",
           "club": "wesham",
           "sex": "F",
@@ -8879,7 +8879,7 @@
           "seriesRunnerId": 283
         },
         {
-          "position": 44,
+          "position": 45,
           "name": "Janine McNeil",
           "club": "thornton",
           "sex": "F",
@@ -8909,7 +8909,7 @@
           "seriesRunnerId": 284
         },
         {
-          "position": 46,
+          "position": 47,
           "name": "Julie Sherwood",
           "club": "thornton",
           "sex": "F",
@@ -8969,7 +8969,7 @@
           "seriesRunnerId": 287
         },
         {
-          "position": 50,
+          "position": 51,
           "name": "Cat Holden",
           "club": "red-rose",
           "sex": "F",


### PR DESCRIPTION
## Summary
- Previously ties shared a position number in `src/data/2016/fell/individual-standings.json` (e.g. two runners both at position 9).
- `overall` category: reordered to match the user-supplied canonical order (each of the 183 entries verified against existing totals — zero discrepancies) and renumbered 1-183.
- `vets`/`v50`/`v60`/`female` categories: no canonical order was supplied for these, so renumbered 1..N using each category's existing runner order (unchanged), just removing duplicate position numbers.
- No other fields (name, club, sex, ageCategory, total, results, seriesRunnerId) were altered.

## Test plan
- [x] `npm test` passes (518 tests)
- [x] `npm run build` succeeds (2896 pages)
- [x] Verified all 5 categories now have unique, sequential positions with zero data drift on other fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)