### PR TITLE
data(fell): fix 2012/2013/2015 vet award category ids

### DIFF
--- a/src/data/2012/fell/awards.json
+++ b/src/data/2012/fell/awards.json
@@ -35,7 +35,7 @@
       ]
     },
     {
-      "id": "m-v40",
+      "id": "v40",
       "awards": [
         {
           "position": 1,
@@ -50,7 +50,6 @@
           "seriesRunnerId": 103
         }
       ],
-      "sex": "M",
       "ageCategory": "V40"
     },
     {
@@ -67,7 +66,7 @@
       "sex": "M"
     },
     {
-      "id": "m-v50",
+      "id": "v50",
       "awards": [
         {
           "position": 2,
@@ -76,7 +75,6 @@
           "seriesRunnerId": 142
         }
       ],
-      "sex": "M",
       "ageCategory": "V50"
     },
     {
@@ -107,7 +105,7 @@
       "ageCategory": "V40"
     },
     {
-      "id": "m-v60",
+      "id": "v60",
       "awards": [
         {
           "position": 1,
@@ -116,7 +114,6 @@
           "seriesRunnerId": 136
         }
       ],
-      "sex": "M",
       "ageCategory": "V60"
     }
   ]

--- a/src/data/2013/fell/awards.json
+++ b/src/data/2013/fell/awards.json
@@ -75,7 +75,7 @@
       "sex": "F"
     },
     {
-      "id": "m-v40",
+      "id": "v40",
       "awards": [
         {
           "position": 2,
@@ -90,11 +90,10 @@
           "seriesRunnerId": 112
         }
       ],
-      "sex": "M",
       "ageCategory": "V40"
     },
     {
-      "id": "m-v50",
+      "id": "v50",
       "awards": [
         {
           "position": 1,
@@ -115,11 +114,10 @@
           "seriesRunnerId": 115
         }
       ],
-      "sex": "M",
       "ageCategory": "V50"
     },
     {
-      "id": "m-v60",
+      "id": "v60",
       "awards": [
         {
           "position": 1,
@@ -128,7 +126,6 @@
           "seriesRunnerId": 131
         }
       ],
-      "sex": "M",
       "ageCategory": "V60"
     }
   ]

--- a/src/data/2015/fell/awards.json
+++ b/src/data/2015/fell/awards.json
@@ -48,7 +48,7 @@
       "sex": "M"
     },
     {
-      "id": "m-v40",
+      "id": "v40",
       "awards": [
         {
           "position": 1,
@@ -63,11 +63,10 @@
           "seriesRunnerId": 105
         }
       ],
-      "sex": "M",
       "ageCategory": "V40"
     },
     {
-      "id": "m-v50",
+      "id": "v50",
       "awards": [
         {
           "position": 1,
@@ -82,11 +81,10 @@
           "seriesRunnerId": 178
         }
       ],
-      "sex": "M",
       "ageCategory": "V50"
     },
     {
-      "id": "m-v60",
+      "id": "v60",
       "awards": [
         {
           "position": 1,
@@ -101,7 +99,6 @@
           "seriesRunnerId": 169
         }
       ],
-      "sex": "M",
       "ageCategory": "V60"
     },
     {


### PR DESCRIPTION
## Summary
- Prior to 2017 the fell championship vet awards (V40/V50/V60) were sex-agnostic categories — confirmed by the team `vets`/`v50`/`v60` categories already used that way in the same years.
- 2012, 2013, and 2015 `individualAwards` entries incorrectly used male-specific ids (`m-v40`, `m-v50`, `m-v60`) with a `sex: "M"` field.
- Renamed to `v40`/`v50`/`v60` and removed the stray `sex` field so they match 2014 and 2016, which were already correct.
- 2017 onward is untouched — male vet categories became sex-specific from that year on and are already ided correctly (`m-v40`, etc.).

## Test plan
- [x] Validated all three edited `awards.json` files parse as valid JSON
- [x] Diffed category ids/sex fields across all fell years 2012–2025 to confirm only 2012/2013/2015 needed the fix