### PR TITLE
fix(vests): show unknown vest fallback consistently everywhere

### DIFF
--- a/src/components/AwardsHistoryIndividuals.astro
+++ b/src/components/AwardsHistoryIndividuals.astro
@@ -331,13 +331,11 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                                   <td class="py-2 px-3 align-middle">
                                     {entry ? (
                                       <div class="flex items-center gap-2 min-w-0">
-                                        {entry.clubVest && (
-                                          <img
-                                            src={siteUrl(`/images/vests/${entry.clubVest.replace('.png', '-sm.png')}`)}
-                                            alt=""
-                                            class="h-8 w-auto shrink-0 object-contain"
-                                          />
-                                        )}
+                                        <img
+                                          src={siteUrl(`/images/vests/${(entry.clubVest ?? 'unknown.png').replace('.png', '-sm.png')}`)}
+                                          alt=""
+                                          class="h-8 w-auto shrink-0 object-contain"
+                                        />
                                         <div class="min-w-0 overflow-hidden">
                                           <div class="text-[13px] font-semibold leading-tight truncate">
                                             {entry.runnerUrl ? (
@@ -413,9 +411,7 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                                 <td class="py-3 pl-4 pr-2 font-mono text-xs font-medium text-muted align-middle">{wi + 1}</td>
                                 <td class="py-3 px-2 align-middle">
                                   <div class="flex items-center gap-2 min-w-0">
-                                    {w.clubVest && (
-                                      <img src={siteUrl(`/images/vests/${w.clubVest.replace('.png', '-sm.png')}`)} alt="" class="h-8 w-auto shrink-0 object-contain" />
-                                    )}
+                                    <img src={siteUrl(`/images/vests/${(w.clubVest ?? 'unknown.png').replace('.png', '-sm.png')}`)} alt="" class="h-8 w-auto shrink-0 object-contain" />
                                     <div class="min-w-0">
                                       <div class="text-[13px] font-semibold leading-tight truncate">
                                         {w.runnerUrl ? <a href={w.runnerUrl} class="link link-hover">{w.name}</a> : w.name}
@@ -485,13 +481,11 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                                   class="inline-flex items-center justify-center w-6 h-6 rounded-full font-mono text-[10px] font-bold shrink-0"
                                   style={`background:${MEDAL_BG[pos]};color:${MEDAL_FG[pos]};box-shadow:inset 0 -1px 0 rgba(0,0,0,0.15)`}
                                 >{pos}</span>
-                                {entry?.clubVest && (
-                                  <img
-                                    src={siteUrl(`/images/vests/${entry.clubVest.replace('.png', '-sm.png')}`)}
-                                    alt=""
-                                    class="h-9 w-[26px] shrink-0 object-contain"
-                                  />
-                                )}
+                                <img
+                                  src={siteUrl(`/images/vests/${(entry.clubVest ?? 'unknown.png').replace('.png', '-sm.png')}`)}
+                                  alt=""
+                                  class="h-9 w-[26px] shrink-0 object-contain"
+                                />
                                 <div class="flex-1 min-w-0">
                                   <div class="font-head text-[15px] font-bold tracking-tight leading-tight truncate">
                                     {entry.runnerUrl ? (
@@ -528,9 +522,7 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                             <!-- Accordion header / toggle -->
                             <button class="ih-hof-toggle w-full flex items-center gap-3 py-3 pl-3 pr-3 text-left cursor-pointer bg-transparent border-0">
                               <span class="font-mono text-sm font-medium text-muted w-6 shrink-0 text-center tabular-nums">{wi + 1}</span>
-                              {w.clubVest && (
-                                <img src={siteUrl(`/images/vests/${w.clubVest.replace('.png', '-sm.png')}`)} alt="" class="h-8 w-[22px] shrink-0 object-contain" />
-                              )}
+                              <img src={siteUrl(`/images/vests/${(w.clubVest ?? 'unknown.png').replace('.png', '-sm.png')}`)} alt="" class="h-8 w-[22px] shrink-0 object-contain" />
                               <div class="flex-1 min-w-0">
                                 <div class="font-head text-sm font-bold tracking-tight truncate">
                                   {w.runnerUrl ? <a href={w.runnerUrl} class="link link-hover" onclick="event.stopPropagation()">{w.name}</a> : w.name}
@@ -649,9 +641,7 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                       <td class="hidden xs:table-cell py-3 pl-4 pr-1 font-mono text-xs font-medium text-muted align-middle">{i + 1}</td>
                       <td class="py-3 pl-4 xs:pl-2 pr-2 align-middle max-w-0 overflow-hidden">
                         <div class="flex items-center gap-2 min-w-0">
-                          {w.clubVest && (
-                            <img src={siteUrl(`/images/vests/${w.clubVest.replace('.png', '-sm.png')}`)} alt="" class="h-7 w-auto shrink-0 object-contain" />
-                          )}
+                          <img src={siteUrl(`/images/vests/${(w.clubVest ?? 'unknown.png').replace('.png', '-sm.png')}`)} alt="" class="h-7 w-auto shrink-0 object-contain" />
                           <div class="min-w-0">
                             <div class="text-[13px] font-semibold leading-tight truncate">
                               {w.runnerUrl ? <a href={w.runnerUrl} class="link link-hover">{w.name}</a> : w.name}
@@ -715,9 +705,7 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                     <div class="bg-surface border border-line rounded-xl mb-2 overflow-hidden relative ih-hof-accordion">
                       <button class="ih-hof-toggle w-full flex items-center gap-3 py-3 pl-3 pr-3 text-left cursor-pointer bg-transparent border-0">
                         <span class="font-mono text-sm font-medium text-muted w-6 shrink-0 text-center tabular-nums">{wi + 1}</span>
-                        {w.clubVest && (
-                          <img src={siteUrl(`/images/vests/${w.clubVest.replace('.png', '-sm.png')}`)} alt="" class="h-8 w-[22px] shrink-0 object-contain" />
-                        )}
+                        <img src={siteUrl(`/images/vests/${(w.clubVest ?? 'unknown.png').replace('.png', '-sm.png')}`)} alt="" class="h-8 w-[22px] shrink-0 object-contain" />
                         <div class="flex-1 min-w-0">
                           <div class="font-head text-sm font-bold tracking-tight truncate">
                             {w.runnerUrl ? <a href={w.runnerUrl} class="link link-hover" onclick="event.stopPropagation()">{w.name}</a> : w.name}
@@ -826,9 +814,7 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                       <td class="hidden xs:table-cell py-3 pl-4 pr-1 font-mono text-xs font-medium text-muted align-middle">{i + 1}</td>
                       <td class="py-3 pl-4 xs:pl-2 pr-2 align-middle max-w-0 overflow-hidden">
                         <div class="flex items-center gap-2 min-w-0">
-                          {w.clubVest && (
-                            <img src={siteUrl(`/images/vests/${w.clubVest.replace('.png', '-sm.png')}`)} alt="" class="h-7 w-auto shrink-0 object-contain" />
-                          )}
+                          <img src={siteUrl(`/images/vests/${(w.clubVest ?? 'unknown.png').replace('.png', '-sm.png')}`)} alt="" class="h-7 w-auto shrink-0 object-contain" />
                           <div class="min-w-0">
                             <div class="text-[13px] font-semibold leading-tight truncate">
                               {w.runnerUrl ? <a href={w.runnerUrl} class="link link-hover">{w.name}</a> : w.name}
@@ -892,9 +878,7 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                     <div class="bg-surface border border-line rounded-xl mb-2 overflow-hidden relative ih-hof-accordion">
                       <button class="ih-hof-toggle w-full flex items-center gap-3 py-3 pl-3 pr-3 text-left cursor-pointer bg-transparent border-0">
                         <span class="font-mono text-sm font-medium text-muted w-6 shrink-0 text-center tabular-nums">{wi + 1}</span>
-                        {w.clubVest && (
-                          <img src={siteUrl(`/images/vests/${w.clubVest.replace('.png', '-sm.png')}`)} alt="" class="h-8 w-[22px] shrink-0 object-contain" />
-                        )}
+                        <img src={siteUrl(`/images/vests/${(w.clubVest ?? 'unknown.png').replace('.png', '-sm.png')}`)} alt="" class="h-8 w-[22px] shrink-0 object-contain" />
                         <div class="flex-1 min-w-0">
                           <div class="font-head text-sm font-bold tracking-tight truncate">
                             {w.runnerUrl ? <a href={w.runnerUrl} class="link link-hover" onclick="event.stopPropagation()">{w.name}</a> : w.name}

--- a/src/components/IndividualStandingsLayout.astro
+++ b/src/components/IndividualStandingsLayout.astro
@@ -468,9 +468,7 @@ const raceColWidth = standings.races.length >= 7 ? '3rem'
                           </td>
                           <td class="py-2.5 px-2 align-middle max-w-0 overflow-hidden">
                             <div class="flex gap-2 min-w-0">
-                              {clubById[runner.club]?.vest && (
-                                <img src={siteUrl(`/images/vests/${clubById[runner.club].vest}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
-                              )}
+                              <img src={siteUrl(`/images/vests/${clubById[runner.club]?.vest ?? 'unknown.png'}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
                               <div class="min-w-0">
                                 <div class="font-semibold leading-tight truncate">
                                   {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]
@@ -563,9 +561,7 @@ const raceColWidth = standings.races.length >= 7 ? '3rem'
                         </td>
                         <td class="py-2.5 pl-2 pr-4 align-middle max-w-0 overflow-hidden">
                           <div class="flex gap-2 min-w-0">
-                            {clubById[runner.club]?.vest && (
-                              <img src={siteUrl(`/images/vests/${clubById[runner.club].vest}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
-                            )}
+                            <img src={siteUrl(`/images/vests/${clubById[runner.club]?.vest ?? 'unknown.png'}`)} alt="" class="h-9 w-auto shrink-0 object-contain" />
                             <div class="min-w-0">
                               <div class="font-semibold leading-tight truncate">
                                 {runner.seriesRunnerId != null && runnerUrlMap[runner.seriesRunnerId]

--- a/src/lib/awardsHistory.ts
+++ b/src/lib/awardsHistory.ts
@@ -151,7 +151,10 @@ export function buildTeamHistory(
   return { allCategories, fullYearList };
 }
 
-export function buildIndividualHistoryData(series: Series): CategoryHistoryData[] {
+export function buildIndividualHistoryData(
+  series: Series,
+  clubMeta: Record<string, ClubInfo>
+): CategoryHistoryData[] {
   const allYearlyAwards = getAllAwardsByYear(series);
   const noteByYear = new Map(
     getAllSeriesConfigs(series)
@@ -166,13 +169,19 @@ export function buildIndividualHistoryData(series: Series): CategoryHistoryData[
         id: ia.id,
         name: resolveIndividualCategoryName(ia.id, ia.sex, ia.ageCategory, ia.name),
         sex: ia.sex ?? null,
-        awards: ia.awards.map(a => ({
-          position: a.position,
-          name: a.name,
-          clubName: yearly.clubs.find(c => c.id === a.club)?.name ?? a.club ?? '',
-          clubVest: yearly.clubs.find(c => c.id === a.club)?.vest,
-          runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
-        })),
+        awards: ia.awards.map(a => {
+          // Prefer that year's club roster (captures the vest in use at the time), falling
+          // back to clubMeta for clubs no longer in a current clubs.json (e.g. defunct clubs).
+          const yearClub = yearly.clubs.find(c => c.id === a.club);
+          const meta = clubMeta[a.club];
+          return {
+            position: a.position,
+            name: a.name,
+            clubName: yearClub?.name ?? meta?.name ?? a.club ?? '',
+            clubVest: yearClub?.vest ?? meta?.vest ?? 'unknown.png',
+            runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
+          };
+        }),
       })),
     };
   });

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -410,7 +410,7 @@ export interface YearlyResolvedIndividual {
       position: number;
       name: string;
       clubName: string;
-      clubVest?: string;
+      clubVest: string;
       runnerUrl?: string;
     }>;
   }>;
@@ -419,7 +419,7 @@ export interface YearlyResolvedIndividual {
 export interface CategoryHistoryEntry {
   name: string;
   clubName: string;
-  clubVest?: string;
+  clubVest: string;
   runnerUrl?: string;
 }
 

--- a/src/lib/runners.ts
+++ b/src/lib/runners.ts
@@ -156,12 +156,29 @@ export function resolveClubName(clubId: string): string {
   return clubId;
 }
 
-function resolveClubVest(clubId: string): string | undefined {
-  for (const clubs of Object.values(allClubFiles)) {
+// Resolves the vest as of `year` — clubs can change vest design over time, so this
+// finds the most recent clubs.json at or before `year` that has a vest for this club,
+// falling back to any year's vest if none exists at or before `year`.
+function resolveClubVest(clubId: string, year: number): string {
+  let bestYear = -Infinity;
+  let bestVest: string | undefined;
+  let fallbackVest: string | undefined;
+
+  for (const [path, clubs] of Object.entries(allClubFiles)) {
+    const match = path.match(/\/(\d{4})\/clubs\.json$/);
+    if (!match) continue;
+    const fileYear = Number(match[1]);
     const club = clubs.default.find(c => c.id === clubId);
-    if (club?.vest) return club.vest;
+    if (!club?.vest) continue;
+
+    fallbackVest ??= club.vest;
+    if (fileYear <= year && fileYear > bestYear) {
+      bestYear = fileYear;
+      bestVest = club.vest;
+    }
   }
-  return undefined;
+
+  return bestVest ?? fallbackVest ?? 'unknown.png';
 }
 
 function buildClubHistory(entries: Array<{ year: number; club: string }>): RunnerClubHistory[] {
@@ -189,7 +206,7 @@ function buildClubHistory(entries: Array<{ year: number; club: string }>): Runne
     clubId,
     clubName: resolveClubName(clubId),
     yearRanges: formatYearRanges(years),
-    vest: resolveClubVest(clubId),
+    vest: resolveClubVest(clubId, Math.max(...years)),
   }));
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -105,7 +105,7 @@ export interface RunnerClubHistory {
   clubId: string;
   clubName: string;
   yearRanges: string;   // pre-formatted, e.g. "2019–2021, 2025"
-  vest?: string;        // vest filename e.g. "blackpool.png" from clubs.json
+  vest: string;         // vest filename e.g. "blackpool.png" from clubs.json; "unknown.png" when club has no vest configured
 }
 
 export interface RunnerAwardSummaryEntry {

--- a/src/pages/[series]/history/[type].astro
+++ b/src/pages/[series]/history/[type].astro
@@ -27,7 +27,7 @@ const { allCategories, fullYearList } = type === 'teams'
   ? buildTeamHistory(series, CANONICAL_IDS[series], ID_ALIASES, clubMeta)
   : { allCategories: [], fullYearList: [] };
 
-const categoryData = type === 'individuals' ? buildIndividualHistoryData(series) : [];
+const categoryData = type === 'individuals' ? buildIndividualHistoryData(series, clubMeta) : [];
 
 const historyBase = import.meta.env.BASE_URL.replace(/\/$/, '');
 const historyYears = type === 'individuals'

--- a/src/pages/runners/[slug].astro
+++ b/src/pages/runners/[slug].astro
@@ -56,13 +56,11 @@ const totalRaces  = totalRoadGp + totalFell;
         <div class="space-y-3">
           {clubHistory.map(ch => (
             <div class="flex items-center gap-3 text-sm">
-              {ch.vest && (
-                <img
-                  src={siteUrl(`/images/vests/${ch.vest}`)}
-                  alt=""
-                  class="h-10 w-auto shrink-0 object-contain"
-                />
-              )}
+              <img
+                src={siteUrl(`/images/vests/${ch.vest}`)}
+                alt=""
+                class="h-10 w-auto shrink-0 object-contain"
+              />
               <div class="min-w-0">
                 <div class="font-semibold">{ch.clubName}</div>
                 <div class="font-mono text-xs text-muted">{ch.yearRanges}</div>
@@ -153,13 +151,11 @@ const totalRaces  = totalRoadGp + totalFell;
           <div class="flex flex-col xs:flex-row xs:flex-wrap gap-x-6 gap-y-3">
             {clubHistory.map(ch => (
               <div class="flex items-center gap-3 text-sm">
-                {ch.vest && (
-                  <img
-                    src={siteUrl(`/images/vests/${ch.vest}`)}
-                    alt=""
-                    class="h-10 w-auto shrink-0 object-contain"
-                  />
-                )}
+                <img
+                  src={siteUrl(`/images/vests/${ch.vest}`)}
+                  alt=""
+                  class="h-10 w-auto shrink-0 object-contain"
+                />
                 <div class="min-w-0">
                   <div class="font-semibold">{ch.clubName}</div>
                   <div class="font-mono text-xs text-muted">{ch.yearRanges}</div>


### PR DESCRIPTION
## Summary
- Runner detail page ("Competed for") could omit the vest image entirely when a club had no vest configured, and could show a stale/outdated vest design for a club that changed kit after the runner left (e.g. Thornton Cleveleys' pre-2022 vest shown for a 2025 club-history entry).
- Individual standings desktop table and the Individual Winners / Hall of Fame history page had several spots where the vest `<img>` was conditionally rendered and simply dropped when no vest was found, instead of falling back to `unknown.png` like the rest of the site.

## Changes
- `runners.ts`: `resolveClubVest` now resolves the vest as it was configured for the *last year* the runner competed for that club (clubs can redesign their vest over time), with a final fallback to `unknown.png`.
- `awardsHistory.ts`: `buildIndividualHistoryData` now also checks `clubMeta` (which includes historical/defunct clubs like "North Fylde AC") when the award year's own `clubs.json` has no matching club, so award entries for old/renamed clubs still resolve a vest, falling back to `unknown.png`.
- `AwardsHistoryIndividuals.astro` / `IndividualStandingsLayout.astro`: replaced `{vest && <img>}` conditional rendering with unconditional rendering using the guaranteed fallback, matching the pattern already used elsewhere (`HistoryRaceList.astro`, `TeamStandingsLayout.astro`, etc.).
- `types.ts` / `results.ts`: tightened `vest`/`clubVest` fields to non-optional `string` where they're now always populated by the builder functions.

## Test plan
- [x] `npm run build` — 3502 pages built successfully, no type errors
- [x] `npm test` — all 536 tests pass
- [x] Verified in browser (network requests) that a runner's club-history vest falls back to `unknown.png` when unconfigured
- [x] Verified in built HTML that Thornton Cleveleys club-history spans use the correct vest per era (pre-2022 vs current) based on the last year of each span
- [x] Verified in built HTML that every entry on the Individual Winners history page now renders a vest image (previously some entries had none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)