### PR TITLE
fix: merged/mislinked runner identities found via age-category validation

### DIFF
--- a/src/data/2005/road-gp/runners.json
+++ b/src/data/2005/road-gp/runners.json
@@ -537,7 +537,7 @@
     "club": "chorley-ac",
     "sex": "M",
     "ageCategory": "V40",
-    "runnerId": 13733
+    "runnerId": 13918
   },
   {
     "id": 160,

--- a/src/data/2008/road-gp/runners.json
+++ b/src/data/2008/road-gp/runners.json
@@ -1104,7 +1104,7 @@
     "club": "blackpool",
     "sex": "M",
     "ageCategory": "V50",
-    "runnerId": 10047
+    "runnerId": 13745
   },
   {
     "id": 223,

--- a/src/data/2014/road-gp/runners.json
+++ b/src/data/2014/road-gp/runners.json
@@ -3273,7 +3273,7 @@
     "club": "chorley",
     "sex": "M",
     "ageCategory": "V65",
-    "runnerId": 12776
+    "runnerId": 13417
   },
   {
     "id": 464,

--- a/src/data/2017/road-gp/results/chorley.csv
+++ b/src/data/2017/road-gp/results/chorley.csv
@@ -190,7 +190,7 @@
 189,184,38,20,54,,106,901,Paula,Plowman,red-rose,V50,F,41:33,286
 190,185,,,55,,107,900,John,Plowman,red-rose,V50,M,41:36,337
 191,186,,,56,20,108,1388,David,Young,wesham,V65,M,41:38,329
-192,187,,,,,109,579,Kenny,Gawne,preston,V45,M,41:43,195
+192,187,,,,,109,579,Kenny,Gawne,preston,V45,M,41:43,807
 193,188,39,,,,110,863,Natalie,Moore,red-rose,V35,F,41:47,315
 194,189,,,,,111,998,Peter,Withnell,red-rose,V45,M,41:50,562
 195,190,,,,,112,1041,James,Hughes,red-rose,V45,M,41:52,563

--- a/src/data/2017/road-gp/results/preston.csv
+++ b/src/data/2017/road-gp/results/preston.csv
@@ -218,7 +218,7 @@
 217,214,,,,,,1393,Rob,Wallace,wesham,SEN,M,35:23,341
 218,215,45,23,66,22,141,720,Carol,Douglass,red-rose,V70,F,35:26,570
 219,216,,,67,23,142,1388,David,Young,wesham,V65,M,35:33,329
-220,217,,,,,143,579,Kenny,Gawne,preston,V45,M,35:36,195
+220,217,,,,,143,579,Kenny,Gawne,preston,V45,M,35:36,807
 221,218,,,,,,913,Graham,Roberts,red-rose,SEN,M,35:37,734
 222,219,46,24,68,,144,323,Julia,Rolfe,lytham,V50,F,35:38,348
 223,220,47,,,,145,934,Claire,Shaw,red-rose,V35,F,35:47,458

--- a/src/data/2017/road-gp/results/red-rose.csv
+++ b/src/data/2017/road-gp/results/red-rose.csv
@@ -175,7 +175,7 @@
 174,171,39,22,50,,101,890,Alison,Parkinson,red-rose,V50,F,36:34,306
 175,172,40,,,,,736,Rachel,Fisher,red-rose,SEN,F,36:35,733
 176,173,,,,,,666,Gareth,Bell,red-rose,SEN,M,36:47,559
-177,174,,,,,102,579,Kenny,Gawne,preston,V45,M,37:01,195
+177,174,,,,,102,579,Kenny,Gawne,preston,V45,M,37:01,807
 178,175,41,23,51,,103,323,Julia,Rolfe,lytham,V55,F,37:01,348
 179,176,42,,,,104,276,Louise,De-Gier Flood,lytham,V35,F,37:05,655
 180,177,43,,,,,1029,Emily,Sinkinson,red-rose,SEN,F,37:06,401

--- a/src/data/2017/road-gp/results/thornton.csv
+++ b/src/data/2017/road-gp/results/thornton.csv
@@ -178,7 +178,7 @@
 177,175,,,,,115,971,Ian,Waddingham,red-rose,V40,M,39:24,780
 178,176,,,56,18,116,303,Colin,Laidlaw,lytham,V60,M,39:25,279
 179,177,,,,,117,973,Stephen,Walker,red-rose,V40,M,39:28,730
-180,178,,,,,118,579,Kenny,Gawne,preston,V45,M,39:37,195
+180,178,,,,,118,579,Kenny,Gawne,preston,V45,M,39:37,807
 181,179,,,57,19,119,1338,Philip,Leaver,wesham,V60,M,39:40,728
 182,180,33,,,,,566,Jade,Bebbington,preston,SEN,F,39:40,339
 183,181,,,,,120,322,Peter,Reid,lytham,V45,M,39:47,294

--- a/src/data/2017/road-gp/runners.json
+++ b/src/data/2017/road-gp/runners.json
@@ -7067,5 +7067,15 @@
         "club": "red-rose",
         "sex": "M",
         "ageCategory": "SEN"
+    },
+    {
+        "id": 807,
+        "firstName": "Kenny",
+        "lastName": "Gawne (snr)",
+        "club": "preston",
+        "sex": "M",
+        "ageCategory": "V45",
+        "number": 579,
+        "runnerId": 11532
     }
 ]

--- a/src/data/2018/fell/runners.json
+++ b/src/data/2018/fell/runners.json
@@ -924,7 +924,7 @@
         "club":  "red-rose",
         "sex":  "M",
         "ageCategory":  "V50",
-        "runnerId":  11299
+        "runnerId":  13981
     },
     {
         "id":  203,

--- a/src/data/2018/road-gp/runners.json
+++ b/src/data/2018/road-gp/runners.json
@@ -1867,7 +1867,7 @@
         "sex":  "M",
         "ageCategory":  "V50",
         "number":  819,
-        "runnerId":  11299
+        "runnerId":  13981
     },
     {
         "id":  287,

--- a/src/data/2019/road-gp/runners.json
+++ b/src/data/2019/road-gp/runners.json
@@ -4927,7 +4927,7 @@
         "sex":  "M",
         "ageCategory":  "V50",
         "number":  1110,
-        "runnerId":  11299
+        "runnerId":  13981
     },
     {
         "id":  593,

--- a/src/data/2022/fell/runners.json
+++ b/src/data/2022/fell/runners.json
@@ -114,7 +114,7 @@
         "club":  "red-rose",
         "sex":  "M",
         "ageCategory":  "V50",
-        "runnerId":  11299
+        "runnerId":  13981
     },
     {
         "id":  113,

--- a/src/data/2022/road-gp/runners.json
+++ b/src/data/2022/road-gp/runners.json
@@ -2237,7 +2237,7 @@
         "sex":  "M",
         "ageCategory":  "V55",
         "number":  1093,
-        "runnerId":  11299
+        "runnerId":  13981
     },
     {
         "id":  324,
@@ -4787,7 +4787,7 @@
         "sex":  "M",
         "ageCategory":  "V35",
         "number":  639,
-        "runnerId":  11252
+        "runnerId":  13980
     },
     {
         "id":  579,

--- a/src/data/2023/road-gp/runners.json
+++ b/src/data/2023/road-gp/runners.json
@@ -4767,7 +4767,7 @@
     "sex": "M",
     "ageCategory": "V35",
     "number": 717,
-    "runnerId": 11252
+    "runnerId": 13980
   },
   {
     "id": 577,


### PR DESCRIPTION
## Summary

Validated every runner's age-category progression across all years and both series (Road GP + Fell) using the `runners.json` registries, looking for categories that go backwards or jump by an implausible number of years for the elapsed time. Found and fixed 6 global runner ids that had been incorrectly shared between two different real people, or linked to the wrong existing identity.

- **Kenny Gawne** (2017 road-gp): bib 471 (SEN) and bib 579 (V45) were both linked to id 12049; the V45 rows now link to the existing "Gawne (snr)" id 11532.
- **Peter Gibson** (red-rose): 2004–2010 (V55→V60) kept on id 11252; 2022–2023 (V35) split to new id 13980.
- **Kevin Smith** (red-rose): 2004–2005 (V60) kept on id 11299; 2018–2022 (V50→V55) split to new id 13981.
- **Steve Abbott**: 2008 Blackpool entry (V50) relinked from id 10047 to the existing "Steve Abbott, North Fylde" id 13745, continuing its V45→V50 progression; id 10047 now only covers the 2019–2026 Wesham entries.
- **Stuart Swann** (chorley): 2014 V65 entry relinked from id 12776 to id 13417, continuing that runner's V55→V60→V65 progression instead of an impossible SEN→V65 jump.
- **Paul Mason**: 2005 chorley-ac entry relinked from id 13733 (north-fylde) to id 13918 (the existing chorley-ac Paul Mason), fixing both an impossible category jump and an unexplained club move.

Each fix updates the affected series-local `runners.json` `runnerId` link(s), the relevant results CSV `series_runner_id` values where applicable (Gawne only), and the global `runners.json` snapshot (`ageCategory`/`ageCategoryYear`/`club`) for each affected id.

A validation script confirms none of these six runners still show a backwards or oversized category jump after the fixes.

## Test plan

- [x] `npm run build` succeeds after each fix (4444 pages)
- [x] Re-ran the age-category validation script after each fix to confirm the specific anomaly is resolved
- [x] Confirmed all edited `runners.json` files still parse as valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)