### PR TITLE
fix(awards): correct category name display, ordering, and totals

### DIFF
--- a/src/components/AwardsHistoryIndividuals.astro
+++ b/src/components/AwardsHistoryIndividuals.astro
@@ -86,18 +86,27 @@ for (const cat of categories) {
 
 // ── Cross-category "The Greats" ─────────────────────────────────────────
 interface GreatsEntry extends HofEntry {
-  catCounts: Record<string, { gold: number; silver: number; bronze: number; sex?: string }>;
+  catCounts: Record<string, { gold: number; silver: number; bronze: number; sex?: string | null; label: string }>;
   total: number;
 }
 
-function buildGreats(cats: CategoryHistoryData[]): GreatsEntry[] {
+function buildGreats(cats: CategoryHistoryData[], targetSex: 'M' | 'F'): GreatsEntry[] {
   const tally: Record<string, GreatsEntry> = {};
   for (const cat of cats) {
     const lbl = chipLabel(cat);
+    // chipLabel collapses both a plain (no-age) sex-specific category and the
+    // true sex-agnostic "Overall" category down to the same "Overall" text.
+    // Key them separately so a runner's cross-sex Overall wins never get folded
+    // into their Male/Female tally (their display label is still just "Overall").
+    const catKey = lbl === 'Overall' ? `Overall::${cat.sex ?? 'null'}` : lbl;
     for (const row of cat.rows) {
       for (const pos of [1, 2, 3] as const) {
         const entry = row.positions[pos];
         if (!entry || !entry.runnerUrl) continue; // skip entries with no runner ID
+        // Sex-agnostic (overall) categories carry no cat.sex — fall back to the
+        // runner's actual sex so their wins still count toward the right leaderboard.
+        const resolvedSex = cat.sex ?? entry.sex;
+        if (resolvedSex !== targetSex) continue;
         const key = entry.runnerUrl;
         if (!tally[key]) {
           tally[key] = { name: entry.name, clubName: entry.clubName, clubVest: entry.clubVest, runnerUrl: entry.runnerUrl, gold: 0, silver: 0, bronze: 0, catCounts: {}, total: 0 };
@@ -105,10 +114,10 @@ function buildGreats(cats: CategoryHistoryData[]): GreatsEntry[] {
           if (entry.name.length > tally[key].name.length) tally[key].name = entry.name;
           if (entry.clubVest && !tally[key].clubVest) tally[key].clubVest = entry.clubVest;
         }
-        if (!tally[key].catCounts[lbl]) tally[key].catCounts[lbl] = { gold: 0, silver: 0, bronze: 0, sex: cat.sex };
-        if (pos === 1) { tally[key].gold++; tally[key].catCounts[lbl].gold++; }
-        else if (pos === 2) { tally[key].silver++; tally[key].catCounts[lbl].silver++; }
-        else { tally[key].bronze++; tally[key].catCounts[lbl].bronze++; }
+        if (!tally[key].catCounts[catKey]) tally[key].catCounts[catKey] = { gold: 0, silver: 0, bronze: 0, sex: cat.sex, label: lbl };
+        if (pos === 1) { tally[key].gold++; tally[key].catCounts[catKey].gold++; }
+        else if (pos === 2) { tally[key].silver++; tally[key].catCounts[catKey].silver++; }
+        else { tally[key].bronze++; tally[key].catCounts[catKey].bronze++; }
       }
     }
   }
@@ -129,8 +138,26 @@ function greatsLabel(lbl: string, sex?: string): string {
   return lbl;
 }
 
-const greatsM = buildGreats(mCats);
-const greatsF = buildGreats(fCats);
+// Display order for a runner's per-category breakdown: overall (no sex, no age)
+// first, then sex-only (Male/Female), then age categories, youngest to oldest.
+const CAT_LABEL_AGE_ORDER: Record<string, number> = {
+  Junior: 1, Senior: 2,
+  V35: 3, V40: 4, V45: 5, V50: 6, V55: 7,
+  V60: 8, V65: 9, V70: 10, V75: 11, V80: 12, V85: 13, V90: 14, V95: 15, V100: 16,
+};
+function sortedCatCounts(catCounts: GreatsEntry['catCounts']) {
+  return Object.values(catCounts).sort((a, b) => {
+    const tierA = a.label !== 'Overall' ? 2 : a.sex == null ? 0 : 1;
+    const tierB = b.label !== 'Overall' ? 2 : b.sex == null ? 0 : 1;
+    if (tierA !== tierB) return tierA - tierB;
+    return (CAT_LABEL_AGE_ORDER[a.label] ?? 99) - (CAT_LABEL_AGE_ORDER[b.label] ?? 99);
+  });
+}
+
+// Include sex-agnostic (overall) categories in both leaderboards — buildGreats
+// attributes each entry using the runner's actual sex, not the category's.
+const greatsM = buildGreats(sortedCats, 'M');
+const greatsF = buildGreats(sortedCats, 'F');
 
 
 
@@ -633,9 +660,9 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                 </thead>
                 <tbody>
                   {greatsM.map((w, i) => {
-                    const goldCats = Object.entries(w.catCounts).filter(([,c]) => c.gold > 0).map(([lbl,c]) => `${c.gold} × ${greatsLabel(lbl, c.sex)}`);
-                    const silverCats = Object.entries(w.catCounts).filter(([,c]) => c.silver > 0).map(([lbl,c]) => `${c.silver} × ${greatsLabel(lbl, c.sex)}`);
-                    const bronzeCats = Object.entries(w.catCounts).filter(([,c]) => c.bronze > 0).map(([lbl,c]) => `${c.bronze} × ${greatsLabel(lbl, c.sex)}`);
+                    const goldCats = sortedCatCounts(w.catCounts).filter(c => c.gold > 0).map(c => `${c.gold} × ${greatsLabel(c.label, c.sex)}`);
+                    const silverCats = sortedCatCounts(w.catCounts).filter(c => c.silver > 0).map(c => `${c.silver} × ${greatsLabel(c.label, c.sex)}`);
+                    const bronzeCats = sortedCatCounts(w.catCounts).filter(c => c.bronze > 0).map(c => `${c.bronze} × ${greatsLabel(c.label, c.sex)}`);
                     return (
                     <tr class="border-b border-line last:border-0">
                       <td class="hidden xs:table-cell py-3 pl-4 pr-1 font-mono text-xs font-medium text-muted align-middle">{i + 1}</td>
@@ -698,9 +725,9 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
               <div class="flex flex-col">
                 {greatsM.map((w, wi) => {
                   const total = w.gold + w.silver + w.bronze;
-                  const goldCats = Object.entries(w.catCounts).filter(([,c]) => c.gold > 0).map(([lbl,c]) => `${c.gold} × ${greatsLabel(lbl, c.sex)}`);
-                  const silverCats = Object.entries(w.catCounts).filter(([,c]) => c.silver > 0).map(([lbl,c]) => `${c.silver} × ${greatsLabel(lbl, c.sex)}`);
-                  const bronzeCats = Object.entries(w.catCounts).filter(([,c]) => c.bronze > 0).map(([lbl,c]) => `${c.bronze} × ${greatsLabel(lbl, c.sex)}`);
+                  const goldCats = sortedCatCounts(w.catCounts).filter(c => c.gold > 0).map(c => `${c.gold} × ${greatsLabel(c.label, c.sex)}`);
+                  const silverCats = sortedCatCounts(w.catCounts).filter(c => c.silver > 0).map(c => `${c.silver} × ${greatsLabel(c.label, c.sex)}`);
+                  const bronzeCats = sortedCatCounts(w.catCounts).filter(c => c.bronze > 0).map(c => `${c.bronze} × ${greatsLabel(c.label, c.sex)}`);
                   return (
                     <div class="bg-surface border border-line rounded-xl mb-2 overflow-hidden relative ih-hof-accordion">
                       <button class="ih-hof-toggle w-full flex items-center gap-3 py-3 pl-3 pr-3 text-left cursor-pointer bg-transparent border-0">
@@ -806,9 +833,9 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
                 </thead>
                 <tbody>
                   {greatsF.map((w, i) => {
-                    const goldCats = Object.entries(w.catCounts).filter(([,c]) => c.gold > 0).map(([lbl,c]) => `${c.gold} × ${greatsLabel(lbl, c.sex)}`);
-                    const silverCats = Object.entries(w.catCounts).filter(([,c]) => c.silver > 0).map(([lbl,c]) => `${c.silver} × ${greatsLabel(lbl, c.sex)}`);
-                    const bronzeCats = Object.entries(w.catCounts).filter(([,c]) => c.bronze > 0).map(([lbl,c]) => `${c.bronze} × ${greatsLabel(lbl, c.sex)}`);
+                    const goldCats = sortedCatCounts(w.catCounts).filter(c => c.gold > 0).map(c => `${c.gold} × ${greatsLabel(c.label, c.sex)}`);
+                    const silverCats = sortedCatCounts(w.catCounts).filter(c => c.silver > 0).map(c => `${c.silver} × ${greatsLabel(c.label, c.sex)}`);
+                    const bronzeCats = sortedCatCounts(w.catCounts).filter(c => c.bronze > 0).map(c => `${c.bronze} × ${greatsLabel(c.label, c.sex)}`);
                     return (
                     <tr class="border-b border-line last:border-0">
                       <td class="hidden xs:table-cell py-3 pl-4 pr-1 font-mono text-xs font-medium text-muted align-middle">{i + 1}</td>
@@ -871,9 +898,9 @@ const MEDAL_FG = ['', '#3d2300', '#1f2733', '#ffffff'];
               <div class="flex flex-col">
                 {greatsF.map((w, wi) => {
                   const total = w.gold + w.silver + w.bronze;
-                  const goldCats = Object.entries(w.catCounts).filter(([,c]) => c.gold > 0).map(([lbl,c]) => `${c.gold} × ${greatsLabel(lbl, c.sex)}`);
-                  const silverCats = Object.entries(w.catCounts).filter(([,c]) => c.silver > 0).map(([lbl,c]) => `${c.silver} × ${greatsLabel(lbl, c.sex)}`);
-                  const bronzeCats = Object.entries(w.catCounts).filter(([,c]) => c.bronze > 0).map(([lbl,c]) => `${c.bronze} × ${greatsLabel(lbl, c.sex)}`);
+                  const goldCats = sortedCatCounts(w.catCounts).filter(c => c.gold > 0).map(c => `${c.gold} × ${greatsLabel(c.label, c.sex)}`);
+                  const silverCats = sortedCatCounts(w.catCounts).filter(c => c.silver > 0).map(c => `${c.silver} × ${greatsLabel(c.label, c.sex)}`);
+                  const bronzeCats = sortedCatCounts(w.catCounts).filter(c => c.bronze > 0).map(c => `${c.bronze} × ${greatsLabel(c.label, c.sex)}`);
                   return (
                     <div class="bg-surface border border-line rounded-xl mb-2 overflow-hidden relative ih-hof-accordion">
                       <button class="ih-hof-toggle w-full flex items-center gap-3 py-3 pl-3 pr-3 text-left cursor-pointer bg-transparent border-0">

--- a/src/lib/awardsHistory.ts
+++ b/src/lib/awardsHistory.ts
@@ -5,7 +5,7 @@ import {
   pivotIndividualAwardsByCategory,
   resolveIndividualCategoryName,
 } from './results';
-import { buildRunnerUrlMap } from './runners';
+import { buildRunnerUrlMap, buildRunnerSexMap } from './runners';
 import type { Series, TeamCategory } from './types';
 import type { CategoryHistoryData } from './results';
 
@@ -163,6 +163,7 @@ export function buildIndividualHistoryData(
   );
   const yearlyResolved = allYearlyAwards.map(yearly => {
     const runnerUrlMap = buildRunnerUrlMap(yearly.year, series);
+    const runnerSexMap = buildRunnerSexMap(yearly.year, series);
     return {
       year: yearly.year,
       categories: yearly.awards.individualAwards.map(ia => ({
@@ -180,6 +181,9 @@ export function buildIndividualHistoryData(
             clubName: yearClub?.name ?? meta?.name ?? a.club ?? '',
             clubVest: yearClub?.vest ?? meta?.vest ?? 'unknown.png',
             runnerUrl: a.seriesRunnerId != null ? runnerUrlMap[a.seriesRunnerId] : undefined,
+            // Sex-agnostic (overall) categories need the runner's actual sex to be
+            // attributed to the correct Men's/Women's cross-category leaderboard.
+            sex: a.seriesRunnerId != null ? runnerSexMap[a.seriesRunnerId] : undefined,
           };
         }),
       })),

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -42,14 +42,12 @@ export function resolveIndividualCategoryName(
   name?: string,
 ): string {
   if (name) return name;
-  if (!sex) return id;
+  const ageLabel = ageCategory
+    ? (ageCategory === 'SEN' ? 'Senior' : ageCategory === 'JUN' ? 'Junior' : ageCategory)
+    : undefined;
+  if (!sex) return ageLabel ?? (id.charAt(0).toUpperCase() + id.slice(1));
   const sexLabel = sex === 'M' ? 'Male' : 'Female';
-  if (!ageCategory) return sexLabel;
-  const ageLabel =
-    ageCategory === 'SEN' ? 'Senior' :
-    ageCategory === 'JUN' ? 'Junior' :
-    ageCategory;
-  return `${ageLabel} ${sexLabel}`;
+  return ageLabel ? `${ageLabel} ${sexLabel}` : sexLabel;
 }
 
 const csvFiles = import.meta.glob<string>('../data/*/road-gp/results/*.csv', {
@@ -412,6 +410,7 @@ export interface YearlyResolvedIndividual {
       clubName: string;
       clubVest: string;
       runnerUrl?: string;
+      sex?: string;
     }>;
   }>;
 }
@@ -421,6 +420,7 @@ export interface CategoryHistoryEntry {
   clubName: string;
   clubVest: string;
   runnerUrl?: string;
+  sex?: string;
 }
 
 export interface CategoryHistoryRow {
@@ -501,7 +501,7 @@ export function pivotIndividualAwardsByCategory(
         const cat = yearly.categories.find(c => c.id === id)!;
         const findPos = (pos: number) => cat.awards.find(a => a.position === pos);
         const mapEntry = (a: ReturnType<typeof findPos>): CategoryHistoryEntry | null =>
-          a ? { name: a.name, clubName: a.clubName, clubVest: a.clubVest, runnerUrl: a.runnerUrl } : null;
+          a ? { name: a.name, clubName: a.clubName, clubVest: a.clubVest, runnerUrl: a.runnerUrl, sex: a.sex } : null;
         return {
           year: yearly.year,
           positions: {

--- a/src/lib/runners.ts
+++ b/src/lib/runners.ts
@@ -87,6 +87,18 @@ export function buildRunnerUrlMap(year: number, series: Series): Record<number, 
   return map;
 }
 
+/** Maps series-local runner ID → sex ('M'/'F'), for attributing sex-agnostic (overall) awards. */
+export function buildRunnerSexMap(year: number, series: Series): Record<number, string> {
+  const seriesRunners = getSeriesRunners(year, series);
+  const globalById = Object.fromEntries(getGlobalRunners().map(r => [r.id, r]));
+  const map: Record<number, string> = {};
+  for (const sr of seriesRunners) {
+    const global = globalById[sr.runnerId];
+    if (global) map[sr.id] = global.sex;
+  }
+  return map;
+}
+
 // --- Profile page data aggregation ---
 
 function parseCsvPath(path: string, series: Series, year: number): { raceId: string; provisional: boolean } | null {
@@ -141,10 +153,17 @@ function getAwardsForRunner(year: number, series: Series, seriesLocalId: number)
     const entry = ia.awards.find(a => a.seriesRunnerId === seriesLocalId);
     if (entry) {
       const categoryName = resolveIndividualCategoryName(ia.id, ia.sex, ia.ageCategory, ia.name);
-      found.push({ categoryName, position: entry.position });
+      found.push({ categoryName, position: entry.position, sex: ia.sex, ageCategory: ia.ageCategory });
     }
   }
-  return found;
+  return found.sort((a, b) => {
+    const ka = awardCategorySortKey(a.sex, a.ageCategory);
+    const kb = awardCategorySortKey(b.sex, b.ageCategory);
+    for (let i = 0; i < ka.length; i++) {
+      if (ka[i] !== kb[i]) return ka[i] - kb[i];
+    }
+    return a.position - b.position;
+  });
 }
 
 export function resolveClubName(clubId: string): string {
@@ -210,13 +229,34 @@ function buildClubHistory(entries: Array<{ year: number; club: string }>): Runne
   }));
 }
 
+// Ordered: overall (no sex, no age) first, then sex-only (Male/Female), then age
+// categories (no-sex variant before the sex-specific variant), sorted youngest to oldest.
+const AGE_CAT_SORT: Record<string, number> = {
+  JUN: 1, SEN: 2,
+  V35: 3, V40: 4, V45: 5, V50: 6, V55: 7,
+  V60: 8, V65: 9, V70: 10, V75: 11, V80: 12, V85: 13, V90: 14, V95: 15, V100: 16,
+};
+
+function awardCategorySortKey(sex?: string, ageCategory?: string): [number, number, number, number] {
+  const hasSex = sex != null;
+  const hasAge = ageCategory != null;
+  const tier = hasAge ? 2 : hasSex ? 1 : 0;
+  const ageRank = hasAge ? (AGE_CAT_SORT[ageCategory!] ?? 99) : 0;
+  const sexPresence = hasSex ? 1 : 0;
+  const sexRank = sex === 'F' ? 1 : 0;
+  return [tier, ageRank, sexPresence, sexRank];
+}
+
 function buildAwardSummary(yearBlocks: RunnerYearBlock[]): RunnerAwardSummary {
   const roadGpCounts = new Map<string, RunnerAwardSummaryEntry>();
   const fellCounts = new Map<string, RunnerAwardSummaryEntry>();
 
   function tally(map: Map<string, RunnerAwardSummaryEntry>, award: RunnerProfileAward) {
     const key = `${award.categoryName}|${award.position}`;
-    const entry = map.get(key) ?? { categoryName: award.categoryName, position: award.position, count: 0 };
+    const entry = map.get(key) ?? {
+      categoryName: award.categoryName, position: award.position, count: 0,
+      sex: award.sex, ageCategory: award.ageCategory,
+    };
     entry.count++;
     map.set(key, entry);
   }
@@ -227,7 +267,14 @@ function buildAwardSummary(yearBlocks: RunnerYearBlock[]): RunnerAwardSummary {
   }
 
   const sortEntries = (entries: RunnerAwardSummaryEntry[]) =>
-    entries.sort((a, b) => a.position !== b.position ? a.position - b.position : a.categoryName.localeCompare(b.categoryName));
+    entries.sort((a, b) => {
+      const ka = awardCategorySortKey(a.sex, a.ageCategory);
+      const kb = awardCategorySortKey(b.sex, b.ageCategory);
+      for (let i = 0; i < ka.length; i++) {
+        if (ka[i] !== kb[i]) return ka[i] - kb[i];
+      }
+      return a.position - b.position;
+    });
 
   return {
     roadGp: sortEntries([...roadGpCounts.values()]),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -88,6 +88,8 @@ export interface RunnerProfileRace {
 export interface RunnerProfileAward {
   categoryName: string;
   position: number;
+  sex?: 'M' | 'F';
+  ageCategory?: string;
 }
 
 export interface RunnerYearSeries {
@@ -112,6 +114,8 @@ export interface RunnerAwardSummaryEntry {
   categoryName: string;
   position: number;
   count: number;
+  sex?: 'M' | 'F';
+  ageCategory?: string;
 }
 
 export interface RunnerAwardSummary {

--- a/tests/lib/results.test.ts
+++ b/tests/lib/results.test.ts
@@ -370,7 +370,15 @@ describe('resolveIndividualCategoryName', () => {
     expect(resolveIndividualCategoryName('female', 'F')).toBe('Female');
   });
 
-  it('falls back to raw id when no sex, ageCategory, or name', () => {
-    expect(resolveIndividualCategoryName('something-custom')).toBe('something-custom');
+  it('falls back to capitalized id when no sex, ageCategory, or name', () => {
+    expect(resolveIndividualCategoryName('something-custom')).toBe('Something-custom');
+  });
+
+  it('derives ageCategory label alone when ageCategory present but sex missing', () => {
+    expect(resolveIndividualCategoryName('v60', undefined, 'V60')).toBe('V60');
+  });
+
+  it('derives Senior when ageCategory is SEN but sex missing', () => {
+    expect(resolveIndividualCategoryName('sen', undefined, 'SEN')).toBe('Senior');
   });
 });


### PR DESCRIPTION
- resolveIndividualCategoryName no longer falls back to a raw lowercase category id (e.g. "overall", "v60") when only ageCategory is set but sex is missing.
- Runner profile award badges/summary are now ordered overall -> sex-only -> age categories (youngest to oldest), matching across year blocks and the aggregate summary.
- The "Individual Winners" history leaderboard's cross-category "Most decorated" tally was silently excluding sex-agnostic (overall) categories from both Men's and Women's totals, undercounting runners like Rob Danson and Nichola Jackson. Overall wins are now attributed using the runner's actual sex (via a new buildRunnerSexMap) and kept in their own bucket so they display separately from Male/Female wins instead of being silently merged into them.
- Per-runner category breakdowns in that leaderboard are now ordered the same way: overall, then sex-only, then age categories by age.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>