### PR TITLE
data(2011-fell): reorder ladies category to follow open

### DIFF
--- a/src/data/2011/fell/results/golf-ball-teams.json
+++ b/src/data/2011/fell/results/golf-ball-teams.json
@@ -159,6 +159,112 @@
       ]
     },
     {
+      "id": "ladies",
+      "clubs": [
+        {
+          "position": 1,
+          "points": 15,
+          "total": 15,
+          "club": "preston",
+          "scorers": [
+            {
+              "name": "Nichola Jackson",
+              "position": 1,
+              "seriesRunnerId": 102
+            },
+            {
+              "name": "Lindsey Berends",
+              "position": 3,
+              "seriesRunnerId": 113
+            },
+            {
+              "name": "Melanie Haworth",
+              "position": 11,
+              "seriesRunnerId": 138
+            }
+          ]
+        },
+        {
+          "position": 2,
+          "points": 19,
+          "total": 19,
+          "club": "lytham",
+          "scorers": [
+            {
+              "name": "Melanie Koth",
+              "position": 2,
+              "seriesRunnerId": 116
+            },
+            {
+              "name": "Debbie Cooper",
+              "position": 7,
+              "seriesRunnerId": 131
+            },
+            {
+              "name": "Julia Rolfe",
+              "position": 10,
+              "seriesRunnerId": 196
+            }
+          ]
+        },
+        {
+          "position": 3,
+          "points": 23,
+          "total": 23,
+          "club": "red-rose",
+          "scorers": [
+            {
+              "name": "Glenda Dobie",
+              "position": 6,
+              "seriesRunnerId": 129
+            },
+            {
+              "name": "Paula Plowman",
+              "position": 8,
+              "seriesRunnerId": 172
+            },
+            {
+              "name": "Debbie Kirkman",
+              "position": 9,
+              "seriesRunnerId": 195
+            }
+          ]
+        },
+        {
+          "position": 4,
+          "points": 9,
+          "total": 9,
+          "club": "wesham",
+          "scorers": [
+            {
+              "name": "Sarah Sherratt",
+              "position": 4,
+              "seriesRunnerId": 108
+            },
+            {
+              "name": "Kath Hoyer",
+              "position": 5,
+              "seriesRunnerId": 188
+            }
+          ]
+        },
+        {
+          "position": 5,
+          "points": 0,
+          "total": 0,
+          "club": "blackpool",
+          "scorers": []
+        },
+        {
+          "position": 6,
+          "points": 0,
+          "total": 0,
+          "club": "chorley-ac",
+          "scorers": []
+        }
+      ]
+    },
+    {
       "id": "vets",
       "clubs": [
         {
@@ -476,112 +582,6 @@
           "points": 0,
           "total": 0,
           "club": "wesham",
-          "scorers": []
-        }
-      ]
-    },
-    {
-      "id": "ladies",
-      "clubs": [
-        {
-          "position": 1,
-          "points": 15,
-          "total": 15,
-          "club": "preston",
-          "scorers": [
-            {
-              "name": "Nichola Jackson",
-              "position": 1,
-              "seriesRunnerId": 102
-            },
-            {
-              "name": "Lindsey Berends",
-              "position": 3,
-              "seriesRunnerId": 113
-            },
-            {
-              "name": "Melanie Haworth",
-              "position": 11,
-              "seriesRunnerId": 138
-            }
-          ]
-        },
-        {
-          "position": 2,
-          "points": 19,
-          "total": 19,
-          "club": "lytham",
-          "scorers": [
-            {
-              "name": "Melanie Koth",
-              "position": 2,
-              "seriesRunnerId": 116
-            },
-            {
-              "name": "Debbie Cooper",
-              "position": 7,
-              "seriesRunnerId": 131
-            },
-            {
-              "name": "Julia Rolfe",
-              "position": 10,
-              "seriesRunnerId": 196
-            }
-          ]
-        },
-        {
-          "position": 3,
-          "points": 23,
-          "total": 23,
-          "club": "red-rose",
-          "scorers": [
-            {
-              "name": "Glenda Dobie",
-              "position": 6,
-              "seriesRunnerId": 129
-            },
-            {
-              "name": "Paula Plowman",
-              "position": 8,
-              "seriesRunnerId": 172
-            },
-            {
-              "name": "Debbie Kirkman",
-              "position": 9,
-              "seriesRunnerId": 195
-            }
-          ]
-        },
-        {
-          "position": 4,
-          "points": 9,
-          "total": 9,
-          "club": "wesham",
-          "scorers": [
-            {
-              "name": "Sarah Sherratt",
-              "position": 4,
-              "seriesRunnerId": 108
-            },
-            {
-              "name": "Kath Hoyer",
-              "position": 5,
-              "seriesRunnerId": 188
-            }
-          ]
-        },
-        {
-          "position": 5,
-          "points": 0,
-          "total": 0,
-          "club": "blackpool",
-          "scorers": []
-        },
-        {
-          "position": 6,
-          "points": 0,
-          "total": 0,
-          "club": "chorley-ac",
           "scorers": []
         }
       ]

--- a/src/data/2011/fell/results/pendle-teams.json
+++ b/src/data/2011/fell/results/pendle-teams.json
@@ -189,6 +189,107 @@
       ]
     },
     {
+      "id": "ladies",
+      "clubs": [
+        {
+          "position": 1,
+          "points": 9,
+          "total": 9,
+          "club": "preston",
+          "scorers": [
+            {
+              "name": "Nichola Jackson",
+              "position": 1,
+              "seriesRunnerId": 102
+            },
+            {
+              "name": "Lindsey Berends",
+              "position": 3,
+              "seriesRunnerId": 113
+            },
+            {
+              "name": "Claire McDermott",
+              "position": 5,
+              "seriesRunnerId": 122
+            }
+          ]
+        },
+        {
+          "position": 2,
+          "points": 24,
+          "total": 24,
+          "club": "lytham",
+          "scorers": [
+            {
+              "name": "Melanie Koth",
+              "position": 4,
+              "seriesRunnerId": 116
+            },
+            {
+              "name": "Debbie Cooper",
+              "position": 8,
+              "seriesRunnerId": 131
+            },
+            {
+              "name": "Dawn Lock",
+              "position": 12,
+              "seriesRunnerId": 147
+            }
+          ]
+        },
+        {
+          "position": 3,
+          "points": 8,
+          "total": 8,
+          "club": "wesham",
+          "scorers": [
+            {
+              "name": "Sarah Sherratt",
+              "position": 2,
+              "seriesRunnerId": 108
+            },
+            {
+              "name": "Jenny Salt",
+              "position": 6,
+              "seriesRunnerId": 125
+            }
+          ]
+        },
+        {
+          "position": 4,
+          "points": 16,
+          "total": 16,
+          "club": "red-rose",
+          "scorers": [
+            {
+              "name": "Glenda Dobie",
+              "position": 7,
+              "seriesRunnerId": 129
+            },
+            {
+              "name": "Sally Cape",
+              "position": 9,
+              "seriesRunnerId": 135
+            }
+          ]
+        },
+        {
+          "position": 5,
+          "points": 0,
+          "total": 0,
+          "club": "blackpool",
+          "scorers": []
+        },
+        {
+          "position": 6,
+          "points": 0,
+          "total": 0,
+          "club": "chorley-ac",
+          "scorers": []
+        }
+      ]
+    },
+    {
       "id": "vets",
       "clubs": [
         {
@@ -546,107 +647,6 @@
           "points": 0,
           "total": 0,
           "club": "wesham",
-          "scorers": []
-        }
-      ]
-    },
-    {
-      "id": "ladies",
-      "clubs": [
-        {
-          "position": 1,
-          "points": 9,
-          "total": 9,
-          "club": "preston",
-          "scorers": [
-            {
-              "name": "Nichola Jackson",
-              "position": 1,
-              "seriesRunnerId": 102
-            },
-            {
-              "name": "Lindsey Berends",
-              "position": 3,
-              "seriesRunnerId": 113
-            },
-            {
-              "name": "Claire McDermott",
-              "position": 5,
-              "seriesRunnerId": 122
-            }
-          ]
-        },
-        {
-          "position": 2,
-          "points": 24,
-          "total": 24,
-          "club": "lytham",
-          "scorers": [
-            {
-              "name": "Melanie Koth",
-              "position": 4,
-              "seriesRunnerId": 116
-            },
-            {
-              "name": "Debbie Cooper",
-              "position": 8,
-              "seriesRunnerId": 131
-            },
-            {
-              "name": "Dawn Lock",
-              "position": 12,
-              "seriesRunnerId": 147
-            }
-          ]
-        },
-        {
-          "position": 3,
-          "points": 8,
-          "total": 8,
-          "club": "wesham",
-          "scorers": [
-            {
-              "name": "Sarah Sherratt",
-              "position": 2,
-              "seriesRunnerId": 108
-            },
-            {
-              "name": "Jenny Salt",
-              "position": 6,
-              "seriesRunnerId": 125
-            }
-          ]
-        },
-        {
-          "position": 4,
-          "points": 16,
-          "total": 16,
-          "club": "red-rose",
-          "scorers": [
-            {
-              "name": "Glenda Dobie",
-              "position": 7,
-              "seriesRunnerId": 129
-            },
-            {
-              "name": "Sally Cape",
-              "position": 9,
-              "seriesRunnerId": 135
-            }
-          ]
-        },
-        {
-          "position": 5,
-          "points": 0,
-          "total": 0,
-          "club": "blackpool",
-          "scorers": []
-        },
-        {
-          "position": 6,
-          "points": 0,
-          "total": 0,
-          "club": "chorley-ac",
           "scorers": []
         }
       ]

--- a/src/data/2011/fell/results/two-lads-teams.json
+++ b/src/data/2011/fell/results/two-lads-teams.json
@@ -189,6 +189,118 @@
       ]
     },
     {
+      "id": "ladies",
+      "clubs": [
+        {
+          "position": 1,
+          "points": 15,
+          "total": 15,
+          "club": "wesham",
+          "scorers": [
+            {
+              "name": "Sarah Sherratt",
+              "position": 3,
+              "seriesRunnerId": 108
+            },
+            {
+              "name": "Helen Lawrenson",
+              "position": 4,
+              "seriesRunnerId": 161
+            },
+            {
+              "name": "Jen Salt",
+              "position": 8,
+              "seriesRunnerId": 171
+            }
+          ]
+        },
+        {
+          "position": 2,
+          "points": 18,
+          "total": 18,
+          "club": "red-rose",
+          "scorers": [
+            {
+              "name": "Alison John-Haslam",
+              "position": 5,
+              "seriesRunnerId": 162
+            },
+            {
+              "name": "Glenda Dobie",
+              "position": 6,
+              "seriesRunnerId": 129
+            },
+            {
+              "name": "Janine Needham",
+              "position": 7,
+              "seriesRunnerId": 169
+            }
+          ]
+        },
+        {
+          "position": 3,
+          "points": 23,
+          "total": 23,
+          "club": "lytham",
+          "scorers": [
+            {
+              "name": "Melanie Koth",
+              "position": 2,
+              "seriesRunnerId": 116
+            },
+            {
+              "name": "Debbie Cooper",
+              "position": 9,
+              "seriesRunnerId": 131
+            },
+            {
+              "name": "Laura Ashworth",
+              "position": 12,
+              "seriesRunnerId": 175
+            }
+          ]
+        },
+        {
+          "position": 4,
+          "points": 17,
+          "total": 17,
+          "club": "preston",
+          "scorers": [
+            {
+              "name": "Nichola Jackson",
+              "position": 1,
+              "seriesRunnerId": 102
+            },
+            {
+              "name": "Melanie Howorth",
+              "position": 16,
+              "seriesRunnerId": 180
+            }
+          ]
+        },
+        {
+          "position": 5,
+          "points": 11,
+          "total": 11,
+          "club": "chorley-ac",
+          "scorers": [
+            {
+              "name": "Lauren Caton",
+              "position": 11,
+              "seriesRunnerId": 173
+            }
+          ]
+        },
+        {
+          "position": 6,
+          "points": 0,
+          "total": 0,
+          "club": "blackpool",
+          "scorers": []
+        }
+      ]
+    },
+    {
       "id": "vets",
       "clubs": [
         {
@@ -544,118 +656,6 @@
               "name": "Dawn Lock",
               "position": 10,
               "seriesRunnerId": 147
-            }
-          ]
-        },
-        {
-          "position": 6,
-          "points": 0,
-          "total": 0,
-          "club": "blackpool",
-          "scorers": []
-        }
-      ]
-    },
-    {
-      "id": "ladies",
-      "clubs": [
-        {
-          "position": 1,
-          "points": 15,
-          "total": 15,
-          "club": "wesham",
-          "scorers": [
-            {
-              "name": "Sarah Sherratt",
-              "position": 3,
-              "seriesRunnerId": 108
-            },
-            {
-              "name": "Helen Lawrenson",
-              "position": 4,
-              "seriesRunnerId": 161
-            },
-            {
-              "name": "Jen Salt",
-              "position": 8,
-              "seriesRunnerId": 171
-            }
-          ]
-        },
-        {
-          "position": 2,
-          "points": 18,
-          "total": 18,
-          "club": "red-rose",
-          "scorers": [
-            {
-              "name": "Alison John-Haslam",
-              "position": 5,
-              "seriesRunnerId": 162
-            },
-            {
-              "name": "Glenda Dobie",
-              "position": 6,
-              "seriesRunnerId": 129
-            },
-            {
-              "name": "Janine Needham",
-              "position": 7,
-              "seriesRunnerId": 169
-            }
-          ]
-        },
-        {
-          "position": 3,
-          "points": 23,
-          "total": 23,
-          "club": "lytham",
-          "scorers": [
-            {
-              "name": "Melanie Koth",
-              "position": 2,
-              "seriesRunnerId": 116
-            },
-            {
-              "name": "Debbie Cooper",
-              "position": 9,
-              "seriesRunnerId": 131
-            },
-            {
-              "name": "Laura Ashworth",
-              "position": 12,
-              "seriesRunnerId": 175
-            }
-          ]
-        },
-        {
-          "position": 4,
-          "points": 17,
-          "total": 17,
-          "club": "preston",
-          "scorers": [
-            {
-              "name": "Nichola Jackson",
-              "position": 1,
-              "seriesRunnerId": 102
-            },
-            {
-              "name": "Melanie Howorth",
-              "position": 16,
-              "seriesRunnerId": 180
-            }
-          ]
-        },
-        {
-          "position": 5,
-          "points": 11,
-          "total": 11,
-          "club": "chorley-ac",
-          "scorers": [
-            {
-              "name": "Lauren Caton",
-              "position": 11,
-              "seriesRunnerId": 173
             }
           ]
         },

--- a/src/data/2011/fell/results/warton-crag-teams.json
+++ b/src/data/2011/fell/results/warton-crag-teams.json
@@ -153,6 +153,86 @@
       ]
     },
     {
+      "id": "ladies",
+      "clubs": [
+        {
+          "position": 1,
+          "points": 6,
+          "total": 6,
+          "club": "wesham",
+          "scorers": [
+            {
+              "name": "Sarah Sherratt",
+              "position": 2,
+              "seriesRunnerId": 108
+            },
+            {
+              "name": "Kath Hoyer",
+              "position": 4,
+              "seriesRunnerId": 188
+            }
+          ]
+        },
+        {
+          "position": 2,
+          "points": 6,
+          "total": 6,
+          "club": "lytham",
+          "scorers": [
+            {
+              "name": "Melanie Koth",
+              "position": 1,
+              "seriesRunnerId": 116
+            },
+            {
+              "name": "Debbie Cooper",
+              "position": 5,
+              "seriesRunnerId": 131
+            }
+          ]
+        },
+        {
+          "position": 3,
+          "points": 9,
+          "total": 9,
+          "club": "red-rose",
+          "scorers": [
+            {
+              "name": "Alison John-Haslam",
+              "position": 3,
+              "seriesRunnerId": 162
+            },
+            {
+              "name": "Paula Plowman",
+              "position": 6,
+              "seriesRunnerId": 172
+            }
+          ]
+        },
+        {
+          "position": 4,
+          "points": 0,
+          "total": 0,
+          "club": "blackpool",
+          "scorers": []
+        },
+        {
+          "position": 5,
+          "points": 0,
+          "total": 0,
+          "club": "chorley-ac",
+          "scorers": []
+        },
+        {
+          "position": 6,
+          "points": 0,
+          "total": 0,
+          "club": "preston",
+          "scorers": []
+        }
+      ]
+    },
+    {
       "id": "vets",
       "clubs": [
         {
@@ -428,86 +508,6 @@
           "points": 0,
           "total": 0,
           "club": "wesham",
-          "scorers": []
-        }
-      ]
-    },
-    {
-      "id": "ladies",
-      "clubs": [
-        {
-          "position": 1,
-          "points": 6,
-          "total": 6,
-          "club": "wesham",
-          "scorers": [
-            {
-              "name": "Sarah Sherratt",
-              "position": 2,
-              "seriesRunnerId": 108
-            },
-            {
-              "name": "Kath Hoyer",
-              "position": 4,
-              "seriesRunnerId": 188
-            }
-          ]
-        },
-        {
-          "position": 2,
-          "points": 6,
-          "total": 6,
-          "club": "lytham",
-          "scorers": [
-            {
-              "name": "Melanie Koth",
-              "position": 1,
-              "seriesRunnerId": 116
-            },
-            {
-              "name": "Debbie Cooper",
-              "position": 5,
-              "seriesRunnerId": 131
-            }
-          ]
-        },
-        {
-          "position": 3,
-          "points": 9,
-          "total": 9,
-          "club": "red-rose",
-          "scorers": [
-            {
-              "name": "Alison John-Haslam",
-              "position": 3,
-              "seriesRunnerId": 162
-            },
-            {
-              "name": "Paula Plowman",
-              "position": 6,
-              "seriesRunnerId": 172
-            }
-          ]
-        },
-        {
-          "position": 4,
-          "points": 0,
-          "total": 0,
-          "club": "blackpool",
-          "scorers": []
-        },
-        {
-          "position": 5,
-          "points": 0,
-          "total": 0,
-          "club": "chorley-ac",
-          "scorers": []
-        },
-        {
-          "position": 6,
-          "points": 0,
-          "total": 0,
-          "club": "preston",
           "scorers": []
         }
       ]

--- a/src/data/2011/fell/team-standings.json
+++ b/src/data/2011/fell/team-standings.json
@@ -1,60 +1,395 @@
 {
   "provisional": false,
-  "races": ["pendle", "two-lads", "warton-crag", "golf-ball"],
+  "races": [
+    "pendle",
+    "two-lads",
+    "warton-crag",
+    "golf-ball"
+  ],
   "categories": [
     {
       "id": "open",
       "clubs": [
-        { "position": 1, "club": "red-rose", "points": [4, 5, 6, 6], "total": 21, "tiebreaker": null },
-        { "position": 2, "club": "wesham", "points": [5, 6, 5, 2], "total": 18, "tiebreaker": null },
-        { "position": 3, "club": "preston", "points": [6, 2, 2, 5], "total": 15, "tiebreaker": null },
-        { "position": 4, "club": "chorley-ac", "points": [3, 4, 4, 3], "total": 14, "tiebreaker": null },
-        { "position": 5, "club": "lytham", "points": [2, 3, 3, 4], "total": 12, "tiebreaker": null },
-        { "position": 6, "club": "blackpool", "points": [1, 1, 0, 1], "total": 3, "tiebreaker": null }
-      ]
-    },
-    {
-      "id": "vets",
-      "clubs": [
-        { "position": 1, "club": "red-rose", "points": [4, 6, 6, 6], "total": 22, "tiebreaker": null },
-        { "position": 2, "club": "chorley-ac", "points": [3, 5, 5, 4], "total": 17, "tiebreaker": "246 points" },
-        { "position": 3, "club": "preston", "points": [6, 3, 3, 5], "total": 17, "tiebreaker": "279 points" },
-        { "position": 4, "club": "wesham", "points": [5, 4, 4, 3], "total": 16, "tiebreaker": null },
-        { "position": 5, "club": "lytham", "points": [1, 2, 0, 2], "total": 5, "tiebreaker": null },
-        { "position": 6, "club": "blackpool", "points": [2, 1, 0, 1], "total": 4, "tiebreaker": null }
-      ]
-    },
-    {
-      "id": "v50",
-      "clubs": [
-        { "position": 1, "club": "red-rose", "points": [6, 6, 6, 6], "total": 24, "tiebreaker": null },
-        { "position": 2, "club": "chorley-ac", "points": [5, 5, 5, 4], "total": 19, "tiebreaker": null },
-        { "position": 3, "club": "preston", "points": [3, 4, 0, 5], "total": 12, "tiebreaker": null },
-        { "position": 4, "club": "wesham", "points": [2, 3, 4, 2], "total": 11, "tiebreaker": null },
-        { "position": 5, "club": "blackpool", "points": [4, 1, 0, 3], "total": 8, "tiebreaker": null },
-        { "position": 6, "club": "lytham", "points": [1, 2, 0, 1], "total": 4, "tiebreaker": null }
-      ]
-    },
-    {
-      "id": "v60",
-      "clubs": [
-        { "position": 1, "club": "chorley-ac", "points": [6, 6, 6, 6], "total": 24, "tiebreaker": null },
-        { "position": 2, "club": "red-rose", "points": [4, 3, 5, 4], "total": 16, "tiebreaker": null },
-        { "position": 3, "club": "preston", "points": [5, 5, 0, 5], "total": 15, "tiebreaker": null },
-        { "position": 4, "club": "lytham", "points": [3, 2, 0, 3], "total": 8, "tiebreaker": null },
-        { "position": 5, "club": "wesham", "points": [0, 4, 0, 0], "total": 4, "tiebreaker": null },
-        { "position": 6, "club": "blackpool", "points": [0, 0, 0, 0], "total": 0, "tiebreaker": null }
+        {
+          "position": 1,
+          "club": "red-rose",
+          "points": [
+            4,
+            5,
+            6,
+            6
+          ],
+          "total": 21,
+          "tiebreaker": null
+        },
+        {
+          "position": 2,
+          "club": "wesham",
+          "points": [
+            5,
+            6,
+            5,
+            2
+          ],
+          "total": 18,
+          "tiebreaker": null
+        },
+        {
+          "position": 3,
+          "club": "preston",
+          "points": [
+            6,
+            2,
+            2,
+            5
+          ],
+          "total": 15,
+          "tiebreaker": null
+        },
+        {
+          "position": 4,
+          "club": "chorley-ac",
+          "points": [
+            3,
+            4,
+            4,
+            3
+          ],
+          "total": 14,
+          "tiebreaker": null
+        },
+        {
+          "position": 5,
+          "club": "lytham",
+          "points": [
+            2,
+            3,
+            3,
+            4
+          ],
+          "total": 12,
+          "tiebreaker": null
+        },
+        {
+          "position": 6,
+          "club": "blackpool",
+          "points": [
+            1,
+            1,
+            0,
+            1
+          ],
+          "total": 3,
+          "tiebreaker": null
+        }
       ]
     },
     {
       "id": "ladies",
       "clubs": [
-        { "position": 1, "club": "lytham", "points": [5, 4, 5, 5], "total": 19, "tiebreaker": "86 points" },
-        { "position": 2, "club": "wesham", "points": [4, 6, 6, 3], "total": 19, "tiebreaker": "108 points" },
-        { "position": 3, "club": "red-rose", "points": [3, 5, 4, 4], "total": 16, "tiebreaker": null },
-        { "position": 4, "club": "preston", "points": [6, 3, 0, 6], "total": 15, "tiebreaker": null },
-        { "position": 5, "club": "chorley-ac", "points": [0, 2, 0, 0], "total": 2, "tiebreaker": null },
-        { "position": 6, "club": "blackpool", "points": [0, 0, 0, 0], "total": 0, "tiebreaker": null }
+        {
+          "position": 1,
+          "club": "lytham",
+          "points": [
+            5,
+            4,
+            5,
+            5
+          ],
+          "total": 19,
+          "tiebreaker": "86 points"
+        },
+        {
+          "position": 2,
+          "club": "wesham",
+          "points": [
+            4,
+            6,
+            6,
+            3
+          ],
+          "total": 19,
+          "tiebreaker": "108 points"
+        },
+        {
+          "position": 3,
+          "club": "red-rose",
+          "points": [
+            3,
+            5,
+            4,
+            4
+          ],
+          "total": 16,
+          "tiebreaker": null
+        },
+        {
+          "position": 4,
+          "club": "preston",
+          "points": [
+            6,
+            3,
+            0,
+            6
+          ],
+          "total": 15,
+          "tiebreaker": null
+        },
+        {
+          "position": 5,
+          "club": "chorley-ac",
+          "points": [
+            0,
+            2,
+            0,
+            0
+          ],
+          "total": 2,
+          "tiebreaker": null
+        },
+        {
+          "position": 6,
+          "club": "blackpool",
+          "points": [
+            0,
+            0,
+            0,
+            0
+          ],
+          "total": 0,
+          "tiebreaker": null
+        }
+      ]
+    },
+    {
+      "id": "vets",
+      "clubs": [
+        {
+          "position": 1,
+          "club": "red-rose",
+          "points": [
+            4,
+            6,
+            6,
+            6
+          ],
+          "total": 22,
+          "tiebreaker": null
+        },
+        {
+          "position": 2,
+          "club": "chorley-ac",
+          "points": [
+            3,
+            5,
+            5,
+            4
+          ],
+          "total": 17,
+          "tiebreaker": "246 points"
+        },
+        {
+          "position": 3,
+          "club": "preston",
+          "points": [
+            6,
+            3,
+            3,
+            5
+          ],
+          "total": 17,
+          "tiebreaker": "279 points"
+        },
+        {
+          "position": 4,
+          "club": "wesham",
+          "points": [
+            5,
+            4,
+            4,
+            3
+          ],
+          "total": 16,
+          "tiebreaker": null
+        },
+        {
+          "position": 5,
+          "club": "lytham",
+          "points": [
+            1,
+            2,
+            0,
+            2
+          ],
+          "total": 5,
+          "tiebreaker": null
+        },
+        {
+          "position": 6,
+          "club": "blackpool",
+          "points": [
+            2,
+            1,
+            0,
+            1
+          ],
+          "total": 4,
+          "tiebreaker": null
+        }
+      ]
+    },
+    {
+      "id": "v50",
+      "clubs": [
+        {
+          "position": 1,
+          "club": "red-rose",
+          "points": [
+            6,
+            6,
+            6,
+            6
+          ],
+          "total": 24,
+          "tiebreaker": null
+        },
+        {
+          "position": 2,
+          "club": "chorley-ac",
+          "points": [
+            5,
+            5,
+            5,
+            4
+          ],
+          "total": 19,
+          "tiebreaker": null
+        },
+        {
+          "position": 3,
+          "club": "preston",
+          "points": [
+            3,
+            4,
+            0,
+            5
+          ],
+          "total": 12,
+          "tiebreaker": null
+        },
+        {
+          "position": 4,
+          "club": "wesham",
+          "points": [
+            2,
+            3,
+            4,
+            2
+          ],
+          "total": 11,
+          "tiebreaker": null
+        },
+        {
+          "position": 5,
+          "club": "blackpool",
+          "points": [
+            4,
+            1,
+            0,
+            3
+          ],
+          "total": 8,
+          "tiebreaker": null
+        },
+        {
+          "position": 6,
+          "club": "lytham",
+          "points": [
+            1,
+            2,
+            0,
+            1
+          ],
+          "total": 4,
+          "tiebreaker": null
+        }
+      ]
+    },
+    {
+      "id": "v60",
+      "clubs": [
+        {
+          "position": 1,
+          "club": "chorley-ac",
+          "points": [
+            6,
+            6,
+            6,
+            6
+          ],
+          "total": 24,
+          "tiebreaker": null
+        },
+        {
+          "position": 2,
+          "club": "red-rose",
+          "points": [
+            4,
+            3,
+            5,
+            4
+          ],
+          "total": 16,
+          "tiebreaker": null
+        },
+        {
+          "position": 3,
+          "club": "preston",
+          "points": [
+            5,
+            5,
+            0,
+            5
+          ],
+          "total": 15,
+          "tiebreaker": null
+        },
+        {
+          "position": 4,
+          "club": "lytham",
+          "points": [
+            3,
+            2,
+            0,
+            3
+          ],
+          "total": 8,
+          "tiebreaker": null
+        },
+        {
+          "position": 5,
+          "club": "wesham",
+          "points": [
+            0,
+            4,
+            0,
+            0
+          ],
+          "total": 4,
+          "tiebreaker": null
+        },
+        {
+          "position": 6,
+          "club": "blackpool",
+          "points": [
+            0,
+            0,
+            0,
+            0
+          ],
+          "total": 0,
+          "tiebreaker": null
+        }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- Reorders the `categories` array in `team-standings.json` and all four per-race `*-teams.json` files so `ladies` immediately follows `open`, matching the order already used in `config.json`'s `teamCategories` and `awards.json`'s `teamAwards`.
- Previously these files had `open, vets, v50, v60, ladies`; now they're all `open, ladies, vets, v50, v60` consistently.

No data values changed — this is a pure reordering of the category array within each file.

## Test plan

- [x] All touched JSON files validated for syntax
- [x] `npm test` passes (536/536)

🤖 Generated with [Claude Code](https://claude.com/claude-code)