### PR TITLE
data: fix fell race name/distance inconsistencies; standardize distance display

### DIFF
--- a/src/components/IndividualResultsLayout.astro
+++ b/src/components/IndividualResultsLayout.astro
@@ -8,7 +8,7 @@ import { CLUB_COLORS } from '../lib/clubColors';
 import { getRace, getRaces } from '../lib/data';
 import { hasTeamResults } from '../lib/results';
 import { siteUrl } from '../lib/url';
-import { formatRaceDate, formatTime, getSeriesLabel, seriesAccent } from '../lib/format';
+import { formatRaceDate, formatDistance, formatTime, getSeriesLabel, seriesAccent } from '../lib/format';
 import type { Club, RaceResult, Series, SeriesConfig } from '../lib/types';
 
 export interface Props {
@@ -86,7 +86,7 @@ const clubTurnout = [...clubCountMap.entries()]
 const raceMeta = [
   race?.date ? formatRaceDate(race.date, race?.time) : null,
   race?.location ?? null,
-  race?.distance ?? null,
+  formatDistance(race?.distance),
 ].filter(Boolean) as string[];
 
 const showTeamResults = hasTeamResults(year, series, raceId);

--- a/src/components/RaceCard.astro
+++ b/src/components/RaceCard.astro
@@ -1,7 +1,7 @@
 ---
 // src/components/RaceCard.astro
 import type { Race, Series } from '../lib/types';
-import { formatRaceDate } from '../lib/format';
+import { formatRaceDate, formatDistance } from '../lib/format';
 import { siteUrl } from '../lib/url';
 
 interface Props {
@@ -13,6 +13,7 @@ interface Props {
 const { race, year, series } = Astro.props;
 const { id, name, date, time, location, distance, detailsUrl, image } = race;
 
+const distanceDisplay = formatDistance(distance);
 const formattedDate = date ? formatRaceDate(date, time) : '';
 const isFell = series === 'fell';
 const href = isFell
@@ -40,7 +41,7 @@ const linkClasses = `${cardClasses} hover:shadow-md transition-shadow`;
       <h2 class="card-title text-base font-bold">{name}</h2>
       {(location || distance) && (
         <p class="text-sm text-content/70">
-          {location}{location && distance && ' · '}{distance}
+          {location}{location && distance && ' · '}{distanceDisplay}
         </p>
       )}
       {detailsUrl && !isFell && (
@@ -70,7 +71,7 @@ const linkClasses = `${cardClasses} hover:shadow-md transition-shadow`;
       <h2 class="card-title text-base font-bold">{name}</h2>
       {(location || distance) && (
         <p class="text-sm text-content/70">
-          {location}{location && distance && ' · '}{distance}
+          {location}{location && distance && ' · '}{distanceDisplay}
         </p>
       )}
       {detailsUrl && !isFell && (

--- a/src/components/TeamResultsLayout.astro
+++ b/src/components/TeamResultsLayout.astro
@@ -12,7 +12,7 @@ import PageHeader from './PageHeader.astro';
 import TeamClubCard from './TeamClubCard.astro';
 import { getRace, getRaces } from '../lib/data';
 import { siteUrl } from '../lib/url';
-import { formatRaceDate, getSeriesLabel, seriesAccent } from '../lib/format';
+import { formatRaceDate, formatDistance, getSeriesLabel, seriesAccent } from '../lib/format';
 import type { Club, Series, SeriesConfig, TeamResults } from '../lib/types';
 
 export interface Props {
@@ -41,7 +41,7 @@ const raceTotal  = allRaces.length;
 const raceMeta = [
   race?.date ? formatRaceDate(race.date, race?.time) : null,
   race?.location ?? null,
-  race?.distance ?? null,
+  formatDistance(race?.distance),
 ].filter(Boolean) as string[];
 
 const clubById     = Object.fromEntries(clubs.map(c => [c.id, c]));

--- a/src/components/home/NextRaceCard.astro
+++ b/src/components/home/NextRaceCard.astro
@@ -8,7 +8,7 @@
  * guarantees both separators sit at the same vertical position within the
  * shared grid row regardless of which card has more content above the separator.
  */
-import { formatRaceDate } from '../../lib/format';
+import { formatRaceDate, formatDistance } from '../../lib/format';
 import type { Race } from '../../lib/types';
 
 interface Props {
@@ -54,6 +54,7 @@ const {
   showLocation = false,
 } = Astro.props;
 
+const distanceDisplay = formatDistance(race.distance);
 const bgClass    = accent === 'amber' ? 'bg-amber'   : 'bg-teal';
 const textAccent = accent === 'amber' ? 'text-amber' : 'text-teal';
 const nameClass  = size === 'large'
@@ -101,7 +102,7 @@ const nameClass  = size === 'large'
   <div class="flex items-end gap-[18px] pt-3 border-t border-white/25">
     {race.distance && (
       <div>
-        <div class="font-mono text-[14px] font-medium">{race.distance}</div>
+        <div class="font-mono text-[14px] font-medium">{distanceDisplay}</div>
         <div class="font-head text-[9px] font-bold tracking-[0.14em] uppercase opacity-70">Distance</div>
       </div>
     )}

--- a/src/data/2005/road-gp/races.json
+++ b/src/data/2005/road-gp/races.json
@@ -4,28 +4,28 @@
     "name": "North Fylde Inter Club",
     "shortName": "NF",
     "date": "2005-04-05",
-    "distance": "5 miles"
+    "distance": "5 mi"
   },
   {
     "id": "lytham",
     "name": "Lytham St Annes Inter Club",
     "shortName": "LSA",
     "date": "2005-05-05",
-    "distance": "5 miles"
+    "distance": "5 mi"
   },
   {
     "id": "blackpool",
     "name": "Blackpool Inter Club",
     "shortName": "BPL",
     "date": "2005-06-07",
-    "distance": "4 miles"
+    "distance": "4 mi"
   },
   {
     "id": "wesham",
     "name": "Wesham Inter Club",
     "shortName": "WES",
     "date": "2005-07-11",
-    "distance": "4.4 miles"
+    "distance": "4.4 mi"
   },
   {
     "id": "preston",

--- a/src/data/2006/road-gp/races.json
+++ b/src/data/2006/road-gp/races.json
@@ -4,41 +4,41 @@
     "name": "North Fylde Inter Club",
     "shortName": "NF",
     "date": "2006-04-05",
-    "distance": "5 miles"
+    "distance": "5 mi"
   },
   {
     "id": "preston",
     "name": "Preston Inter Club",
     "shortName": "PRE",
     "date": "2006-05-10",
-    "distance": "4.9 miles"
+    "distance": "4.9 mi"
   },
   {
     "id": "blackpool",
     "name": "Blackpool Inter Club",
     "shortName": "BPL",
     "date": "2006-06-19",
-    "distance": "4.1 miles"
+    "distance": "4.1 mi"
   },
   {
     "id": "wesham",
     "name": "Wesham Inter Club",
     "shortName": "WES",
     "date": "2006-07-17",
-    "distance": "4.45 miles"
+    "distance": "4.5 mi"
   },
   {
     "id": "chorley",
     "name": "Chorley Inter Club",
     "shortName": "CHO",
     "date": "2006-08-16",
-    "distance": "4.78 miles"
+    "distance": "4.8 mi"
   },
   {
     "id": "red-rose",
     "name": "Red Rose Inter Club",
     "shortName": "RR",
     "date": "2006-09-05",
-    "distance": "4 miles"
+    "distance": "4 mi"
   }
 ]

--- a/src/data/2007/road-gp/races.json
+++ b/src/data/2007/road-gp/races.json
@@ -4,41 +4,41 @@
     "name": "Lytham St Annes Inter Club",
     "shortName": "LSA",
     "date": "2007-04-03",
-    "distance": "5 miles"
+    "distance": "5 mi"
   },
   {
     "id": "preston",
     "name": "Preston Inter Club",
     "shortName": "PRE",
     "date": "2007-05-16",
-    "distance": "4.9 miles"
+    "distance": "4.9 mi"
   },
   {
     "id": "blackpool",
     "name": "Blackpool Inter Club",
     "shortName": "BPL",
     "date": "2007-06-13",
-    "distance": "4 miles"
+    "distance": "4 mi"
   },
   {
     "id": "wesham",
     "name": "Wesham Inter Club",
     "shortName": "WES",
     "date": "2007-07-16",
-    "distance": "4.513 miles"
+    "distance": "4.5 mi"
   },
   {
     "id": "chorley",
     "name": "Chorley Inter Club",
     "shortName": "CHO",
     "date": "2007-08-08",
-    "distance": "4.79 miles"
+    "distance": "4.8 mi"
   },
   {
     "id": "red-rose",
     "name": "Red Rose Inter Club",
     "shortName": "RR",
     "date": "2007-09-05",
-    "distance": "4 miles"
+    "distance": "4 mi"
   }
 ]

--- a/src/data/2008/road-gp/races.json
+++ b/src/data/2008/road-gp/races.json
@@ -5,7 +5,7 @@
     "shortName": "BPL",
     "date": "2008-04-02",
     "time": "19:00",
-    "distance": "4 miles"
+    "distance": "4 mi"
   },
   {
     "id": "lytham",
@@ -13,7 +13,7 @@
     "shortName": "LSA",
     "date": "2008-05-01",
     "time": "19:30",
-    "distance": "5 miles"
+    "distance": "5 mi"
   },
   {
     "id": "preston",
@@ -21,7 +21,7 @@
     "shortName": "PRE",
     "date": "2008-06-11",
     "time": "19:30",
-    "distance": "4.9 miles"
+    "distance": "4.9 mi"
   },
   {
     "id": "wesham",
@@ -29,7 +29,7 @@
     "shortName": "WES",
     "date": "2008-07-14",
     "time": "19:30",
-    "distance": "4.5 miles"
+    "distance": "4.5 mi"
   },
   {
     "id": "chorley",
@@ -37,7 +37,7 @@
     "shortName": "CHO",
     "date": "2008-08-13",
     "time": "19:30",
-    "distance": "4.78 miles"
+    "distance": "4.8 mi"
   },
   {
     "id": "red-rose",
@@ -45,6 +45,6 @@
     "shortName": "RR",
     "date": "2008-09-03",
     "time": "19:00",
-    "distance": "4 miles"
+    "distance": "4 mi"
   }
 ]

--- a/src/data/2009/road-gp/races.json
+++ b/src/data/2009/road-gp/races.json
@@ -5,7 +5,7 @@
     "shortName": "BPL",
     "date": "2009-04-08",
     "time": "19:00",
-    "distance": "4 miles"
+    "distance": "4 mi"
   },
   {
     "id": "lytham",
@@ -13,7 +13,7 @@
     "shortName": "LSA",
     "date": "2009-05-07",
     "time": "19:30",
-    "distance": "5 miles"
+    "distance": "5 mi"
   },
   {
     "id": "preston",
@@ -21,7 +21,7 @@
     "shortName": "PRE",
     "date": "2009-06-10",
     "time": "19:30",
-    "distance": "4.9 miles"
+    "distance": "4.9 mi"
   },
   {
     "id": "wesham",
@@ -29,7 +29,7 @@
     "shortName": "WES",
     "date": "2009-07-20",
     "time": "19:30",
-    "distance": "4.5 miles"
+    "distance": "4.5 mi"
   },
   {
     "id": "chorley",
@@ -37,7 +37,7 @@
     "shortName": "CHO",
     "date": "2009-08-12",
     "time": "19:30",
-    "distance": "4.78 miles"
+    "distance": "4.8 mi"
   },
   {
     "id": "red-rose",
@@ -45,6 +45,6 @@
     "shortName": "RR",
     "date": "2009-09-09",
     "time": "19:00",
-    "distance": "4 miles"
+    "distance": "4 mi"
   }
 ]

--- a/src/data/2010/road-gp/races.json
+++ b/src/data/2010/road-gp/races.json
@@ -5,7 +5,7 @@
     "shortName": "BPL",
     "date": "2010-04-07",
     "time": "19:00",
-    "distance": "4 miles"
+    "distance": "4 mi"
   },
   {
     "id": "lytham",
@@ -13,7 +13,7 @@
     "shortName": "LSA",
     "date": "2010-05-13",
     "time": "19:30",
-    "distance": "5 miles"
+    "distance": "5 mi"
   },
   {
     "id": "preston",
@@ -21,7 +21,7 @@
     "shortName": "PRE",
     "date": "2010-06-09",
     "time": "19:30",
-    "distance": "4.9 miles"
+    "distance": "4.9 mi"
   },
   {
     "id": "wesham",
@@ -29,7 +29,7 @@
     "shortName": "WES",
     "date": "2010-07-19",
     "time": "19:30",
-    "distance": "4.513 miles"
+    "distance": "4.5 mi"
   },
   {
     "id": "chorley",
@@ -37,14 +37,13 @@
     "shortName": "CHO",
     "date": "2010-08-11",
     "time": "19:30",
-    "distance": "4.78 miles"
+    "distance": "4.8 mi"
   },
   {
     "id": "red-rose",
     "name": "Red Rose Inter Club",
     "shortName": "RR",
     "date": "2010-09-01",
-    "time": "19:00",
-    "distance": "unknown"
+    "time": "19:00"
   }
 ]

--- a/src/data/2011/fell/races.json
+++ b/src/data/2011/fell/races.json
@@ -1,14 +1,14 @@
 [
   {
     "id": "pendle",
-    "name": "Pendle FR",
+    "name": "Pendle",
     "shortName": "PEN",
     "date": "2011-04-02",
     "time": "14:00"
   },
   {
     "id": "two-lads",
-    "name": "Two Lads Horwich",
+    "name": "Two Lads",
     "shortName": "TWL",
     "date": "2011-06-16",
     "time": "19:30"
@@ -22,7 +22,7 @@
   },
   {
     "id": "golf-ball",
-    "name": "Golf Ball Rossendale",
+    "name": "Golf Ball",
     "shortName": "GOL",
     "date": "2011-08-17",
     "time": "19:00"

--- a/src/data/2018/fell/races.json
+++ b/src/data/2018/fell/races.json
@@ -5,7 +5,6 @@
     "shortName": "MCL",
     "date": "2018-05-08",
     "time": "19:15",
-    "distance": "5.6 km",
     "ascent": "380 m"
   },
   {
@@ -14,7 +13,6 @@
     "shortName": "AUS",
     "date": "2018-05-28",
     "time": "13:00",
-    "distance": "13 km",
     "ascent": "365 m"
   },
   {
@@ -23,7 +21,6 @@
     "shortName": "SEH",
     "date": "2018-06-17",
     "time": "10:30",
-    "distance": "11.3 km",
     "ascent": "400 m"
   },
   {
@@ -32,7 +29,6 @@
     "shortName": "TOC",
     "date": "2018-07-05",
     "time": "19:15",
-    "distance": "9.3 km",
     "ascent": "335 m"
   }
 ]

--- a/src/data/2022/road-gp/races.json
+++ b/src/data/2022/road-gp/races.json
@@ -4,7 +4,7 @@
     "name": "Blackpool Inter Club",
     "shortName": "BPL",
     "date": "2022-04-06",
-    "distance": "4 miles",
+    "distance": "4 mi",
     "location": "Stanley Park, Blackpool"
   },
   {
@@ -12,7 +12,7 @@
     "name": "Lytham St Annes Inter Club",
     "shortName": "LSA",
     "date": "2022-05-12",
-    "distance": "5 miles",
+    "distance": "5 mi",
     "location": "St Annes Sea Front, Lytham St Annes"
   },
   {
@@ -20,7 +20,7 @@
     "name": "Preston Inter Club",
     "shortName": "PRE",
     "date": "2022-06-15",
-    "distance": "4 miles",
+    "distance": "4 mi",
     "location": "Avenham Park, Preston"
   },
   {
@@ -28,7 +28,7 @@
     "name": "Thornton Cleveleys Inter Club",
     "shortName": "TC",
     "date": "2022-06-28",
-    "distance": "5 miles",
+    "distance": "5 mi",
     "location": "Anchorsholme Prom, Thornton-Cleveleys"
   },
   {
@@ -36,7 +36,7 @@
     "name": "Wesham Inter Club",
     "shortName": "WES",
     "date": "2022-07-18",
-    "distance": "4.5 miles",
+    "distance": "4.5 mi",
     "location": "Lea Town, Preston"
   },
   {
@@ -44,7 +44,7 @@
     "name": "Chorley Inter Club",
     "shortName": "CHO",
     "date": "2022-08-10",
-    "distance": "4.7 miles",
+    "distance": "4.7 mi",
     "location": "Astley Park, Chorley"
   },
   {
@@ -52,7 +52,7 @@
     "name": "Red Rose Inter Club",
     "shortName": "RR",
     "date": "2022-09-07",
-    "distance": "4.2 miles",
+    "distance": "4.2 mi",
     "location": "Worden Park, Leyland"
   }
 ]

--- a/src/data/2023/road-gp/races.json
+++ b/src/data/2023/road-gp/races.json
@@ -4,7 +4,7 @@
     "name": "Blackpool Inter Club",
     "shortName": "BPL",
     "date": "2023-04-05",
-    "distance": "4 miles",
+    "distance": "4 mi",
     "location": "Stanley Park, Blackpool"
   },
   {
@@ -12,7 +12,7 @@
     "name": "Lytham St Annes Inter Club",
     "shortName": "LSA",
     "date": "2023-05-11",
-    "distance": "5 miles",
+    "distance": "5 mi",
     "location": "St Annes Sea Front, Lytham St Annes"
   },
   {
@@ -20,7 +20,7 @@
     "name": "Preston Inter Club",
     "shortName": "PRE",
     "date": "2023-06-14",
-    "distance": "4 miles",
+    "distance": "4 mi",
     "location": "Avenham Park, Preston"
   },
   {
@@ -28,7 +28,7 @@
     "name": "Thornton Cleveleys Inter Club",
     "shortName": "TC",
     "date": "2023-06-27",
-    "distance": "5 miles",
+    "distance": "5 mi",
     "location": "Anchorsholme Prom, Thornton-Cleveleys"
   },
   {
@@ -36,7 +36,7 @@
     "name": "Wesham Inter Club",
     "shortName": "WES",
     "date": "2023-07-17",
-    "distance": "4.5 miles",
+    "distance": "4.5 mi",
     "location": "Lea Town, Preston"
   },
   {
@@ -44,7 +44,7 @@
     "name": "Chorley Inter Club",
     "shortName": "CHO",
     "date": "2023-08-09",
-    "distance": "4.7 miles",
+    "distance": "4.7 mi",
     "location": "Astley Park, Chorley"
   },
   {
@@ -52,7 +52,7 @@
     "name": "Red Rose Inter Club",
     "shortName": "RR",
     "date": "2023-09-06",
-    "distance": "4.2 miles",
+    "distance": "4.2 mi",
     "location": "Worden Park, Leyland"
   }
 ]

--- a/src/data/2024/road-gp/races.json
+++ b/src/data/2024/road-gp/races.json
@@ -4,7 +4,7 @@
     "name": "Blackpool Inter Club",
     "shortName": "BPL",
     "date": "2024-04-06",
-    "distance": "4 miles",
+    "distance": "4 mi",
     "location": "Stanley Park, Blackpool"
   },
   {
@@ -12,7 +12,7 @@
     "name": "Lytham St Annes Inter Club",
     "shortName": "LSA",
     "date": "2024-05-12",
-    "distance": "5 miles",
+    "distance": "5 mi",
     "location": "St Annes Sea Front, Lytham St Annes"
   },
   {
@@ -20,7 +20,7 @@
     "name": "Preston Inter Club",
     "shortName": "PRE",
     "date": "2024-06-15",
-    "distance": "4 miles",
+    "distance": "4 mi",
     "location": "Moor Park, Preston"
   },
   {
@@ -28,7 +28,7 @@
     "name": "Thornton Cleveleys Inter Club",
     "shortName": "TC",
     "date": "2024-06-28",
-    "distance": "5 miles",
+    "distance": "5 mi",
     "location": "Anchorsholme Prom, Thornton-Cleveleys"
   },
   {
@@ -36,7 +36,7 @@
     "name": "Wesham Inter Club",
     "shortName": "WES",
     "date": "2024-07-18",
-    "distance": "4.5 miles",
+    "distance": "4.5 mi",
     "location": "Lea Town, Preston"
   },
   {
@@ -44,7 +44,7 @@
     "name": "Chorley Inter Club",
     "shortName": "CHO",
     "date": "2024-08-10",
-    "distance": "4.7 miles",
+    "distance": "4.7 mi",
     "location": "Astley Park, Chorley"
   },
   {
@@ -52,7 +52,7 @@
     "name": "Red Rose Inter Club",
     "shortName": "RR",
     "date": "2024-09-07",
-    "distance": "4.2 miles",
+    "distance": "4.2 mi",
     "location": "Worden Park, Leyland"
   }
 ]

--- a/src/data/2025/road-gp/races.json
+++ b/src/data/2025/road-gp/races.json
@@ -4,7 +4,7 @@
     "name": "Blackpool Inter Club",
     "shortName": "BPL",
     "date": "2025-04-02",
-    "distance": "4 miles",
+    "distance": "4 mi",
     "location": "Stanley Park, Blackpool"
   },
   {
@@ -12,7 +12,7 @@
     "name": "Lytham St Annes Inter Club",
     "shortName": "LSA",
     "date": "2025-05-08",
-    "distance": "5 miles",
+    "distance": "5 mi",
     "location": "St Annes Sea Front, Lytham St Annes"
   },
   {
@@ -20,7 +20,7 @@
     "name": "Preston Inter Club",
     "shortName": "PRE",
     "date": "2025-06-11",
-    "distance": "4 miles",
+    "distance": "4 mi",
     "location": "Moor Park, Preston"
   },
   {
@@ -28,7 +28,7 @@
     "name": "Thornton Cleveleys Inter Club",
     "shortName": "TC",
     "date": "2025-06-24",
-    "distance": "5 miles",
+    "distance": "5 mi",
     "location": "Anchorsholme Prom, Thornton-Cleveleys"
   },
   {
@@ -36,7 +36,7 @@
     "name": "Wesham Inter Club",
     "shortName": "WES",
     "date": "2025-07-21",
-    "distance": "4.5 miles",
+    "distance": "4.5 mi",
     "location": "Lea Town, Preston"
   },
   {
@@ -44,7 +44,7 @@
     "name": "Chorley Inter Club",
     "shortName": "CHO",
     "date": "2025-08-13",
-    "distance": "4.7 miles",
+    "distance": "4.7 mi",
     "location": "Astley Park, Chorley"
   },
   {
@@ -52,7 +52,7 @@
     "name": "Red Rose Inter Club",
     "shortName": "RR",
     "date": "2025-09-03",
-    "distance": "4.2 miles",
+    "distance": "4.2 mi",
     "location": "Worden Park, Leyland"
   }
 ]

--- a/src/data/2026/fell/races.json
+++ b/src/data/2026/fell/races.json
@@ -5,7 +5,7 @@
     "shortName": "PEN",
     "date": "2026-03-28",
     "time": "14:00",
-    "distance": "7.3 km / 4.5 miles",
+    "distance": "4.5 mi",
     "ascent": "457 m / 1499 ft",
     "detailsUrl": "https://www.fellrunner.org.uk/races/9d3527fe-9d2c-48af-bba7-2e5a50200e30"
   },
@@ -15,7 +15,7 @@
     "shortName": "MCL",
     "date": "2026-05-19",
     "time": "19:15",
-    "distance": "5.6 km / 3.5 miles",
+    "distance": "3.5 mi",
     "ascent": "380 m / 1247 ft",
     "detailsUrl": "https://www.fellrunner.org.uk/races/c0f75676-6fb8-4ba0-905e-ad99acacb43e"
   },
@@ -25,7 +25,7 @@
     "shortName": "PNT",
     "date": "2026-08-29",
     "time": "14:00",
-    "distance": "8 km / 5 miles",
+    "distance": "5 mi",
     "ascent": "457 m / 1499 ft",
     "detailsUrl": "https://www.fellrunner.org.uk/races/292d6faa-35cc-4454-a016-4791088f0775"
   },
@@ -35,7 +35,7 @@
     "shortName": "WAD",
     "date": "2026-09-27",
     "time": "14:00",
-    "distance": "11.3 km / 7 miles",
+    "distance": "7 mi",
     "ascent": "415 m / 1362 ft",
     "detailsUrl": "https://www.fellrunner.org.uk/races/cbddb357-18ad-4a4b-b1cc-87071a3e019d"
   }

--- a/src/data/2026/road-gp/races.json
+++ b/src/data/2026/road-gp/races.json
@@ -6,7 +6,7 @@
     "date": "2026-04-08",
     "time": "19:00",
     "location": "Stanley Park, Blackpool",
-    "distance": "6.5 km / 4 miles",
+    "distance": "4 mi",
     "startAddress": "Stanley Park, West Park Drive, Blackpool, FY3 9HU",
     "mapEmbedUrl": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2355.6136010960613!2d-3.0260347230096007!3d53.814159039617465!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487b43913b301b09%3A0xc6fd3e6919071dd7!2sStanley%20Park!5e0!3m2!1sen!2suk!4v1778956159095!5m2!1sen!2suk",
     "parking": "Blackpool Sports Centre, West Park Drive, Blackpool, FY3 9HQ",
@@ -20,7 +20,7 @@
     "date": "2026-05-05",
     "time": "19:30",
     "location": "St Annes Sea Front, Lytham St Annes",
-    "distance": "8 km / 5 miles",
+    "distance": "5 mi",
     "startAddress": "The Island, St Annes, South Promenade, Lytham St Annes, FY8 1LS",
     "mapEmbedUrl": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2359.4491640233714!2d-3.0299521852871942!3d53.74588472547697!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487b412cf176a973%3A0x38b228b6803c508e!2sSt%20Annes%20Beach%20Huts!5e0!3m2!1sen!2suk!4v1778955406432!5m2!1sen!2suk",
     "parking": "Limited parking is available at the car park behind The Island Cinema. Runners are requested to car share as much as possible and to arrive early, allowing enough time to get to the race start. If you park on the surrounding streets, please be considerate to local homes and businesses.",
@@ -28,8 +28,24 @@
     "routeDescription": "The course is mainly within the park and 4 miles in total, 2 laps.",
     "postRaceVenue": "Fylde Rugby Club, Blackpool Road, Lytham St Annes, FY8 4EL",
     "courseRecords": [
-      { "sex": "M", "name": "Jonathan Prowse", "time": "24:37", "year": 2004, "club": "Blackpool & Fylde AC", "vest": "unknown-sm.png", "runnerId": 13459 },
-      { "sex": "F", "name": "Helen Clitheroe", "time": "26:22", "year": 2007, "club": "Preston Harriers", "vest": "preston-sm.png", "runnerId": 13540 }
+      {
+        "sex": "M",
+        "name": "Jonathan Prowse",
+        "time": "24:37",
+        "year": 2004,
+        "club": "Blackpool & Fylde AC",
+        "vest": "unknown-sm.png",
+        "runnerId": 13459
+      },
+      {
+        "sex": "F",
+        "name": "Helen Clitheroe",
+        "time": "26:22",
+        "year": 2007,
+        "club": "Preston Harriers",
+        "vest": "preston-sm.png",
+        "runnerId": 13540
+      }
     ]
   },
   {
@@ -39,7 +55,7 @@
     "date": "2026-06-10",
     "time": "19:30",
     "location": "Avenham Park, Preston",
-    "distance": "7.2 km / 4.5 miles",
+    "distance": "4.5 mi",
     "startAddress": "Miller Park, South Meadow Lane, Preston, PR1 8JP",
     "mapEmbedUrl": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1179.551009094106!2d-2.705472399555148!3d53.75206649237448!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487b736f2d348e8d%3A0x58c327e45cf2fb8a!2sAvenham%20Park!5e0!3m2!1sen!2suk!4v1778956530622!5m2!1sen!2suk",
     "parking": "Limited parking will be available at the Preston Sports Club (PSC). The BAE/EE car park on South Meadow Lane is not available. Limited parking is available at the Avenham Park car park (opposite the Continental) but much of South Meadow Lane leading to the Avenham Park car park, now has double yellow lines.\n\nYou may wish to consider parking around Winckley Square and accessing the park from there.\n\nRunners are requested to car share as much as possible and to arrive early, allowing enough time to get to the race start.\n\nIf you park on the surrounding streets, please be considerate to local homes and businesses.",
@@ -53,7 +69,7 @@
     "date": "2026-06-23",
     "time": "19:30",
     "location": "Anchorsholme Prom, Thornton-Cleveleys",
-    "distance": "8 km / 5 miles",
+    "distance": "5 mi",
     "startAddress": "Queens Promenade, Norbreck, Blackpool, FY5 1PU (opposite the Norbreck Castle Hotel)",
     "mapEmbedUrl": "https://www.google.com/maps/embed?pb=!1m16!1m12!1m3!1d720.0834622008541!2d-3.050626453345617!3d53.858674812576!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!2m1!1sQueens%20Promenade%2C%20Norbreck%2C%20Blackpool%2C%20FY5%201PU!5e0!3m2!1sen!2suk!4v1778955928778!5m2!1sen!2suk",
     "parking": "There is plenty of free parking along the Queens promenade and surrounding roads.",
@@ -67,7 +83,7 @@
     "date": "2026-07-20",
     "time": "19:30",
     "location": "Lea Town, Preston",
-    "distance": "7.2 km / 4.5 miles",
+    "distance": "4.5 mi",
     "startAddress": "BNFL Salwick, Lea Lane, Lea Town, Preston, PR4 0RP",
     "mapEmbedUrl": "https://www.google.com/maps/embed?pb=!1m14!1m12!1m3!1d2357.792222928991!2d-2.7946552680826358!3d53.775386147323744!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!5e0!3m2!1sen!2suk!4v1778956981647!5m2!1sen!2suk",
     "parking": "Available at the BNFL Salwick Club car park, PR4 0RP. Parking is limited, we request that runners car share where possible. The car park will close at 7.15 so that we can gather the runners for the race brief which will take place at the entrance to the car park.",
@@ -81,7 +97,7 @@
     "date": "2026-08-12",
     "time": "19:30",
     "location": "Astley Park, Chorley",
-    "distance": "7.7 km / 4.8 miles",
+    "distance": "4.8 mi",
     "startAddress": "Astley Park, Park Road, Chorley, PR7 1RF",
     "mapEmbedUrl": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2364.3679386287677!2d-2.6417755230172766!3d53.65824145134062!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487b0c5404f64da9%3A0x746c7d6125f97aab!2sAstley%20Park!5e0!3m2!1sen!2suk!4v1778955638759!5m2!1sen!2suk",
     "parking": "Astley Hall, Hallgate Car Park, Chorley, PR7 1XA",
@@ -95,7 +111,7 @@
     "date": "2026-09-02",
     "time": "19:00",
     "location": "Worden Park, Leyland",
-    "distance": "6.5 km / 4 miles",
+    "distance": "4 mi",
     "startAddress": "Worden Park, Worden Lane, Leyland, PR25 3DH",
     "mapEmbedUrl": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3341.656288849218!2d-2.70130662796849!3d53.68426824872745!2m3!1f0!2f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487b0d5e20ec0a1d%3A0x5938c8d41dc4ae83!2sWorden%20Park!5e0!3m2!1sen!2suk!4v1778955554970!5m2!1sen!2suk"
   }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -78,6 +78,17 @@ export function positionLabel(pos: number): string {
   return `${pos}${suffix}`;
 }
 
+const MILES_TO_KM = 1.60934;
+
+/** Append a km conversion to a "X mi" distance string, e.g. "4.5 mi" -> "4.5 mi (7.2 km)". */
+export function formatDistance(distance: string | null | undefined): string | null {
+  if (!distance) return distance ?? null;
+  const match = distance.match(/^([\d.]+)\s*mi$/);
+  if (!match) return distance;
+  const km = Math.round(parseFloat(match[1]) * MILES_TO_KM * 10) / 10;
+  return `${distance} / ${km} km`;
+}
+
 export function getSeriesLabel(series: Series): string {
   return series === 'road-gp' ? 'Road GP' : 'Fell Championship';
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import Layout from '../components/Layout.astro';
 import RaceListRow from '../components/home/RaceListRow.astro';
 import { getCurrentYear, getRaces } from '../lib/data';
 import { hasResults } from '../lib/results';
+import { formatDistance } from '../lib/format';
 import { siteUrl } from '../lib/url';
 import type { Race } from '../lib/types';
 
@@ -32,7 +33,7 @@ const roadRaceData = roadRaces.map(r => ({
   date: r.date,
   time: r.time ?? null,
   location: r.location ?? null,
-  distance: r.distance ?? null,
+  distance: formatDistance(r.distance),
   hasResults: hasResults(currentYear, 'road-gp', r.id),
   resultsUrl: siteUrl(`/road-gp/${currentYear}/${r.id}/results`),
   infoUrl: siteUrl(`/road-gp/${currentYear}/${r.id}`),
@@ -44,7 +45,7 @@ const fellRaceData = fellRaces.map(r => ({
   name: r.name,
   date: r.date,
   time: r.time ?? null,
-  distance: r.distance ?? null,
+  distance: formatDistance(r.distance),
   ascent: r.ascent ?? null,
   hasResults: hasResults(currentYear, 'fell', r.id),
   resultsUrl: siteUrl(`/fell/${currentYear}/${r.id}/results`),
@@ -129,7 +130,7 @@ const nextFellId = fellRaces.find(r => !isPast(r))?.id ?? null;
               ? (rslt ? siteUrl(`/fell/${currentYear}/${race.id}/results`) : undefined)
               : (race.detailsUrl ?? siteUrl(`/fell/${currentYear}/${race.id}`));
             const isExternal = !past && !!race.detailsUrl;
-            const subtitle   = [race.distance, race.ascent].filter(Boolean).join(' · ') || undefined;
+            const subtitle   = [formatDistance(race.distance), race.ascent].filter(Boolean).join(' · ') || undefined;
             return (
               <RaceListRow
                 accent="teal"

--- a/src/pages/road-gp/[year]/[raceId].astro
+++ b/src/pages/road-gp/[year]/[raceId].astro
@@ -4,7 +4,7 @@ import Layout from '../../../components/Layout.astro';
 import PageHeader from '../../../components/PageHeader.astro';
 import DecadeGrid from '../../../components/DecadeGrid.astro';
 import { getAvailableYears, getRaces, getCurrentYear } from '../../../lib/data';
-import { formatRaceDate } from '../../../lib/format';
+import { formatRaceDate, formatDistance } from '../../../lib/format';
 import { hasResults } from '../../../lib/results';
 import { getGlobalRunners, runnerSlug } from '../../../lib/runners';
 import { siteUrl } from '../../../lib/url';
@@ -49,17 +49,18 @@ const {
 const formattedDate = formatRaceDate(date, time);
 const hasGettingHere = !!(startAddress || mapEmbedUrl || parking);
 const hasCourse = !!(routeDescription || routeImage || (courseRecords && courseRecords.length > 0));
+const distanceDisplay = formatDistance(distance);
 
 const raceMeta = [
   formattedDate || null,
   location     || null,
-  distance     || null,
+  distanceDisplay || null,
   ascent       ? `↑ ${ascent}` : null,
 ].filter(Boolean) as string[];
 
 // "At a glance" facts for the sidebar
 const glanceFacts = [
-  distance      ? { k: 'Distance', v: distance + (ascent ? ` · ↑ ${ascent}` : '') } : null,
+  distance      ? { k: 'Distance', v: distanceDisplay + (ascent ? ` · ↑ ${ascent}` : '') } : null,
   formattedDate ? { k: 'Date',     v: formattedDate } : null,
   location      ? { k: 'Location', v: location }      : null,
   { k: 'Series', v: `Road GP · Race ${raceIndex} of ${totalRaces}` },

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -4,7 +4,7 @@ import PageHeader from '../../components/PageHeader.astro';
 import TrophyIcon from '../../components/TrophyIcon.astro';
 import { getRunnerProfileStaticPaths, resolveClubName } from '../../lib/runners';
 import { siteUrl } from '../../lib/url';
-import { formatTime, positionLabel, formatRaceDateShort } from '../../lib/format';
+import { formatTime, positionLabel, formatRaceDateShort, formatDistance } from '../../lib/format';
 import type { GlobalRunner, RunnerYearBlock, RunnerClubHistory, RunnerAwardSummary } from '../../lib/types';
 
 export async function getStaticPaths() {
@@ -258,7 +258,7 @@ const totalRaces  = totalRoadGp + totalFell;
                           data-year={String(block.year)}
                           data-time={race.time ?? ''}
                           data-results-url={race.hasResults ? siteUrl(`/road-gp/${block.year}/${race.raceId}/results`) : ''}
-                          data-distance={race.distance ?? ''}
+                          data-distance={formatDistance(race.distance) ?? ''}
                           class="border-b border-line last:border-b-0"
                         >
                           <td class="py-2 pr-3 font-mono text-xs text-muted w-12 shrink-0 tabular-nums align-middle">
@@ -268,10 +268,10 @@ const totalRaces  = totalRoadGp + totalFell;
                             {race.hasResults
                               ? <a href={siteUrl(`/road-gp/${block.year}/${race.raceId}/results`)} class="link link-hover">{race.raceName}</a>
                               : <span class="text-muted">{race.raceName}</span>}
-                            {race.distance && <div class="sm:hidden font-mono text-xs text-muted mt-0.5">{race.distance}</div>}
+                            {race.distance && <div class="sm:hidden font-mono text-xs text-muted mt-0.5">{formatDistance(race.distance)}</div>}
                           </td>
-                          <td class="hidden sm:table-cell py-2 px-3 font-mono text-xs text-muted text-left align-middle w-32">
-                            {race.distance ?? ''}
+                          <td class="hidden sm:table-cell py-2 px-3 font-mono text-xs text-muted text-left align-middle w-40 whitespace-nowrap">
+                            {formatDistance(race.distance) ?? ''}
                           </td>
                           <td class:list={[
                             'py-2 text-right font-mono text-sm tabular-nums align-middle w-16',
@@ -316,10 +316,10 @@ const totalRaces  = totalRoadGp + totalFell;
                             {race.hasResults
                               ? <a href={siteUrl(`/fell/${block.year}/${race.raceId}/results`)} class="link link-hover">{race.raceName}</a>
                               : <span class="text-muted">{race.raceName}</span>}
-                            {race.distance && <div class="sm:hidden font-mono text-xs text-muted mt-0.5">{race.distance}</div>}
+                            {race.distance && <div class="sm:hidden font-mono text-xs text-muted mt-0.5">{formatDistance(race.distance)}</div>}
                           </td>
-                          <td class="hidden sm:table-cell py-2 px-3 font-mono text-xs text-muted text-left align-middle w-32">
-                            {race.distance ?? ''}
+                          <td class="hidden sm:table-cell py-2 px-3 font-mono text-xs text-muted text-left align-middle w-40 whitespace-nowrap">
+                            {formatDistance(race.distance) ?? ''}
                           </td>
                           <td class:list={[
                             'py-2 text-right font-mono text-sm tabular-nums align-middle w-16',
@@ -345,7 +345,7 @@ const totalRaces  = totalRoadGp + totalFell;
           <thead>
             <tr class="border-b-2 border-content">
               <th class="pb-1.5 text-left font-head font-bold text-xs uppercase tracking-widest text-muted w-16">Year</th>
-              <th class="pb-1.5 px-3 text-left font-head font-bold text-xs uppercase tracking-widest text-muted w-32">Distance</th>
+              <th class="pb-1.5 px-3 text-left font-head font-bold text-xs uppercase tracking-widest text-muted w-40">Distance</th>
               <th class="pb-1.5 text-right font-head font-bold text-xs uppercase tracking-widest text-muted w-16">Time</th>
             </tr>
           </thead>


### PR DESCRIPTION
## Summary
- Fixed 2011 fell race names that carried old descriptors dropped in later years: "Pendle FR" → "Pendle", "Golf Ball Rossendale" → "Golf Ball", "Two Lads Horwich" → "Two Lads"
- Removed the placeholder `"unknown"` distance on 2010 Red Rose; rounded Wesham/Chorley distances to 1 decimal place where they had extra precision
- Standardized every race's `distance` field to a single `"X mi"` format (was a mix of `"X miles"` and `"Y km / X miles"`); removed `distance` from 2018 fell races (no reliable source value)
- Added a shared `formatDistance()` helper in `src/lib/format.ts` that appends a km conversion (e.g. `"4.5 mi / 7.2 km"`) everywhere a distance is shown — home page hero cards, race list rows, race-info sidebar, results page header, and runner profile tables
- Widened the runner profile page's distance column so the longer "mi / km" string no longer wraps

## Test plan
- [x] `npm run build` completes with no errors across all 3502 pages
- [x] Verified in browser: home page hero cards and race list rows, road-gp race-info page, results page header, and runner profile page all show the new `"X mi / Y km"` format correctly and without wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)